### PR TITLE
Revert adding of license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,35 +158,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <configuration>
-                    <verbose>false</verbose>
-                    <addSvnKeyWords>true</addSvnKeyWords>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>first</id>
-                        <goals>
-                            <goal>update-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                        <configuration>
-                            <licenseName>gpl_v3</licenseName>
-                            <inceptionYear>2006</inceptionYear>
-                            <organizationName>Informatici Senza Frontiere</organizationName>
-                            <projectName>OpenHospital</projectName>
-                            <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
-                            <roots>
-                                <root>src/main/java</root>
-                                <root>src/test/java</root>
-                            </roots>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Per discussion in core's [PR 165](https://github.com/informatici/openhospital-core/pull/165) and opened up [OP-265](https://openhospital.atlassian.net/jira/software/c/projects/OP/issues/OP-256) to define an the license header comment.