### PR TITLE
Fixing OP-204 com.fasterxml.jackson.databind.JsonMappingException

### DIFF
--- a/src/main/java/org/isf/accounting/dto/BillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillDTO.java
@@ -159,11 +159,11 @@ public class BillDTO {
 		this.listId = listId;
 	}
 
-	public PatientDTO getPatient() {
+	public PatientDTO getPatientDTO() {
 		return patient;
 	}
 
-	public void setPatient(PatientDTO patient) {
+	public void setPatientDTO(PatientDTO patient) {
 		this.patient = patient;
 	}
 	


### PR DESCRIPTION
Updating setter and getter on `BillDTO` class for `PatientDTO patient` field to avoid conflict with `setPatient(boolean)` method.

>  org.isf.accounting.dto.BillDTO["patient"]); nested exception is com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of boolean out of START_OBJECT token 

```
@@ -159,11 +159,11 @@ public class BillDTO {
                this.listId = listId;
        }

-       public PatientDTO getPatient() {
+       public PatientDTO getPatientDTO() {
                return patient;
        }

-       public void setPatient(PatientDTO patient) {
+       public void setPatientDTO(PatientDTO patient) {
                this.patient = patient;
        }
```