### PR TITLE
Add README.md and Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ before_install:
  - git clone https://github.com/informatici/openhospital-core.git --branch OP-102_master-refactoring-for-api
  - cd openhospital-core
  - mvn clean install -DskipTests=true
+ - cd -
 install: true
-script: mvn clean package -DskipTests=true
+script: 
+ - mvn clean package -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 before_install:
  - git clone https://github.com/informatici/openhospital-core.git --branch OP-102_master-refactoring-for-api
  - cd openhospital-core
- - mvn clean install -DskipTests=true
+ - mvn clean install -DskipTests=true &>/dev/null
  - cd -
 install: true
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+ - openjdk8
+
+before_install:
+ - git clone https://github.com/informatici/openhospital-core.git --branch OP-102_master-refactoring-for-api
+ - cd openhospital-core
+ - mvn clean install -DskipTests=true
+install: true
+script: mvn clean package -DskipTests=true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Open Hospital API [![Build Status](https://travis-ci.org/pviotti/openhospital-api.svg?branch=master)](https://travis-ci.org/pviotti/openhospital-api)
+
+This is the API project of [Open Hospital][openhospital]: it exposes a REST API of the business logic implemented in the [openhospital-core project][core].  
+
+## How to build [WIP]
+
+For the moment, to build this project you should 
+
+ 1. fetch and build the `OP-102_master-refactoring-for-api` branch of the [core] project
+    
+        git clone https://github.com/informatici/openhospital-core.git --branch OP-102_master-refactoring-for-api
+        cd openhospital-core
+        mvn clean install -DskipTests=true
+        
+ 2. clone and build this project
+ 
+        git clone https://github.com/informatici/openhospital-api
+        cd openhospital-api
+        mvn clean install -DskipTests=true
+
+
+ [openhospital]: https://www.open-hospital.org/
+ [core]: https://github.com/informatici/openhospital/openhospital-core
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Hospital API [![Build Status](https://travis-ci.org/pviotti/openhospital-api.svg?branch=master)](https://travis-ci.org/pviotti/openhospital-api)
+# Open Hospital API [![Build Status](https://travis-ci.org/informatici/openhospital-api.svg?branch=master)](https://travis-ci.org/informatici/openhospital-api)
 
 This is the API project of [Open Hospital][openhospital]: it exposes a REST API of the business logic implemented in the [openhospital-core project][core].  
 


### PR DESCRIPTION
This PR tries to address: [OP-123](https://openhospital.atlassian.net/browse/OP-123) and [OP-122](https://openhospital.atlassian.net/browse/OP-122)  

Test build: https://travis-ci.org/pviotti/openhospital-api/builds/594216356

Some things are work-in-progress and will be addressed in future PRs. For instance:
 - it uses a specific branch of openhospital-core instead of master
 - tests are skipped because they'd require Docker