### PR TITLE
OP-256 add license plugin and add headers

### DIFF
--- a/.license-header/license-header.txt
+++ b/.license-header/license-header.txt
@@ -1,0 +1,19 @@
+${project.name} (${project.url})
+Copyright © ${license.git.copyrightYears} ${owner} (${email})
+
+${project.description}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+https://www.gnu.org/licenses/gpl-3.0-standalone.html
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/pom.xml
+++ b/pom.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.0.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>org.isf</groupId>
-	<artifactId>openhospital-api</artifactId>
-	<version>0.0.1</version>
-	<name>openhospital-api</name>
-	<description>Openhospital Spring Boot REST API </description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.4.0.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>org.isf</groupId>
+    <artifactId>openhospital-api</artifactId>
+    <version>0.0.1</version>
+    <name>openhospital-api</name>
+    <description>Openhospital Spring Boot REST API </description>
 
-	<properties>
-		<java.version>1.8</java.version>
-		<spring-boot-admin.version>2.1.3</spring-boot-admin.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <properties>
+        <java.version>1.8</java.version>
+        <spring-boot-admin.version>2.1.3</spring-boot-admin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.maven.plugin.version>4.0.rc2</license.maven.plugin.version>
+    </properties>
 
 	<dependencies>
 		<dependency>
@@ -86,14 +87,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.isf</groupId>
-			<artifactId>OH-core</artifactId>
-			<version>1.10</version>
-			<classifier>tests</classifier>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
@@ -109,21 +102,20 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.6.1</version>
         </dependency>
-        <!-- <dependency>
+        <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
-        </dependency> -->
+            <version>2.2.4</version>
+        </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.glassfish.web</groupId>
             <artifactId>javax.el</artifactId>
-            <!-- version>2.2.4</version> -->
-            <version>3.0.1-b08</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -166,6 +158,55 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license.maven.plugin.version}</version>
+                <configuration>
+                    <!-- <header>.license-header/license-header.txt</header> -->
+                    <licenseSets>
+                        <licenseSet>
+                            <header>.license-header/license-header.txt</header>
+                            <excludes>
+                                <exclude>./license-header/**</exclude>
+                                <exclude>./ide-settings/eclipse/**</exclude>
+                                <exclude>./ide-settings/idea/**</exclude>
+                                <exclude>.editorconfig</exclude>
+                                <exclude>.springBeans</exclude>
+                                <exclude>**/README</exclude>
+                                <exclude>doc/**/*.txt</exclude>
+                                <exclude>lib/**</exclude>
+                                <exclude>mysql/db/**</exclude>
+                                <exclude>repo/**</exclude>
+                                <exclude>rpt/**</exclude>
+                                <exclude>rsc/**</exclude>
+                                <exclude>rsc-test/**</exclude>
+                                <exclude>src/test/resources/**</exclude>
+                                <exclude>src/main/resources/**</exclude>
+                                <exclude>**/*.properties</exclude>
+                                <exclude>**/*.xml</exclude>
+                                <exclude>**/*.yml</exclude>
+                                <exclude>**/*.jfd</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                    <properties>
+                        <owner>Informatici Senza Frontiere</owner>
+                        <email>info@informaticisenzafrontiere.org</email>
+                        <project.inceptionYear>2006</project.inceptionYear>
+                        <project.name>Open Hospital</project.name>
+                        <project.url>www.open-hospital.org</project.url>
+                        <project.description>Open Hospital is a free and open source software for healthcare data management.</project.description>
+                    </properties>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin-git</artifactId>
+                        <version>${license.maven.plugin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,19 +111,14 @@
             <version>2.6.1</version>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>2.2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
+            <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
-            <version>2.2.4</version>
+            <version>3.0.1-b08</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <scope>provided</scope>
+            <version>1.18.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,14 @@
 			</exclusions>
 		</dependency>
         <dependency>
+            <groupId>org.isf</groupId>
+            <artifactId>OH-core</artifactId>
+            <version>1.10</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
             <version>2.2.0</version>

--- a/src/main/java/org/isf/OpenHospitalApiApplication.java
+++ b/src/main/java/org/isf/OpenHospitalApiApplication.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf;
 
 import org.springframework.boot.SpringApplication;

--- a/src/main/java/org/isf/accounting/dto/BillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.dto;
 
 import java.util.Date;
@@ -5,7 +26,6 @@ import java.util.Date;
 import javax.validation.constraints.NotNull;
 
 import org.isf.patient.dto.PatientDTO;
-import org.isf.priceslist.dto.PriceListDTO;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
@@ -1,10 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.dto;
 
 import java.util.Date;
 
 import javax.validation.constraints.NotNull;
-
-import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/accounting/dto/FullBillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/FullBillDTO.java
@@ -1,5 +1,25 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.dto;
-
 
 import java.util.List;
 

--- a/src/main/java/org/isf/accounting/mapper/BillItemsMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillItemsMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.mapper;
 
 import org.isf.accounting.dto.BillItemsDTO;

--- a/src/main/java/org/isf/accounting/mapper/BillMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.mapper;
 
 import org.isf.accounting.dto.BillDTO;

--- a/src/main/java/org/isf/accounting/mapper/BillPaymentsMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillPaymentsMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.mapper;
 
 import org.isf.accounting.dto.BillPaymentsDTO;

--- a/src/main/java/org/isf/accounting/rest/BillController.java
+++ b/src/main/java/org/isf/accounting/rest/BillController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/admission/dto/AdmissionDTO.java
+++ b/src/main/java/org/isf/admission/dto/AdmissionDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/admission/dto/AdmittedPatientDTO.java
+++ b/src/main/java/org/isf/admission/dto/AdmittedPatientDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.dto;
 
 import org.isf.patient.dto.PatientDTO;

--- a/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
+++ b/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.mapper;
 
 import org.isf.admission.dto.AdmissionDTO;

--- a/src/main/java/org/isf/admission/mapper/AdmittedPatientMapper.java
+++ b/src/main/java/org/isf/admission/mapper/AdmittedPatientMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.mapper;
 
 import org.isf.admission.dto.AdmittedPatientDTO;

--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.rest;
 
 import java.util.GregorianCalendar;

--- a/src/main/java/org/isf/admtype/dto/AdmissionTypeDTO.java
+++ b/src/main/java/org/isf/admtype/dto/AdmissionTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admtype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/admtype/mapper/AdmissionTypeMapper.java
+++ b/src/main/java/org/isf/admtype/mapper/AdmissionTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admtype.mapper;
 
 import org.isf.admtype.dto.AdmissionTypeDTO;

--- a/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
+++ b/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admtype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/agetype/dto/AgeTypeDTO.java
+++ b/src/main/java/org/isf/agetype/dto/AgeTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.agetype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/agetype/mapper/AgeTypeMapper.java
+++ b/src/main/java/org/isf/agetype/mapper/AgeTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.agetype.mapper;
 
 import org.isf.agetype.dto.AgeTypeDTO;

--- a/src/main/java/org/isf/agetype/rest/AgeTypeController.java
+++ b/src/main/java/org/isf/agetype/rest/AgeTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.agetype.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.config;
 
 import org.isf.security.OHSimpleUrlAuthenticationSuccessHandler;

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -21,6 +21,8 @@
  */
 package org.isf.config;
 
+import java.util.Arrays;
+
 import org.isf.security.OHSimpleUrlAuthenticationSuccessHandler;
 import org.isf.security.RestAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +43,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-
-import java.util.Arrays;
 
 
 @Configuration

--- a/src/main/java/org/isf/config/SpringFoxConfig.java
+++ b/src/main/java/org/isf/config/SpringFoxConfig.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2019 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -21,8 +21,11 @@
  */
 package org.isf.config;
 
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.AuthorizationScope;
@@ -33,8 +36,6 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableSwagger2

--- a/src/main/java/org/isf/config/SpringFoxConfig.java
+++ b/src/main/java/org/isf/config/SpringFoxConfig.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2019 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/org/isf/disctype/dto/DischargeTypeDTO.java
+++ b/src/main/java/org/isf/disctype/dto/DischargeTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disctype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/disctype/mapper/DischargeTypeMapper.java
+++ b/src/main/java/org/isf/disctype/mapper/DischargeTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disctype.mapper;
 
 import org.isf.disctype.dto.DischargeTypeDTO;

--- a/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
+++ b/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disctype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/disease/dto/DiseaseDTO.java
+++ b/src/main/java/org/isf/disease/dto/DiseaseDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disease.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/disease/mapper/DiseaseMapper.java
+++ b/src/main/java/org/isf/disease/mapper/DiseaseMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disease.mapper;
 
 import org.isf.disease.dto.DiseaseDTO;

--- a/src/main/java/org/isf/disease/rest/DiseaseController.java
+++ b/src/main/java/org/isf/disease/rest/DiseaseController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disease.rest;
 
 import java.util.HashMap;

--- a/src/main/java/org/isf/distype/dto/DiseaseTypeDTO.java
+++ b/src/main/java/org/isf/distype/dto/DiseaseTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.distype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/distype/mapper/DiseaseTypeMapper.java
+++ b/src/main/java/org/isf/distype/mapper/DiseaseTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.distype.mapper;
 
 import org.isf.distype.dto.DiseaseTypeDTO;

--- a/src/main/java/org/isf/distype/rest/DiseaseTypeController.java
+++ b/src/main/java/org/isf/distype/rest/DiseaseTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.distype.rest;
 
 import java.util.HashMap;

--- a/src/main/java/org/isf/dlvrrestype/dto/DeliveryResultTypeDTO.java
+++ b/src/main/java/org/isf/dlvrrestype/dto/DeliveryResultTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrrestype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/dlvrrestype/mapper/DeliveryResultTypeMapper.java
+++ b/src/main/java/org/isf/dlvrrestype/mapper/DeliveryResultTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrrestype.mapper;
 
 import org.isf.dlvrrestype.dto.DeliveryResultTypeDTO;

--- a/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
+++ b/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrrestype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/dlvrtype/dto/DeliveryTypeDTO.java
+++ b/src/main/java/org/isf/dlvrtype/dto/DeliveryTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrtype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/dlvrtype/mapper/DeliveryTypeMapper.java
+++ b/src/main/java/org/isf/dlvrtype/mapper/DeliveryTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrtype.mapper;
 
 import org.isf.dlvrtype.dto.DeliveryTypeDTO;

--- a/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
+++ b/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrtype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/exam/dto/ExamDTO.java
+++ b/src/main/java/org/isf/exam/dto/ExamDTO.java
@@ -1,7 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.dto;
 
-import io.swagger.annotations.ApiModelProperty;
 import org.isf.exatype.dto.ExamTypeDTO;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class ExamDTO {
 

--- a/src/main/java/org/isf/exam/dto/ExamRowDTO.java
+++ b/src/main/java/org/isf/exam/dto/ExamRowDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.dto;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/exam/mapper/ExamMapper.java
+++ b/src/main/java/org/isf/exam/mapper/ExamMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.mapper;
 
 import org.isf.exa.model.Exam;

--- a/src/main/java/org/isf/exam/mapper/ExamRowMapper.java
+++ b/src/main/java/org/isf/exam/mapper/ExamRowMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.mapper;
 
 import org.isf.exa.model.ExamRow;

--- a/src/main/java/org/isf/exam/rest/ExamController.java
+++ b/src/main/java/org/isf/exam/rest/ExamController.java
@@ -1,7 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.util.List;
+import java.util.Optional;
+
 import org.isf.exa.manager.ExamBrowsingManager;
 import org.isf.exa.model.Exam;
 import org.isf.exam.dto.ExamDTO;
@@ -18,10 +40,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-import java.util.Optional;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/exams", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/exam/rest/ExamRowController.java
+++ b/src/main/java/org/isf/exam/rest/ExamRowController.java
@@ -1,7 +1,28 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exam.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.util.List;
+
 import org.isf.exa.manager.ExamBrowsingManager;
 import org.isf.exa.manager.ExamRowBrowsingManager;
 import org.isf.exa.model.Exam;
@@ -18,9 +39,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/exams", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/examination/dto/PatientExaminationDTO.java
+++ b/src/main/java/org/isf/examination/dto/PatientExaminationDTO.java
@@ -1,8 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.examination.dto;
 
-import io.swagger.annotations.ApiModelProperty;
-
 import java.sql.Date;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class PatientExaminationDTO {
 

--- a/src/main/java/org/isf/examination/mapper/PatientExaminationMapper.java
+++ b/src/main/java/org/isf/examination/mapper/PatientExaminationMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.examination.mapper;
 
 import org.isf.examination.dto.PatientExaminationDTO;

--- a/src/main/java/org/isf/examination/rest/ExaminationController.java
+++ b/src/main/java/org/isf/examination/rest/ExaminationController.java
@@ -1,7 +1,28 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.examination.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.util.List;
+
 import org.isf.examination.dto.PatientExaminationDTO;
 import org.isf.examination.manager.ExaminationBrowserManager;
 import org.isf.examination.mapper.PatientExaminationMapper;
@@ -19,9 +40,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/examinations", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/exatype/dto/ExamTypeDTO.java
+++ b/src/main/java/org/isf/exatype/dto/ExamTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exatype.dto;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/exatype/mapper/ExamTypeMapper.java
+++ b/src/main/java/org/isf/exatype/mapper/ExamTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exatype.mapper;
 
 import org.isf.exatype.dto.ExamTypeDTO;

--- a/src/main/java/org/isf/exatype/rest/ExamTypeController.java
+++ b/src/main/java/org/isf/exatype/rest/ExamTypeController.java
@@ -1,7 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.exatype.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.util.List;
+import java.util.Optional;
+
 import org.isf.exatype.dto.ExamTypeDTO;
 import org.isf.exatype.manager.ExamTypeBrowserManager;
 import org.isf.exatype.mapper.ExamTypeMapper;
@@ -16,10 +38,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-import java.util.Optional;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/examtypes", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/hospital/dto/HospitalDTO.java
+++ b/src/main/java/org/isf/hospital/dto/HospitalDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.hospital.dto;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/hospital/mapper/HospitalMapper.java
+++ b/src/main/java/org/isf/hospital/mapper/HospitalMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.hospital.mapper;
 
 import org.isf.hospital.dto.HospitalDTO;

--- a/src/main/java/org/isf/hospital/rest/HospitalController.java
+++ b/src/main/java/org/isf/hospital/rest/HospitalController.java
@@ -1,7 +1,26 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.hospital.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
 import org.isf.hospital.dto.HospitalDTO;
 import org.isf.hospital.manager.HospitalBrowsingManager;
 import org.isf.hospital.mapper.HospitalMapper;
@@ -16,7 +35,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/hospitals", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/lab/dto/LabWithRowsDTO.java
+++ b/src/main/java/org/isf/lab/dto/LabWithRowsDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.dto;
 
 import java.util.List;

--- a/src/main/java/org/isf/lab/dto/LaboratoryDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryDTO.java
@@ -1,11 +1,31 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.dto;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.isf.exam.dto.ExamDTO;
-import org.isf.patient.dto.PatientDTO;
-
 import java.util.Date;
-import java.util.GregorianCalendar;
+
+import org.isf.exam.dto.ExamDTO;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class LaboratoryDTO {
 

--- a/src/main/java/org/isf/lab/dto/LaboratoryForPrintDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryForPrintDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.dto;
 
 public class LaboratoryForPrintDTO {

--- a/src/main/java/org/isf/lab/dto/LaboratoryRowDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryRowDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.dto;
 
 public class LaboratoryRowDTO {

--- a/src/main/java/org/isf/lab/mapper/LaboratoryForPrintMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryForPrintMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.mapper;
 
 import org.isf.lab.dto.LaboratoryForPrintDTO;

--- a/src/main/java/org/isf/lab/mapper/LaboratoryMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.mapper;
 
 import org.isf.lab.dto.LaboratoryDTO;

--- a/src/main/java/org/isf/lab/mapper/LaboratoryRowMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryRowMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.mapper;
 
 import org.isf.lab.dto.LaboratoryRowDTO;

--- a/src/main/java/org/isf/lab/rest/LaboratoryController.java
+++ b/src/main/java/org/isf/lab/rest/LaboratoryController.java
@@ -1,7 +1,31 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.lab.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
 import org.isf.exa.manager.ExamBrowsingManager;
 import org.isf.exa.model.Exam;
 import org.isf.lab.dto.LabWithRowsDTO;
@@ -28,12 +52,17 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/laboratories", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})

--- a/src/main/java/org/isf/malnutrition/dto/MalnutritionDTO.java
+++ b/src/main/java/org/isf/malnutrition/dto/MalnutritionDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.malnutrition.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/malnutrition/mapper/MalnutritionMapper.java
+++ b/src/main/java/org/isf/malnutrition/mapper/MalnutritionMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.malnutrition.mapper;
 
 import org.isf.malnutrition.dto.MalnutritionDTO;

--- a/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
+++ b/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.malnutrition.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/medical/dto/MedicalDTO.java
+++ b/src/main/java/org/isf/medical/dto/MedicalDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medical.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/medical/dto/MedicalSortBy.java
+++ b/src/main/java/org/isf/medical/dto/MedicalSortBy.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medical.dto;
 
 public enum MedicalSortBy {

--- a/src/main/java/org/isf/medical/mapper/MedicalMapper.java
+++ b/src/main/java/org/isf/medical/mapper/MedicalMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medical.mapper;
 
 import org.isf.medical.dto.MedicalDTO;

--- a/src/main/java/org/isf/medical/rest/MedicalController.java
+++ b/src/main/java/org/isf/medical/rest/MedicalController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medical.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/medicalstock/dto/LotDTO.java
+++ b/src/main/java/org/isf/medicalstock/dto/LotDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstock.dto;
 
 import java.math.BigDecimal;

--- a/src/main/java/org/isf/medicalstock/dto/MovementDTO.java
+++ b/src/main/java/org/isf/medicalstock/dto/MovementDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstock.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/medicalstock/mapper/LotMapper.java
+++ b/src/main/java/org/isf/medicalstock/mapper/LotMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstock.mapper;
 
 import org.isf.medicalstock.dto.LotDTO;

--- a/src/main/java/org/isf/medicalstock/mapper/MovementMapper.java
+++ b/src/main/java/org/isf/medicalstock/mapper/MovementMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstock.mapper;
 
 import org.isf.medicalstock.dto.MovementDTO;

--- a/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
+++ b/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstock.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.dto;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/medicalstockward/dto/MedicalWardIdDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MedicalWardIdDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/medicalstockward/mapper/MedicalWardIdMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MedicalWardIdMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.mapper;
 
 import org.isf.medicalstockward.dto.MedicalWardIdDTO;

--- a/src/main/java/org/isf/medicalstockward/mapper/MedicalWardMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MedicalWardMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.mapper;
 
 import org.isf.medicalstockward.dto.MedicalWardDTO;

--- a/src/main/java/org/isf/medicalstockward/mapper/MovementWardMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MovementWardMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.mapper;
 
 import org.isf.medicalstockward.dto.MovementWardDTO;

--- a/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
+++ b/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medicalstockward.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/medstockmovtype/dto/MovementTypeDTO.java
+++ b/src/main/java/org/isf/medstockmovtype/dto/MovementTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medstockmovtype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/medstockmovtype/mapper/MovementTypeMapper.java
+++ b/src/main/java/org/isf/medstockmovtype/mapper/MovementTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medstockmovtype.mapper;
 
 import org.isf.medstockmovtype.dto.MovementTypeDTO;

--- a/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
+++ b/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medstockmovtype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/medtype/dto/MedicalTypeDTO.java
+++ b/src/main/java/org/isf/medtype/dto/MedicalTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medtype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/medtype/mapper/MedicalTypeMapper.java
+++ b/src/main/java/org/isf/medtype/mapper/MedicalTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medtype.mapper;
 
 import org.isf.medtype.dto.MedicalTypeDTO;

--- a/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
+++ b/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.medtype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/menu/dto/GroupMenuDTO.java
+++ b/src/main/java/org/isf/menu/dto/GroupMenuDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/menu/dto/UserDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/menu/dto/UserGroupDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserGroupDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/menu/dto/UserMenuItemDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserMenuItemDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/menu/mapper/GroupMenuMapper.java
+++ b/src/main/java/org/isf/menu/mapper/GroupMenuMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.mapper;
 
 import org.isf.menu.dto.GroupMenuDTO;

--- a/src/main/java/org/isf/menu/mapper/UserGroupMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserGroupMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.mapper;
 
 import org.isf.menu.dto.UserGroupDTO;

--- a/src/main/java/org/isf/menu/mapper/UserMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.mapper;
 
 import org.isf.menu.dto.UserDTO;

--- a/src/main/java/org/isf/menu/mapper/UserMenuItemMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserMenuItemMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.mapper;
 
 import org.isf.menu.dto.UserMenuItemDTO;

--- a/src/main/java/org/isf/menu/rest/UserController.java
+++ b/src/main/java/org/isf/menu/rest/UserController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.menu.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/opd/dto/OpdDTO.java
+++ b/src/main/java/org/isf/opd/dto/OpdDTO.java
@@ -1,10 +1,33 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opd.dto;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.isf.disease.dto.DiseaseDTO;
+import java.util.Date;
 
 import javax.validation.constraints.NotNull;
-import java.util.Date;
+
+import org.isf.disease.dto.DiseaseDTO;
+
+import io.swagger.annotations.ApiModelProperty;
 
 /**
  * @author gildas

--- a/src/main/java/org/isf/opd/mapper/OpdMapper.java
+++ b/src/main/java/org/isf/opd/mapper/OpdMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opd.mapper;
 
 import org.isf.opd.dto.OpdDTO;

--- a/src/main/java/org/isf/opd/rest/OpdController.java
+++ b/src/main/java/org/isf/opd/rest/OpdController.java
@@ -1,11 +1,30 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opd.rest;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import org.isf.disease.manager.DiseaseBrowserManager;
-import org.isf.disease.mapper.DiseaseMapper;
 import org.isf.opd.dto.OpdDTO;
 import org.isf.opd.manager.OpdBrowserManager;
 import org.isf.opd.mapper.OpdMapper;

--- a/src/main/java/org/isf/operation/dto/OperationDTO.java
+++ b/src/main/java/org/isf/operation/dto/OperationDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.operation.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/operation/dto/OperationRowDTO.java
+++ b/src/main/java/org/isf/operation/dto/OperationRowDTO.java
@@ -1,4 +1,25 @@
 /*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
@@ -7,9 +28,6 @@ package org.isf.operation.dto;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
 import org.isf.accounting.dto.BillDTO;

--- a/src/main/java/org/isf/operation/mapper/OperationMapper.java
+++ b/src/main/java/org/isf/operation/mapper/OperationMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.operation.mapper;
 
 import org.isf.operation.dto.OperationDTO;

--- a/src/main/java/org/isf/operation/mapper/OperationRowMapper.java
+++ b/src/main/java/org/isf/operation/mapper/OperationRowMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.operation.mapper;
 
 import org.isf.operation.dto.OperationRowDTO;

--- a/src/main/java/org/isf/operation/rest/OperationController.java
+++ b/src/main/java/org/isf/operation/rest/OperationController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.operation.rest;
 
 import java.util.List;
@@ -6,7 +27,6 @@ import java.util.stream.Collectors;
 import org.isf.admission.manager.AdmissionBrowserManager;
 import org.isf.admission.model.Admission;
 import org.isf.opd.dto.OpdDTO;
-import org.isf.opd.manager.OpdBrowserManager;
 import org.isf.opd.mapper.OpdMapper;
 import org.isf.operation.dto.OperationDTO;
 import org.isf.operation.dto.OperationRowDTO;

--- a/src/main/java/org/isf/opetype/dto/OperationTypeDTO.java
+++ b/src/main/java/org/isf/opetype/dto/OperationTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opetype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/opetype/mapper/OperationTypeMapper.java
+++ b/src/main/java/org/isf/opetype/mapper/OperationTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opetype.mapper;
 
 import org.isf.opetype.dto.OperationTypeDTO;

--- a/src/main/java/org/isf/opetype/rest/OperationTypeController.java
+++ b/src/main/java/org/isf/opetype/rest/OperationTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.opetype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/patient/dto/PatientDTO.java
+++ b/src/main/java/org/isf/patient/dto/PatientDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patient.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/patient/mapper/PatientMapper.java
+++ b/src/main/java/org/isf/patient/mapper/PatientMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patient.mapper;
 
 import org.isf.patient.dto.PatientDTO;

--- a/src/main/java/org/isf/patient/rest/PatientController.java
+++ b/src/main/java/org/isf/patient/rest/PatientController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patient.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/patvac/dto/PatientVaccineDTO.java
+++ b/src/main/java/org/isf/patvac/dto/PatientVaccineDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patvac.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
+++ b/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patvac.mapper;
 
 import org.isf.patvac.dto.PatientVaccineDTO;

--- a/src/main/java/org/isf/patvac/rest/PatVacController.java
+++ b/src/main/java/org/isf/patvac/rest/PatVacController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patvac.rest;
 
 import java.util.Date;
@@ -12,7 +33,6 @@ import org.isf.shared.exceptions.OHAPIException;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.utils.exception.model.OHSeverityLevel;
-import org.isf.vaccine.manager.VaccineBrowserManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/isf/pregtreattype/dto/PregnantTreatmentTypeDTO.java
+++ b/src/main/java/org/isf/pregtreattype/dto/PregnantTreatmentTypeDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pregtreattype.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/pregtreattype/mapper/PregnantTreatmentTypeMapper.java
+++ b/src/main/java/org/isf/pregtreattype/mapper/PregnantTreatmentTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pregtreattype.mapper;
 
 import org.isf.pregtreattype.dto.PregnantTreatmentTypeDTO;

--- a/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
+++ b/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pregtreattype.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/priceslist/dto/PriceDTO.java
+++ b/src/main/java/org/isf/priceslist/dto/PriceDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.priceslist.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/priceslist/dto/PriceListDTO.java
+++ b/src/main/java/org/isf/priceslist/dto/PriceListDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.priceslist.dto;
 
 import io.swagger.annotations.ApiModel;

--- a/src/main/java/org/isf/priceslist/mapper/PriceListMapper.java
+++ b/src/main/java/org/isf/priceslist/mapper/PriceListMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.priceslist.mapper;
 
 import org.isf.priceslist.dto.PriceListDTO;

--- a/src/main/java/org/isf/priceslist/mapper/PriceMapper.java
+++ b/src/main/java/org/isf/priceslist/mapper/PriceMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.priceslist.mapper;
 
 import org.isf.priceslist.dto.PriceDTO;

--- a/src/main/java/org/isf/priceslist/rest/PriceListController.java
+++ b/src/main/java/org/isf/priceslist/rest/PriceListController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.priceslist.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/pricesothers/dto/PricesOthersDTO.java
+++ b/src/main/java/org/isf/pricesothers/dto/PricesOthersDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pricesothers.dto;
 
 import javax.persistence.Id;

--- a/src/main/java/org/isf/pricesothers/mapper/PricesOthersMapper.java
+++ b/src/main/java/org/isf/pricesothers/mapper/PricesOthersMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pricesothers.mapper;
 
 import org.isf.pricesothers.dto.PricesOthersDTO;

--- a/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
+++ b/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pricesothers.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/security/LoginApi.java
+++ b/src/main/java/org/isf/security/LoginApi.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.security;
 
 import org.springframework.security.core.Authentication;

--- a/src/main/java/org/isf/security/OHFilterInvocationSecurityMetadataSource.java
+++ b/src/main/java/org/isf/security/OHFilterInvocationSecurityMetadataSource.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.security;
 
 import java.util.Collection;

--- a/src/main/java/org/isf/security/OHSimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/org/isf/security/OHSimpleUrlAuthenticationSuccessHandler.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.security;
 
 import java.io.IOException;

--- a/src/main/java/org/isf/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/isf/security/RestAuthenticationEntryPoint.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.security;
 
 import java.io.IOException;

--- a/src/main/java/org/isf/security/UserDetailsServiceImpl.java
+++ b/src/main/java/org/isf/security/UserDetailsServiceImpl.java
@@ -23,7 +23,6 @@ package org.isf.security;
 
 import java.util.ArrayList;
 
-import lombok.extern.slf4j.Slf4j;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.utils.exception.OHServiceException;
@@ -33,6 +32,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j

--- a/src/main/java/org/isf/security/UserDetailsServiceImpl.java
+++ b/src/main/java/org/isf/security/UserDetailsServiceImpl.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.security;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/shared/GenericMapper.java
+++ b/src/main/java/org/isf/shared/GenericMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/isf/shared/Mapper.java
+++ b/src/main/java/org/isf/shared/Mapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared;
 
 import java.util.List;

--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.exceptions;
 
 import java.io.PrintWriter;

--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -26,10 +26,11 @@ import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.isf.utils.exception.OHServiceException;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.Setter;
 
 //import com.fasterxml.jackson.annotation.JsonFormat;
 

--- a/src/main/java/org/isf/shared/exceptions/OHAPIException.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIException.java
@@ -21,10 +21,11 @@
  */
 package org.isf.shared.exceptions;
 
-import lombok.Getter;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public class OHAPIException extends OHServiceException {

--- a/src/main/java/org/isf/shared/exceptions/OHAPIException.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIException.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.exceptions;
 
 import lombok.Getter;

--- a/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
+++ b/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.exceptions;
 
 import java.util.Locale;

--- a/src/main/java/org/isf/shared/mapper/OHModelMapper.java
+++ b/src/main/java/org/isf/shared/mapper/OHModelMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.mapper;
 
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;

--- a/src/main/java/org/isf/shared/mapper/converter/BlobToByteArrayConverter.java
+++ b/src/main/java/org/isf/shared/mapper/converter/BlobToByteArrayConverter.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.mapper.converter;
 
 import java.sql.Blob;

--- a/src/main/java/org/isf/shared/mapper/converter/ByteArrayToBlobConverter.java
+++ b/src/main/java/org/isf/shared/mapper/converter/ByteArrayToBlobConverter.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.mapper.converter;
 
 import java.sql.Blob;

--- a/src/main/java/org/isf/shared/mapper/converter/ModelMapperConfig.java
+++ b/src/main/java/org/isf/shared/mapper/converter/ModelMapperConfig.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.shared.mapper.converter;
 
 import org.modelmapper.ModelMapper;

--- a/src/main/java/org/isf/sms/dto/SmsDTO.java
+++ b/src/main/java/org/isf/sms/dto/SmsDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.sms.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/sms/mapper/SmsMapper.java
+++ b/src/main/java/org/isf/sms/mapper/SmsMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.sms.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/sms/rest/SmsController.java
+++ b/src/main/java/org/isf/sms/rest/SmsController.java
@@ -1,7 +1,25 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.sms.rest;
-
-import org.isf.shared.exceptions.OHAPIException;
-import org.isf.sms.dto.SmsDTO;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -10,6 +28,8 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import org.isf.shared.exceptions.OHAPIException;
+import org.isf.sms.dto.SmsDTO;
 import org.isf.sms.manager.SmsManager;
 import org.isf.sms.mapper.SmsMapper;
 import org.isf.sms.model.Sms;

--- a/src/main/java/org/isf/stats/rest/ReportsController.java
+++ b/src/main/java/org/isf/stats/rest/ReportsController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.stats.rest;
 
 import java.io.IOException;

--- a/src/main/java/org/isf/supplier/dto/SupplierDTO.java
+++ b/src/main/java/org/isf/supplier/dto/SupplierDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.supplier.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/supplier/mapper/SupplierMapper.java
+++ b/src/main/java/org/isf/supplier/mapper/SupplierMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.supplier.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/supplier/rest/SupplierController.java
+++ b/src/main/java/org/isf/supplier/rest/SupplierController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.supplier.rest;
 
 import java.util.List;

--- a/src/main/java/org/isf/therapy/dto/TherapyDTO.java
+++ b/src/main/java/org/isf/therapy/dto/TherapyDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.therapy.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/therapy/dto/TherapyRowDTO.java
+++ b/src/main/java/org/isf/therapy/dto/TherapyRowDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.therapy.dto;
 
 import java.util.Date;

--- a/src/main/java/org/isf/therapy/mapper/TherapyMapper.java
+++ b/src/main/java/org/isf/therapy/mapper/TherapyMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.therapy.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/therapy/mapper/TherapyRowMapper.java
+++ b/src/main/java/org/isf/therapy/mapper/TherapyRowMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.therapy.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/therapy/rest/TherapyController.java
+++ b/src/main/java/org/isf/therapy/rest/TherapyController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.therapy.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/vaccine/dto/VaccineDTO.java
+++ b/src/main/java/org/isf/vaccine/dto/VaccineDTO.java
@@ -1,9 +1,29 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vaccine.dto;
 
 import javax.validation.constraints.NotNull;
 
 import org.isf.vactype.dto.VaccineTypeDTO;
-import org.isf.vactype.model.VaccineType;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/org/isf/vaccine/mapper/VaccineMapper.java
+++ b/src/main/java/org/isf/vaccine/mapper/VaccineMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vaccine.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/vaccine/rest/VaccineController.java
+++ b/src/main/java/org/isf/vaccine/rest/VaccineController.java
@@ -1,8 +1,28 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vaccine.rest;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.isf.shared.exceptions.OHAPIException;
 import org.isf.utils.exception.OHDataIntegrityViolationException;

--- a/src/main/java/org/isf/vactype/dto/VaccineTypeDTO.java
+++ b/src/main/java/org/isf/vactype/dto/VaccineTypeDTO.java
@@ -1,11 +1,30 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vactype.dto;
+
+import javax.validation.constraints.NotNull;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-
-import javax.persistence.Column;
-import javax.persistence.Transient;
-import javax.validation.constraints.NotNull;
 
 @ApiModel(description = "Class representing a vaccine type")
 public class VaccineTypeDTO {

--- a/src/main/java/org/isf/vactype/mapper/VaccineTypeMapper.java
+++ b/src/main/java/org/isf/vactype/mapper/VaccineTypeMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vactype.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
+++ b/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vactype.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/visits/dto/VisitDTO.java
+++ b/src/main/java/org/isf/visits/dto/VisitDTO.java
@@ -1,15 +1,34 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.visits.dto;
+
+import java.util.GregorianCalendar;
+
+import javax.validation.constraints.NotNull;
+
+import org.isf.patient.dto.PatientDTO;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.isf.patient.dto.PatientDTO;
-import org.isf.patient.model.Patient;
-
-import javax.persistence.Column;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.validation.constraints.NotNull;
-import java.util.GregorianCalendar;
 
 @ApiModel(description = "Class representing a vaccine type")
 public class VisitDTO {

--- a/src/main/java/org/isf/visits/mapper/VisitMapper.java
+++ b/src/main/java/org/isf/visits/mapper/VisitMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.visits.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/visits/rest/VisitsController.java
+++ b/src/main/java/org/isf/visits/rest/VisitsController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.visits.rest;
 
 import java.util.ArrayList;

--- a/src/main/java/org/isf/ward/dto/WardDTO.java
+++ b/src/main/java/org/isf/ward/dto/WardDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.ward.dto;
 
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/isf/ward/mapper/WardMapper.java
+++ b/src/main/java/org/isf/ward/mapper/WardMapper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.ward.mapper;
 
 import org.isf.shared.GenericMapper;

--- a/src/main/java/org/isf/ward/rest/WardController.java
+++ b/src/main/java/org/isf/ward/rest/WardController.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.ward.rest;
 
 import java.util.ArrayList;

--- a/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
+++ b/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
@@ -30,8 +30,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest
 public class OpenHospitalApiApplicationTests {
 
-    @Test
-    public void contextLoads() {
-    }
+	@Test
+	public void contextLoads() {
+	}
 
 }

--- a/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
+++ b/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf;
 
 import org.junit.Test;

--- a/src/test/java/org/isf/accounting/data/BillDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillDTOHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.data;
 
 import java.util.List;
@@ -12,22 +33,23 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class BillDTOHelper{
-	public static BillDTO setup(PatientMapper patientMapper) throws OHException{
+public class BillDTOHelper {
+
+	public static BillDTO setup(PatientMapper patientMapper) throws OHException {
 		Patient patient = new TestPatient().setup(true);
 		PatientDTO patientDTO = patientMapper.map2DTO(patient);
 		BillDTO billDTO = new BillDTO();
 		billDTO.setPatientDTO(patientDTO);
 		return billDTO;
 	}
-	
+
 	public static BillDTO setup(Integer id, PatientMapper patientMapper) throws OHException {
 		BillDTO billDTO = BillDTOHelper.setup(patientMapper);
 		billDTO.setId(id);
 		return billDTO;
 	}
 
-	public static String asJsonString(BillDTO billDTO){
+	public static String asJsonString(BillDTO billDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(billDTO);
 		} catch (JsonProcessingException e) {
@@ -35,8 +57,8 @@ public class BillDTOHelper{
 		}
 		return null;
 	}
-	
-	public static String asJsonString(List<BillDTO> billDTOList){
+
+	public static String asJsonString(List<BillDTO> billDTOList) {
 		try {
 			return new ObjectMapper().writeValueAsString(billDTOList);
 		} catch (JsonProcessingException e) {

--- a/src/test/java/org/isf/accounting/data/BillHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.data;
 
 import java.util.ArrayList;
@@ -16,24 +37,25 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class BillHelper{
-	public static Bill setup() throws OHException{
-		TestPatient testPatient =  new TestPatient();
-		Patient patient = testPatient.setup(false); 
-		TestPriceList testPriceList =  new TestPriceList();
+public class BillHelper {
+
+	public static Bill setup() throws OHException {
+		TestPatient testPatient = new TestPatient();
+		Patient patient = testPatient.setup(false);
+		TestPriceList testPriceList = new TestPriceList();
 		PriceList priceList = testPriceList.setup(false);
 		TestBill testBill = new TestBill();
 		Bill bill = testBill.setup(priceList, patient, false);
 		return bill;
 	}
-	
+
 	public static Bill setup(Integer id) throws OHException {
 		Bill bill = BillHelper.setup();
 		bill.setId(id);
 		return bill;
 	}
 
-	public static String asJsonString(Bill bill){
+	public static String asJsonString(Bill bill) {
 		try {
 			return new ObjectMapper().writeValueAsString(bill);
 		} catch (JsonProcessingException e) {
@@ -41,21 +63,22 @@ public class BillHelper{
 		}
 		return null;
 	}
-	
+
 	public static List<Bill> genList(int n) {
-		
+
 		return IntStream.range(0, n)
-				.mapToObj(i -> {	try {
-										return BillHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
-		
+				.mapToObj(i -> {
+					try {
+						return BillHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
+
 	}
-	
-	public static ArrayList<Bill>  genArrayList(int n){
+
+	public static ArrayList<Bill> genArrayList(int n) {
 		return new ArrayList<Bill>(BillHelper.genList(n));
 	}
 }

--- a/src/test/java/org/isf/accounting/data/BillItemsDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillItemsDTOHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.data;
 
 import java.util.ArrayList;
@@ -14,16 +35,17 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class BillItemsDTOHelper{
-	public static BillItemsDTO setup(BillItemsMapper billItemsMapper) throws OHException{
+public class BillItemsDTOHelper {
+
+	public static BillItemsDTO setup(BillItemsMapper billItemsMapper) throws OHException {
 		Bill bill = BillHelper.setup();
 		TestBillItems tbi = new TestBillItems();
 		BillItems billItems = tbi.setup(bill, false);
 		BillItemsDTO billItemsDTO = billItemsMapper.map2DTO(billItems);
 		return billItemsDTO;
 	}
-	
-	public static String asJsonString(BillItemsDTO billItemsDTO){
+
+	public static String asJsonString(BillItemsDTO billItemsDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(billItemsDTO);
 		} catch (JsonProcessingException e) {
@@ -31,8 +53,8 @@ public class BillItemsDTOHelper{
 		}
 		return null;
 	}
-	
-	public static String asJsonString(List<BillItemsDTO> billItemsDTOList){
+
+	public static String asJsonString(List<BillItemsDTO> billItemsDTOList) {
 		try {
 			return new ObjectMapper().writeValueAsString(billItemsDTOList);
 		} catch (JsonProcessingException e) {
@@ -40,9 +62,10 @@ public class BillItemsDTOHelper{
 		}
 		return null;
 	}
-	
-	public static ArrayList<BillItems> toModelList(List<BillItemsDTO> billItemsDTOList, BillItemsMapper billItemsMapper){
-        ArrayList<BillItems> billItems = new ArrayList<BillItems>(billItemsDTOList.stream().map(pay-> billItemsMapper.map2Model(pay)).collect(Collectors.toList()));
-        return billItems;
+
+	public static ArrayList<BillItems> toModelList(List<BillItemsDTO> billItemsDTOList, BillItemsMapper billItemsMapper) {
+		ArrayList<BillItems> billItems = new ArrayList<BillItems>(
+				billItemsDTOList.stream().map(pay -> billItemsMapper.map2Model(pay)).collect(Collectors.toList()));
+		return billItems;
 	}
 }

--- a/src/test/java/org/isf/accounting/data/BillPaymentsDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillPaymentsDTOHelper.java
@@ -1,5 +1,25 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.data;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,16 +36,17 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class BillPaymentsDTOHelper{
-	public static BillPaymentsDTO setup(BillPaymentsMapper billPaymentsMapper ) throws OHException{
+public class BillPaymentsDTOHelper {
+
+	public static BillPaymentsDTO setup(BillPaymentsMapper billPaymentsMapper) throws OHException {
 		Bill bill = BillHelper.setup();
-		TestBillPayments testBillPayments =  new TestBillPayments();
+		TestBillPayments testBillPayments = new TestBillPayments();
 		BillPayments billPayments = testBillPayments.setup(bill, true);
-		BillPaymentsDTO billPaymentsDTO =billPaymentsMapper.map2DTO(billPayments);
+		BillPaymentsDTO billPaymentsDTO = billPaymentsMapper.map2DTO(billPayments);
 		return billPaymentsDTO;
 	}
-	
-	public static String asJsonString(BillPaymentsDTO billPaymentsDTO){
+
+	public static String asJsonString(BillPaymentsDTO billPaymentsDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(billPaymentsDTO);
 		} catch (JsonProcessingException e) {
@@ -33,8 +54,8 @@ public class BillPaymentsDTOHelper{
 		}
 		return null;
 	}
-	
-	public static String asJsonString(List<BillPaymentsDTO> billPaymentsDTOList){
+
+	public static String asJsonString(List<BillPaymentsDTO> billPaymentsDTOList) {
 		try {
 			return new ObjectMapper().writeValueAsString(billPaymentsDTOList);
 		} catch (JsonProcessingException e) {
@@ -42,29 +63,31 @@ public class BillPaymentsDTOHelper{
 		}
 		return null;
 	}
-	
-	public static ArrayList<BillPayments> toModelList(List<BillPaymentsDTO> billPaymentsDTOList, BillPaymentsMapper billPaymentsMapper){
-        ArrayList<BillPayments> billPayments = new ArrayList<BillPayments>(billPaymentsDTOList.stream().map(pay-> billPaymentsMapper.map2Model(pay)).collect(Collectors.toList()));
-        return billPayments;
+
+	public static ArrayList<BillPayments> toModelList(List<BillPaymentsDTO> billPaymentsDTOList, BillPaymentsMapper billPaymentsMapper) {
+		ArrayList<BillPayments> billPayments = new ArrayList<BillPayments>(
+				billPaymentsDTOList.stream().map(pay -> billPaymentsMapper.map2Model(pay)).collect(Collectors.toList()));
+		return billPayments;
 	}
-	
-	public static List<BillPaymentsDTO> genList(int n, BillPaymentsMapper billPaymentsMapper) throws OHException{
+
+	public static List<BillPaymentsDTO> genList(int n, BillPaymentsMapper billPaymentsMapper) throws OHException {
 		return IntStream.range(0, n)
-			.mapToObj(i -> {	try {
-									return BillPaymentsDTOHelper.setup(billPaymentsMapper);
-								} catch (OHException e) {
-									e.printStackTrace();
-								}
-								return null;
-							}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return BillPaymentsDTOHelper.setup(billPaymentsMapper);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
-	
-	public static ArrayList<BillPaymentsDTO> genArrayList(int n, BillPaymentsMapper billPaymentsMapper) throws OHException{
+
+	public static ArrayList<BillPaymentsDTO> genArrayList(int n, BillPaymentsMapper billPaymentsMapper) throws OHException {
 		return new ArrayList<BillPaymentsDTO>(genList(n, billPaymentsMapper));
 	}
 
 	public static ArrayList<BillPayments> genListModel(int n, BillPaymentsMapper billPaymentsMapper) throws OHException {
 		return BillPaymentsDTOHelper.toModelList(BillPaymentsDTOHelper.genList(n, billPaymentsMapper), billPaymentsMapper);
 	}
-	
+
 }

--- a/src/test/java/org/isf/accounting/data/FullBillDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/FullBillDTOHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.data;
 
 import java.util.Arrays;
@@ -23,14 +44,15 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class FullBillDTOHelper{
-	public static FullBillDTO setup(PatientMapper patientMapper, BillItemsMapper billItemsMapper, BillPaymentsMapper billPaymentsMapper) throws OHException{
+public class FullBillDTOHelper {
+
+	public static FullBillDTO setup(PatientMapper patientMapper, BillItemsMapper billItemsMapper, BillPaymentsMapper billPaymentsMapper) throws OHException {
 		Bill bill = BillHelper.setup();
-		FullBillDTO fullBillDTO = new  FullBillDTO();
-		
+		FullBillDTO fullBillDTO = new FullBillDTO();
+
 		Patient patient = new TestPatient().setup(true);
 		PatientDTO patientDTO = patientMapper.map2DTO(patient);
-		
+
 		BillDTO billDTO = new BillDTO();
 		billDTO.setPatientDTO(patientDTO);
 		billDTO.setListName(bill.getListName());
@@ -38,7 +60,7 @@ public class FullBillDTOHelper{
 		//OP-205
 		//BillDTO billDTO = OHModelMapper.getObjectMapper().map(bill, BillDTO.class);
 		fullBillDTO.setBillDTO(billDTO);
-		
+
 		TestBillItems tbi = new TestBillItems();
 		BillItems billItems = tbi.setup(bill, false);
 		BillItemsDTO billItemsDTO = billItemsMapper.map2DTO(billItems);
@@ -48,11 +70,11 @@ public class FullBillDTOHelper{
 		BillPayments billPayments = tbp.setup(bill, false);
 		BillPaymentsDTO billPaymentsDTO = billPaymentsMapper.map2DTO(billPayments);
 		fullBillDTO.setBillPaymentsDTO(Arrays.asList(billPaymentsDTO));
-		
+
 		return fullBillDTO;
 	}
-	
-	public static String asJsonString(FullBillDTO fullBillDTO){
+
+	public static String asJsonString(FullBillDTO fullBillDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(fullBillDTO);
 		} catch (JsonProcessingException e) {
@@ -60,8 +82,8 @@ public class FullBillDTOHelper{
 		}
 		return null;
 	}
-	
-	public static String asJsonString(List<FullBillDTO> fullBillDTOList){
+
+	public static String asJsonString(List<FullBillDTO> fullBillDTOList) {
 		try {
 			return new ObjectMapper().writeValueAsString(fullBillDTOList);
 		} catch (JsonProcessingException e) {

--- a/src/test/java/org/isf/accounting/rest/BillControllerTest.java
+++ b/src/test/java/org/isf/accounting/rest/BillControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.accounting.rest;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -72,126 +93,126 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Emerson Castaneda
- *
  */
 
 public class BillControllerTest extends ControllerBaseTest {
+
 	@Mock
 	private BillBrowserManager billManagerMock;
-	
+
 	@Mock
 	private PriceListManager priceListManagerMock;
-	
+
 	@Mock
 	private PatientBrowserManager patientManagerMock;
-	
-	private BillMapper billMapper = new BillMapper();
-	
-	private BillItemsMapper billItemsMapper = new BillItemsMapper();
-	
-	private BillPaymentsMapper billPaymentsMapper = new BillPaymentsMapper();
-	
-	private PatientMapper patientMapper = new PatientMapper();
-	
-    private MockMvc mockMvc;
 
-    @Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	private BillMapper billMapper = new BillMapper();
+
+	private BillItemsMapper billItemsMapper = new BillItemsMapper();
+
+	private BillPaymentsMapper billPaymentsMapper = new BillPaymentsMapper();
+
+	private PatientMapper patientMapper = new PatientMapper();
+
+	private MockMvc mockMvc;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new BillController(billManagerMock, priceListManagerMock, patientManagerMock, billMapper, billItemsMapper, billPaymentsMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(billMapper, "modelMapper", modelMapper);
 		ReflectionTestUtils.setField(billItemsMapper, "modelMapper", modelMapper);
 		ReflectionTestUtils.setField(billPaymentsMapper, "modelMapper", modelMapper);
-		
+
 		ReflectionTestUtils.setField(patientMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void when_post_bills_is_call_without_contentType_header_then_HttpMediaTypeNotSupportedException() throws Exception {
 		String request = "/bills";
-		
+
 		MvcResult result = this.mockMvc
-			.perform(post(request).content(new byte[]{'a', 'b', 'c'}))
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isUnsupportedMediaType())
-			.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
-			.andReturn();
-		
+				.perform(post(request).content(new byte[] { 'a', 'b', 'c' }))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isUnsupportedMediaType())
+				.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
+				.andReturn();
+
 		Optional<HttpMediaTypeNotSupportedException> exception = Optional.ofNullable((HttpMediaTypeNotSupportedException) result.getResolvedException());
 		logger.debug("exception: {}", exception);
-		exception.ifPresent( (se) -> assertThat(se, notNullValue()));
-		exception.ifPresent( (se) -> assertThat(se, instanceOf(HttpMediaTypeNotSupportedException.class)));
-	
+		exception.ifPresent((se) -> assertThat(se, notNullValue()));
+		exception.ifPresent((se) -> assertThat(se, instanceOf(HttpMediaTypeNotSupportedException.class)));
+
 	}
-	
+
 	@Test
 	public void when_post_bills_is_call_with_empty_body_then_BadRequest_HttpMessageNotReadableException() throws Exception {
 		String request = "/bills";
 		String empty_body = "";
-				
+
 		MvcResult result = this.mockMvc
-			.perform(
-				post(request)
-				.content(empty_body.getBytes())
-				.contentType(MediaType.APPLICATION_JSON)
-			)
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest())
-			.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
-			.andReturn();
-		
+				.perform(
+						post(request)
+								.content(empty_body.getBytes())
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
+				.andReturn();
+
 		Optional<HttpMessageNotReadableException> exception = Optional.ofNullable((HttpMessageNotReadableException) result.getResolvedException());
 		logger.debug("exception: {}", exception);
-		exception.ifPresent( (se) -> assertThat(se, notNullValue()));
-		exception.ifPresent( (se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
+		exception.ifPresent((se) -> assertThat(se, notNullValue()));
+		exception.ifPresent((se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
 	}
-	
+
 	@Test
 	public void when_post_patients_PatientBrowserManager_getPatient_returns_null_then_OHAPIException_BadRequest() throws Exception {
 		String request = "/bills";
-		FullBillDTO newFullBillDTO =  FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
+		FullBillDTO newFullBillDTO = FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
 		Integer id = 0;
 		newFullBillDTO.getBillDTO().setId(id);
 		Integer code = 0;
 		newFullBillDTO.getBillDTO().getPatientDTO().setCode(code);
-		
+
 		newFullBillDTO.getBillDTO().setPatient(true);
-		
+
 		when(patientManagerMock.getPatientByName(any(String.class))).thenReturn(null); //FIXME: why we were searching by name?
-		
+
 		MvcResult result = this.mockMvc
-			.perform(
-				post(request)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
-			)
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
-			.andExpect(content().string(containsString("Patient Not found!")))
-			.andReturn();
-		
+				.perform(
+						post(request)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
+				.andExpect(content().string(containsString("Patient Not found!")))
+				.andReturn();
+
 		//TODO Create OHCreateAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
-		
+
 	@Test
 	public void when_put_bills_PatientBrowserManager_getPatient_returns_null_then_OHAPIException_BadRequest() throws Exception {
 		Integer id = 123;
 		String request = "/bills/{id}";
-		
-		FullBillDTO newFullBillDTO =  FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
+
+		FullBillDTO newFullBillDTO = FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
 		newFullBillDTO.getBillDTO().setId(id);
 		Integer code = 111;
 		newFullBillDTO.getBillDTO().getPatientDTO().setCode(code);
@@ -200,296 +221,297 @@ public class BillControllerTest extends ControllerBaseTest {
 		when(patientManagerMock.getPatientByName(eq(bill.getPatName()))).thenReturn(null); //FIXME: why we were searching by name?
 		when(billManagerMock.getBill(eq(id))).thenReturn(bill);
 		when(billManagerMock.deleteBill(eq(bill))).thenReturn(true);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(
-				put(request, id)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
-			)
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
-			.andExpect(content().string(containsString("Patient Not found!")))
-			.andReturn();
-		
+				.perform(
+						put(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
+				.andExpect(content().string(containsString("Patient Not found!")))
+				.andReturn();
+
 		//TODO Create OHCreateAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
-	
+
 	@Test
 	public void when_put_bills_PatientBrowserManager_getPatient_returns_null_then_OK() throws Exception {
 		Integer id = 123;
 		String request = "/bills/{id}";
-		FullBillDTO newFullBillDTO =  FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
+		FullBillDTO newFullBillDTO = FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
 		newFullBillDTO.getBillDTO().setId(id);
 		Integer code = 111;
 		newFullBillDTO.getBillDTO().getPatientDTO().setCode(code);
 		newFullBillDTO.getBillDTO().setPatient(true);
 		Bill bill = BillHelper.setup();
-		 
+
 		Patient patient = bill.getBillPatient();
 		//Patient patient = bill.getPatient();
-		
+
 		when(patientManagerMock.getPatientByName(any(String.class))).thenReturn(patient); //FIXME: why we were searching by name?
 		when(billManagerMock.getBill(eq(id))).thenReturn(bill);
 		ArrayList<PriceList> priceListList = new ArrayList<PriceList>();
-		
+
 		PriceList priceList = bill.getPriceList();
-		
+
 		priceList.setName("TestListNameToMatch");
 		newFullBillDTO.getBillDTO().setListName("TestListNameToMatch");
 		priceListList.add(priceList);
 		when(priceListManagerMock.getLists()).thenReturn(priceListList);
-		
+
 		//TODO open a ticket for suggesting refactoring for updateBill() method in order to accept generic List instead of ArrayList  like:
 		// public boolean updateBill(Bill updateBill,
 		//		List<BillItems> billItems, 
 		//		List<BillPayments> billPayments) throws OHServiceException 
 		//ArrayList<BillItems> billItemsArrayList = new ArrayList(newFullBillDTO.getBillItems());
 		//billItemsArrayList.addAll(newFullBillDTO.getBillItems());
-		
+
 		ArrayList<BillItems> billItemsArrayList = BillItemsDTOHelper.toModelList(newFullBillDTO.getBillItemsDTO(), billItemsMapper);
-		
+
 		ArrayList<BillPayments> billPaymentsArrayList = BillPaymentsDTOHelper.toModelList(newFullBillDTO.getBillPaymentsDTO(), billPaymentsMapper);
-		
+
 		//TODO  check eq(bill) case
 		//when(billManagerMock.updateBill(eq(bill), eq(billItemsArrayList), eq(billPaymentsArrayList)))
 		when(billManagerMock.updateBill(any(Bill.class), eq(billItemsArrayList), eq(billPaymentsArrayList)))
-		.thenReturn(true);
+				.thenReturn(true);
 
 		this.mockMvc
-			.perform(
-				put(request, id)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
-			)
-			.andDo(log())
-			.andExpect(status().isCreated()) 
-			.andExpect(content().string(containsString(FullBillDTOHelper.asJsonString(newFullBillDTO))))
-			.andReturn();
+				.perform(
+						put(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(FullBillDTOHelper.asJsonString(newFullBillDTO))
+				)
+				.andDo(log())
+				.andExpect(status().isCreated())
+				.andExpect(content().string(containsString(FullBillDTOHelper.asJsonString(newFullBillDTO))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_get_items_with_existent_id_then_getItems_returns_items_and_OK() throws Exception {
 		Integer id = 123;
 		String request = "/bills/items/{bill_id}";
-		
-		FullBillDTO newFullBillDTO =  FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
+
+		FullBillDTO newFullBillDTO = FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
 		newFullBillDTO.getBillDTO().setId(id);
-		
+
 		ArrayList<BillItems> itemsDTOSExpected = new ArrayList<BillItems>();
-		itemsDTOSExpected.addAll(newFullBillDTO.getBillItemsDTO().stream().map(it-> billItemsMapper.map2Model(it)).collect(Collectors.toList()));
-				
+		itemsDTOSExpected.addAll(newFullBillDTO.getBillItemsDTO().stream().map(it -> billItemsMapper.map2Model(it)).collect(Collectors.toList()));
+
 		when(billManagerMock.getItems(eq(id))).thenReturn(itemsDTOSExpected);
-		
+
 		this.mockMvc
-			.perform(
-					get(request, id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(newFullBillDTO.getBillItemsDTO()))))
-			.andReturn();
+				.perform(
+						get(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(newFullBillDTO.getBillItemsDTO()))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_get_items_with_existent_id_then_getItems_is_empty_and_isNoContent() throws Exception {
 		Integer id = 123;
 		String request = "/bills/items/{bill_id}";
-		
+
 		this.mockMvc
-			.perform(
-					get(request, id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isNoContent());
+				.perform(
+						get(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNoContent());
 	}
 
 	@Test
 	public void when_get_bill_with_existent_id_then_response_BillDTO_and_OK() throws Exception {
 		Integer id = 123;
 		String request = "/bills/{id}";
-		
+
 		Bill bill = BillHelper.setup();
 		bill.setId(id);
 
 		when(billManagerMock.getBill(eq(id))).thenReturn(bill);
-				
+
 		this.mockMvc
-			.perform(
-					get(request, id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
-			.andReturn();
+				.perform(
+						get(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
+				.andReturn();
 	}
 
 	@Test
 	public void when_delete_bill_with_existent_id_then_response_true_and_OK() throws Exception {
 		Integer id = 123;
 		String request = "/bills/{id}";
-		
+
 		Bill bill = BillHelper.setup();
-		
+
 		when(billManagerMock.getBill(eq(id))).thenReturn(bill);
-		
+
 		when(billManagerMock.deleteBill(eq(bill))).thenReturn(true);
-		
+
 		this.mockMvc
-			.perform(
-					delete(request, id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("true")));
+				.perform(
+						delete(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("true")));
 	}
-	
+
 	@Test
 	public void when_get_bill_pending_affiliate_with_existent_patient_code_then_response_List_of_BillDTO_and_OK() throws Exception {
 		Integer code = 123;
 		String request = "/bills/pending/affiliate?patient_code={code}";
-		
+
 		ArrayList<Bill> billList = BillHelper.genArrayList(2);
 		BillDTO expectedBillDTO1 = billMapper.map2DTO(billList.get(0));
 		BillDTO expectedBillDTO2 = billMapper.map2DTO(billList.get(1));
 
 		when(billManagerMock.getPendingBillsAffiliate(eq(code))).thenReturn(billList);
-		
+
 		this.mockMvc
-			.perform(
-					get(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
-			.andReturn();
+				.perform(
+						get(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_post_searchBillsByPayments_with_a_list_of_existent_billsPaymentsDTO_then_response_List_of_BillDTO_and_OK() throws Exception {
 		String request = "/bills/search/by/payments";
-				
-		ArrayList<BillPayments> billsPaymentsList = BillPaymentsDTOHelper.genListModel(2,billPaymentsMapper);
+
+		ArrayList<BillPayments> billsPaymentsList = BillPaymentsDTOHelper.genListModel(2, billPaymentsMapper);
 		ArrayList<BillPaymentsDTO> billsPaymentsDTOList = BillPaymentsDTOHelper.genArrayList(2, billPaymentsMapper);
-		
+
 		ArrayList<Bill> billList = BillHelper.genArrayList(2);
 		BillDTO expectedBillDTO1 = billMapper.map2DTO(billList.get(0));
 		BillDTO expectedBillDTO2 = billMapper.map2DTO(billList.get(1));
-		
+
 		when(billManagerMock.getBills(eq(billsPaymentsList))).thenReturn(billList);
-		
+
 		this.mockMvc
-			.perform(
-					post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(BillPaymentsDTOHelper.asJsonString(billsPaymentsDTOList))
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
-			.andReturn();
+				.perform(
+						post(request)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(BillPaymentsDTOHelper.asJsonString(billsPaymentsDTOList))
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
+				.andReturn();
 	}
 
 	@Test
 	public void when_get_pendingBills_with_existent_patient_code_then_response_List_of_BillDTO_and_OK() throws Exception {
 		Integer code = 123;
 		String request = "/bills/pending?patient_code={code}";
-		
+
 		ArrayList<Bill> billList = BillHelper.genArrayList(2);
 		BillDTO expectedBillDTO1 = billMapper.map2DTO(billList.get(0));
 		BillDTO expectedBillDTO2 = billMapper.map2DTO(billList.get(1));
 
-	    List<BillDTO> billDTOS = billList.stream().map(b-> billMapper.map2DTO(b)).collect(Collectors.toList());
-		
+		List<BillDTO> billDTOS = billList.stream().map(b -> billMapper.map2DTO(b)).collect(Collectors.toList());
+
 		when(billManagerMock.getPendingBills(eq(code))).thenReturn(billList);
-		
+
 		this.mockMvc
-			.perform(
-					get(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
-			.andExpect(content().string(containsString(BillDTOHelper.asJsonString(billDTOS))))
-			.andReturn();
+				.perform(
+						get(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO1))))
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(expectedBillDTO2))))
+				.andExpect(content().string(containsString(BillDTOHelper.asJsonString(billDTOS))))
+				.andReturn();
 	}
-	
+
 	@Test
-	public void when_post_searchBillsByItem_with_valid_dates_and_billItemsDTO_content_and_PatientBrowserManager_getBills_returns_billList_then_OK() throws Exception {
+	public void when_post_searchBillsByItem_with_valid_dates_and_billItemsDTO_content_and_PatientBrowserManager_getBills_returns_billList_then_OK()
+			throws Exception {
 		String request = "/bills/search/by/item?datefrom={dateFrom}&dateto={dateTo}";
 		String dateFrom = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
 		String dateTo = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
-		
-		BillItemsDTO billItemsDTO = BillItemsDTOHelper.setup(billItemsMapper);
-	    BillItems billItem = billItemsMapper.map2Model(billItemsDTO);
-	             
-	    ArrayList<Bill> billList = new ArrayList<Bill>();
-	    Integer id = 0;
-	    Bill bill = BillHelper.setup(id);
-	    billList.add(bill);
-		
-	    //TODO add test(s) with incorrect formatted dates returning an exception
-	    //TODO add test(s) with specific dates returning an empty list and asserting  HttpStatus.NO_CONTENT
-	    //TODO add test(s) with different BillItem returning an empty list and asserting  HttpStatus.NO_CONTENT
-	    when(billManagerMock.getBills(any(GregorianCalendar.class), any(GregorianCalendar.class), eq(billItem))).thenReturn(billList);
 
-	    this.mockMvc
-			.perform(
-					post(request, dateFrom, dateTo)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(BillItemsDTOHelper.asJsonString(billItemsDTO))
-					)		
-			.andDo(log())
-			.andDo(print())
-			.andExpect(status().isOk())
-			// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
-			.andReturn();
+		BillItemsDTO billItemsDTO = BillItemsDTOHelper.setup(billItemsMapper);
+		BillItems billItem = billItemsMapper.map2Model(billItemsDTO);
+
+		ArrayList<Bill> billList = new ArrayList<Bill>();
+		Integer id = 0;
+		Bill bill = BillHelper.setup(id);
+		billList.add(bill);
+
+		//TODO add test(s) with incorrect formatted dates returning an exception
+		//TODO add test(s) with specific dates returning an empty list and asserting  HttpStatus.NO_CONTENT
+		//TODO add test(s) with different BillItem returning an empty list and asserting  HttpStatus.NO_CONTENT
+		when(billManagerMock.getBills(any(GregorianCalendar.class), any(GregorianCalendar.class), eq(billItem))).thenReturn(billList);
+
+		this.mockMvc
+				.perform(
+						post(request, dateFrom, dateTo)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(BillItemsDTOHelper.asJsonString(billItemsDTO))
+				)
+				.andDo(log())
+				.andDo(print())
+				.andExpect(status().isOk())
+				// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_get_searchBills_with_valid_dates_and_valid_patient_code_and_PatientBrowserManager_getBills_returns_billList_then_OK() throws Exception {
 		String request = "/bills?datefrom={dateFrom}&dateto={dateTo}&patient_code={patient_code}";
 		String dateFrom = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
 		String dateTo = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
 		Integer patientCode = 1;
-		
+
 		ArrayList<Bill> billList = BillHelper.genArrayList(1);
 
-	    Patient patient = new TestPatient().setup(true);
-	    
-	    when(patientManagerMock.getPatientById(eq(patientCode))).thenReturn(patient);
-	   
-	    //TODO add test(s) with incorrect formatted dates returning an exception 
-	    //TODO add test(s) with specific dates returning an empty list and asserting  HttpStatus.NO_CONTENT
-	    //TODO add test(s) with a different patient returning an empty list and asserting  HttpStatus.NO_CONTENT
-	    when(billManagerMock.getBills(any(GregorianCalendar.class), any(GregorianCalendar.class), eq(patient))).thenReturn(billList);
-	    
-	    this.mockMvc
-			.perform(
-					get(request, dateFrom, dateTo, patientCode)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andDo(print())
-			.andExpect(status().isOk())
-			// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
-			.andReturn();
+		Patient patient = new TestPatient().setup(true);
+
+		when(patientManagerMock.getPatientById(eq(patientCode))).thenReturn(patient);
+
+		//TODO add test(s) with incorrect formatted dates returning an exception
+		//TODO add test(s) with specific dates returning an empty list and asserting  HttpStatus.NO_CONTENT
+		//TODO add test(s) with a different patient returning an empty list and asserting  HttpStatus.NO_CONTENT
+		when(billManagerMock.getBills(any(GregorianCalendar.class), any(GregorianCalendar.class), eq(patient))).thenReturn(billList);
+
+		this.mockMvc
+				.perform(
+						get(request, dateFrom, dateTo, patientCode)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andDo(print())
+				.andExpect(status().isOk())
+				// TODO 1 .andExpect(content().string(containsString(BillDTOHelper.asJsonString(BillDTOHelper.setup(id)))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_get_getDistinctItems_BillBrowserManager_getDistinctItems_returns_BillItemsDTOList_then_OK() throws Exception {
 		String request = "/bills/items";
@@ -502,42 +524,42 @@ public class BillControllerTest extends ControllerBaseTest {
 		ArrayList<BillItems> billItemsList = new ArrayList<BillItems>();
 		billItemsList.add(billItems1);
 		billItemsList.add(billItems2);
-		
-        List<BillItemsDTO> expectedBillItemsDTOList = billItemsList.stream().map(it-> billItemsMapper.map2DTO(it)).collect(Collectors.toList());
-        
-        //TODO emulate distinct behavior since both billItems in List are equal
-        when(billManagerMock.getDistinctItems()).thenReturn(billItemsList);
-			    
-	    this.mockMvc
-			.perform(
-					get(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(BillItemsDTOHelper.asJsonString(expectedBillItemsDTOList))))
-			.andReturn();
+
+		List<BillItemsDTO> expectedBillItemsDTOList = billItemsList.stream().map(it -> billItemsMapper.map2DTO(it)).collect(Collectors.toList());
+
+		//TODO emulate distinct behavior since both billItems in List are equal
+		when(billManagerMock.getDistinctItems()).thenReturn(billItemsList);
+
+		this.mockMvc
+				.perform(
+						get(request)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(BillItemsDTOHelper.asJsonString(expectedBillItemsDTOList))))
+				.andReturn();
 	}
-	
+
 	@Test
 	public void when_get_getPaymentsByBillId_with_valid_bill_id_and_BillBrowserManager_getPayments_returns_BillPaymentsList_then_OK() throws Exception {
 		String request = "/bills/payments/{bill_id}";
-		
-		Integer billId  =123;
-	    
+
+		Integer billId = 123;
+
 		List<BillPaymentsDTO> billPaymentsDTOList = BillPaymentsDTOHelper.genList(3, billPaymentsMapper);
-		
-	    when(billManagerMock.getPayments(eq(billId))).thenReturn(BillPaymentsDTOHelper.toModelList(billPaymentsDTOList, billPaymentsMapper));
-			    
-	    this.mockMvc
-			.perform(
-					get(request, billId)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(BillPaymentsDTOHelper.asJsonString(billPaymentsDTOList))))
-			.andReturn();
+
+		when(billManagerMock.getPayments(eq(billId))).thenReturn(BillPaymentsDTOHelper.toModelList(billPaymentsDTOList, billPaymentsMapper));
+
+		this.mockMvc
+				.perform(
+						get(request, billId)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(BillPaymentsDTOHelper.asJsonString(billPaymentsDTOList))))
+				.andReturn();
 	}
-	
+
 }

--- a/src/test/java/org/isf/admission/data/AdmissionHelper.java
+++ b/src/test/java/org/isf/admission/data/AdmissionHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.data;
 
 import java.util.ArrayList;
@@ -34,7 +55,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class AdmissionHelper {
 
 	public static Admission setup() throws OHException {
-		TestAdmission testAdmission =  new TestAdmission();
+		TestAdmission testAdmission = new TestAdmission();
 		TestWard testWard = new TestWard();
 		Ward ward = testWard.setup(false);
 		Patient patient = new TestPatient().setup(true);
@@ -44,36 +65,37 @@ public class AdmissionHelper {
 		DiseaseType diseaseType = (new TestDiseaseType()).setup(false);
 		Disease diseaseIn = testDisease.setup(diseaseType, false);
 		Disease diseaseOut1 = testDisease.setup(diseaseType, false);
-		Disease diseaseOut2 = testDisease.setup(diseaseType, false); 	
+		Disease diseaseOut2 = testDisease.setup(diseaseType, false);
 		Disease diseaseOut3 = testDisease.setup(diseaseType, false);
-		
-		TestOperation testOperation =  new TestOperation();
+
+		TestOperation testOperation = new TestOperation();
 		OperationType operationType = null;
 		Operation operation = testOperation.setup(operationType, false);
-		
+
 		DischargeType dischargeType = DischargeTypeHelper.setup("0");
-		
+
 		PregnantTreatmentType pregTreatmentType = null;
 		DeliveryType deliveryType = null;
 		DeliveryResultType deliveryResult = null;
-		
-		
-		return testAdmission.setup(ward, patient, admissionType, diseaseIn, diseaseOut1, diseaseOut2, diseaseOut3, operation, dischargeType, pregTreatmentType, deliveryType, deliveryResult, false);
+
+		return testAdmission.setup(ward, patient, admissionType, diseaseIn, diseaseOut1, diseaseOut2, diseaseOut3, operation, dischargeType, pregTreatmentType,
+				deliveryType, deliveryResult, false);
 	}
-	
+
 	public static ArrayList<Admission> setupAdmissionList(int size) {
-		return (ArrayList<Admission>) IntStream.range(1, size+1)
-				.mapToObj(i -> {	Admission ep = null;
-									try {
-										ep = AdmissionHelper.setup();
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return ep;
-								}
+		return (ArrayList<Admission>) IntStream.range(1, size + 1)
+				.mapToObj(i -> {
+							Admission ep = null;
+							try {
+								ep = AdmissionHelper.setup();
+							} catch (OHException e) {
+								e.printStackTrace();
+							}
+							return ep;
+						}
 				).collect(Collectors.toList());
 	}
-	
+
 	public static String asJsonString(AdmissionDTO admissionDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(admissionDTO);

--- a/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
+++ b/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admission.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -60,6 +81,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class AdmissionControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(AdmissionControllerTest.class);
 
 	@Mock
@@ -85,52 +107,51 @@ public class AdmissionControllerTest {
 
 	@Mock
 	private DeliveryResultTypeBrowserManager dlvrrestTypeManagerMock;
-	
+
 	@Autowired
 	private AdmissionMapper admissionMapper = new AdmissionMapper();
-	
-	@Autowired 
-	private AdmittedPatientMapper admittedMapper= new AdmittedPatientMapper();
-	
-	
+
+	@Autowired
+	private AdmittedPatientMapper admittedMapper = new AdmittedPatientMapper();
+
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
-				.standaloneSetup(new  AdmissionController(admissionManagerMock ,patientManagerMock ,wardManagerMock,
-						 diseaseManagerMock, operationManagerMock, pregTraitTypeManagerMock, 
-						 dlvrTypeManagerMock, dlvrrestTypeManagerMock,	admissionMapper, 
-						 admittedMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
+				.standaloneSetup(new AdmissionController(admissionManagerMock, patientManagerMock, wardManagerMock,
+						diseaseManagerMock, operationManagerMock, pregTraitTypeManagerMock,
+						dlvrTypeManagerMock, dlvrrestTypeManagerMock, admissionMapper,
+						admittedMapper))
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(admissionMapper, "modelMapper", modelMapper);
 		ReflectionTestUtils.setField(admittedMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetAdmissions_200() throws Exception {
 		String request = "/admissions/{id}";
 		Integer id = 1;
-	
+
 		Admission admission = AdmissionHelper.setup();
 		when(admissionManagerMock.getAdmission(id))
-			.thenReturn(admission);
-		
+				.thenReturn(admission);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request,id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(AdmissionHelper.asJsonString(admissionMapper.map2DTO(admission)))))
-			.andReturn();
-		
+				.perform(get(request, id)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(AdmissionHelper.asJsonString(admissionMapper.map2DTO(admission)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -138,52 +159,51 @@ public class AdmissionControllerTest {
 	public void testGetCurrentAdmission_200() throws Exception {
 		String request = "/admissions/current?patientcode={patientCode}";
 		Integer patientCode = 1;
-	
-		Patient patient = PatientHelper.setup(); 
+
+		Patient patient = PatientHelper.setup();
 		when(patientManagerMock.getPatientById(patientCode))
-			.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		Integer id = 0;
 		Admission admission = AdmissionHelper.setup();
 		when(admissionManagerMock.getCurrentAdmission(patient))
-		.thenReturn(admission);
-		
+				.thenReturn(admission);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request,patientCode)
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(AdmissionHelper.asJsonString(admissionMapper.map2DTO(admission)))))
-			.andReturn();
-		
+				.perform(get(request, patientCode)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(AdmissionHelper.asJsonString(admissionMapper.map2DTO(admission)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testGetAdmittedPatients_200() throws Exception {
 		String request = "/admissions/admittedPatients?searchterms=searchTerms";
 		ArrayList<AdmittedPatient> amittedPatients = PatientHelper.setupAdmittedPatientList(2);
-	
+
 		//GregorianCalendar[] admissionRange = null;
 		//GregorianCalendar[] dischargeRange = null;
 		String searchTerms = "";
 		//when(admissionManagerMock.getAdmittedPatients(admissionRange, dischargeRange, searchTerms))
 		when(admissionManagerMock.getAdmittedPatients(any(GregorianCalendar[].class), any(GregorianCalendar[].class), any(String.class)))
-		.thenReturn(amittedPatients);
-		
-		
+				.thenReturn(amittedPatients);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, searchTerms )
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(admittedMapper.map2DTOList(amittedPatients)))))
-			.andReturn();
-		
+				.perform(get(request, searchTerms)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(admittedMapper.map2DTOList(amittedPatients)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -192,27 +212,26 @@ public class AdmissionControllerTest {
 		String request = "/admissions?patientcode={patientCode}";
 		Integer patientCode = 1;
 
-		Patient patient = PatientHelper.setup(); 
+		Patient patient = PatientHelper.setup();
 		when(patientManagerMock.getPatientById(patientCode))
-			.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		ArrayList<Admission> admissions = AdmissionHelper.setupAdmissionList(2);
 		when(admissionManagerMock.getAdmissions(patient))
-		.thenReturn(admissions);
-		
+				.thenReturn(admissions);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, patientCode )
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(admissionMapper.map2DTOList(admissions)))))
-			.andReturn();
-		
+				.perform(get(request, patientCode)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(admissionMapper.map2DTOList(admissions)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
 
 	@Test
 	public void testGetNextYProg_200() throws Exception {
@@ -220,22 +239,22 @@ public class AdmissionControllerTest {
 		String wardCode = "1";
 
 		when(wardManagerMock.codeControl(wardCode))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		Integer nextYProg = 1;
 		when(admissionManagerMock.getNextYProg(wardCode))
-		.thenReturn(nextYProg);
-		
+				.thenReturn(nextYProg);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, wardCode )
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(nextYProg.toString())))
-			.andReturn();
-		
+				.perform(get(request, wardCode)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(nextYProg.toString())))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -245,174 +264,163 @@ public class AdmissionControllerTest {
 		String wardCode = "1";
 
 		when(wardManagerMock.codeControl(wardCode))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		Integer bed = 1012;
 		when(admissionManagerMock.getUsedWardBed(wardCode))
-		.thenReturn(bed);
-		
+				.thenReturn(bed);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, wardCode )
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(bed.toString())))
-			.andReturn();
-		
+				.perform(get(request, wardCode)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(bed.toString())))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testDeleteAdmissionType_200() throws Exception {
 		Integer id = 123;
 		String request = "/admissions/{id}";
-		
+
 		Admission admission = AdmissionHelper.setup();
 		when(admissionManagerMock.getAdmission(id))
-			.thenReturn(admission);
+				.thenReturn(admission);
 
 		when(admissionManagerMock.setDeleted(eq(id))).thenReturn(true);
-				
+
 		this.mockMvc
-			.perform(
-					get(request, id)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("true")))
-			.andReturn();
+				.perform(
+						get(request, id)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("true")))
+				.andReturn();
 	}
-	
 
 	@Test
 	public void testNewAdmissions_201() throws Exception {
 		String request = "/admissions";
-		
-		
+
 		Integer id = 1;
 		AdmissionDTO body = AdmissionHelper.setup(admissionMapper);
 		Integer code = 10;
 		body.getPatient().setCode(code);
-		
+
 		Admission newAdmission = admissionMapper.map2Model(body);
 
-		
-		
-		
 		when(admissionManagerMock.newAdmissionReturnKey(newAdmission))
-			.thenReturn(id);
+				.thenReturn(id);
 
 		ArrayList<Ward> wardList = WardHelper.setupWardList(2);
 		when(wardManagerMock.getWards())
-			.thenReturn(wardList);
+				.thenReturn(wardList);
 
-		ArrayList<AdmissionType> admissionTypeList =  AdmissionTypeDTOHelper.setupAdmissionTypeList(3);
+		ArrayList<AdmissionType> admissionTypeList = AdmissionTypeDTOHelper.setupAdmissionTypeList(3);
 		when(admissionManagerMock.getAdmissionType())
-		.thenReturn(admissionTypeList);
+				.thenReturn(admissionTypeList);
 
 		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
 		when(patientManagerMock.getPatientById(body.getPatient().getCode()))
-		.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		when(patientManagerMock.getPatientById(body.getPatient().getCode()))
-		.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		ArrayList<Disease> diseaseList = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseManagerMock.getDisease())
-		.thenReturn(diseaseList);
-		
-		
+				.thenReturn(diseaseList);
+
 		ArrayList<Operation> operationsList = OperationHelper.setupOperationList(3);
 		when(operationManagerMock.getOperation())
-		.thenReturn(operationsList);
-		
+				.thenReturn(operationsList);
+
 		ArrayList<DischargeType> disTypes = DischargeTypeHelper.setupDischargeTypeList(3);
 		when(admissionManagerMock.getDischargeType())
-		.thenReturn(disTypes);
-		
-	
-		
+				.thenReturn(disTypes);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(AdmissionHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(AdmissionHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testUpdateAdmissions() throws Exception {
 		String request = "/admissions";
-		
+
 		AdmissionDTO body = AdmissionHelper.setup(admissionMapper);
 		Integer code = 10;
 		body.getPatient().setCode(code);
-		
+
 		Admission old = admissionMapper.map2Model(body);
 		Admission update = admissionMapper.map2Model(body);
-		
-		
+
 		when(admissionManagerMock.getAdmission(eq(body.getId())))
-		.thenReturn(old);
-		
+				.thenReturn(old);
+
 		ArrayList<Ward> wardList = WardHelper.setupWardList(2);
 		when(wardManagerMock.getWards())
-			.thenReturn(wardList);
-		
-		ArrayList<AdmissionType> admissionTypeList =  AdmissionTypeDTOHelper.setupAdmissionTypeList(3);
+				.thenReturn(wardList);
+
+		ArrayList<AdmissionType> admissionTypeList = AdmissionTypeDTOHelper.setupAdmissionTypeList(3);
 		when(admissionManagerMock.getAdmissionType())
-		.thenReturn(admissionTypeList);
+				.thenReturn(admissionTypeList);
 
 		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
 		when(patientManagerMock.getPatientById(body.getPatient().getCode()))
-		.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		when(patientManagerMock.getPatientById(body.getPatient().getCode()))
-		.thenReturn(patient);
-		
+				.thenReturn(patient);
+
 		ArrayList<Disease> diseaseList = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseManagerMock.getDisease())
-		.thenReturn(diseaseList);
-		
-		
+				.thenReturn(diseaseList);
+
 		ArrayList<Operation> operationsList = OperationHelper.setupOperationList(3);
 		when(operationManagerMock.getOperation())
-		.thenReturn(operationsList);
-		
+				.thenReturn(operationsList);
+
 		ArrayList<DischargeType> disTypes = DischargeTypeHelper.setupDischargeTypeList(3);
 		when(admissionManagerMock.getDischargeType())
-		.thenReturn(disTypes);
-		
+				.thenReturn(disTypes);
+
 		ArrayList<PregnantTreatmentType> pregTTypes = PregnantTreatmentTypeHelper.setupPregnantTreatmentTypeList(3);
 		when(pregTraitTypeManagerMock.getPregnantTreatmentType())
-		.thenReturn(pregTTypes);
+				.thenReturn(pregTTypes);
 
-		
 		boolean isUpdated = true;
-		
+
 		when(admissionManagerMock.updateAdmission(update))
-		.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(AdmissionHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(AdmissionHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/admtype/data/AdmissionTypeDTOHelper.java
+++ b/src/test/java/org/isf/admtype/data/AdmissionTypeDTOHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admtype.data;
 
 import java.util.ArrayList;
@@ -16,25 +37,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class AdmissionTypeDTOHelper {
 
 	public static AdmissionTypeDTO setup(AdmissionTypeMapper admissionTypeMapper) throws OHException {
-		TestAdmissionType testAdmissionTypeHelper =  new TestAdmissionType();
+		TestAdmissionType testAdmissionTypeHelper = new TestAdmissionType();
 		return admissionTypeMapper.map2DTO(testAdmissionTypeHelper.setup(false));
 	}
-	
+
 	public static AdmissionType setup() throws OHException {
-		TestAdmissionType testAdmissionType =  new TestAdmissionType();
+		TestAdmissionType testAdmissionType = new TestAdmissionType();
 		return testAdmissionType.setup(false);
 	}
-	
+
 	public static ArrayList<AdmissionType> setupAdmissionTypeList(int size) {
 		return (ArrayList<AdmissionType>) IntStream.range(0, size)
-					.mapToObj(i -> {	try {
-											return AdmissionTypeDTOHelper.setup();
-										} catch (OHException e) {
-											e.printStackTrace();
-										}
-										return null;
-									}).collect(Collectors.toList());
-			
+				.mapToObj(i -> {
+					try {
+						return AdmissionTypeDTOHelper.setup();
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
+
 	}
 
 	public static String asJsonString(AdmissionTypeDTO admissionTypeDTO) {

--- a/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
+++ b/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.admtype.rest;
 
 import static org.mockito.Mockito.when;
@@ -32,53 +53,54 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class AdmissionTypeControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(AdmissionTypeControllerTest.class);
-	
+
 	@Mock
 	protected AdmissionTypeBrowserManager admtManagerMock;
-	
-	protected AdmissionTypeMapper admissionTypemapper = new  AdmissionTypeMapper();
+
+	protected AdmissionTypeMapper admissionTypemapper = new AdmissionTypeMapper();
 
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new AdmissionTypeController(admtManagerMock, admissionTypemapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(admissionTypemapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testNewAdmissionType_201() throws Exception {
 		String request = "/admissiontypes";
 		AdmissionTypeDTO body = AdmissionTypeDTOHelper.setup(admissionTypemapper);
-		
+
 		boolean isCreated = true;
 		when(admtManagerMock.newAdmissionType(admissionTypemapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
-		AdmissionType admissionType =  new AdmissionType("ZZ","aDescription");
+				.thenReturn(isCreated);
+
+		AdmissionType admissionType = new AdmissionType("ZZ", "aDescription");
 		ArrayList<AdmissionType> admtFounds = new ArrayList<AdmissionType>();
 		admtFounds.add(admissionType);
 		when(admtManagerMock.getAdmissionType())
-			.thenReturn(admtFounds);
-		
+				.thenReturn(admtFounds);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(AdmissionTypeDTOHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(AdmissionTypeDTOHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -86,47 +108,47 @@ public class AdmissionTypeControllerTest {
 	public void testUpdateAdmissionTypet_200() throws Exception {
 		String request = "/admissiontypes";
 		AdmissionTypeDTO body = AdmissionTypeDTOHelper.setup(admissionTypemapper);
-		
+
 		when(admtManagerMock.codeControl(body.getCode()))
-			.thenReturn(true);
-		
-		AdmissionType admissionType =  new AdmissionType("ZZ","aDescription");
+				.thenReturn(true);
+
+		AdmissionType admissionType = new AdmissionType("ZZ", "aDescription");
 		ArrayList<AdmissionType> admtFounds = new ArrayList<AdmissionType>();
 		admtFounds.add(admissionType);
 		boolean isUpdated = true;
 		when(admtManagerMock.updateAdmissionType(admissionTypemapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(AdmissionTypeDTOHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(AdmissionTypeDTOHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetAdmissionTypes_200() throws Exception {
 		String request = "/admissiontypes";
-		
-		AdmissionType admissionType =  new AdmissionType("ZZ","aDescription");
+
+		AdmissionType admissionType = new AdmissionType("ZZ", "aDescription");
 		ArrayList<AdmissionType> admtFounds = new ArrayList<AdmissionType>();
 		admtFounds.add(admissionType);
 		when(admtManagerMock.getAdmissionType())
-			.thenReturn(admtFounds);
-		
+				.thenReturn(admtFounds);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -136,26 +158,25 @@ public class AdmissionTypeControllerTest {
 		AdmissionTypeDTO body = AdmissionTypeDTOHelper.setup(admissionTypemapper);
 		String code = body.getCode();
 
-
 		when(admtManagerMock.codeControl(code))
-		.thenReturn(true);
-		
-		AdmissionType admissionType =  new AdmissionType("ZZ","aDescription");
+				.thenReturn(true);
+
+		AdmissionType admissionType = new AdmissionType("ZZ", "aDescription");
 		ArrayList<AdmissionType> admtFounds = new ArrayList<AdmissionType>();
 		admtFounds.add(admissionType);
 		when(admtManagerMock.getAdmissionType())
-			.thenReturn(admtFounds);
-		
+				.thenReturn(admtFounds);
+
 		when(admtManagerMock.deleteAdmissionType(admtFounds.get(0)))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/agetype/data/AgeTypeHelper.java
+++ b/src/test/java/org/isf/agetype/data/AgeTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.agetype.data;
 
 import java.util.ArrayList;
@@ -16,31 +37,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class AgeTypeHelper {
 
 	public static AgeType setup() throws OHException {
-		TestAgeType testAgeType =  new TestAgeType();
-		AgeType ageType = testAgeType.setup(false); 
+		TestAgeType testAgeType = new TestAgeType();
+		AgeType ageType = testAgeType.setup(false);
 		return ageType;
 	}
-	
+
 	public static AgeType setup(Integer id) throws OHException {
 		AgeType ageType = AgeTypeHelper.setup();
-		ageType.setCode(ageType.getCode()+id);
+		ageType.setCode(ageType.getCode() + id);
 		return ageType;
 	}
-
-
 
 	public static List<AgeType> genList(int n) {
 		return IntStream.range(0, n)
-				.mapToObj(i -> {	try {
-										return AgeTypeHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return AgeTypeHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
-	public static ArrayList<AgeType>  genArrayList(int n){
+	public static ArrayList<AgeType> genArrayList(int n) {
 		return new ArrayList<AgeType>(AgeTypeHelper.genList(n));
 	}
 
@@ -52,6 +72,5 @@ public class AgeTypeHelper {
 		}
 		return null;
 	}
-	
 
 }

--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.agetype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,47 +58,47 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class AgeTypeControllerTest {
-	
-private final Logger logger = LoggerFactory.getLogger(AdmissionTypeControllerTest.class);
-	
+
+	private final Logger logger = LoggerFactory.getLogger(AdmissionTypeControllerTest.class);
+
 	@Mock
 	private AgeTypeBrowserManager ageTypeManagerMock;
-	
-	private AgeTypeMapper ageTypeMapper = new  AgeTypeMapper();
+
+	private AgeTypeMapper ageTypeMapper = new AgeTypeMapper();
 
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new AgeTypeController(ageTypeManagerMock, ageTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(ageTypeMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetAllAgeTypes_200() throws JsonProcessingException, Exception {
 		String request = "/agetypes";
-		
+
 		ArrayList<AgeType> results = AgeTypeHelper.genArrayList(5);
 		List<AgeTypeDTO> parsedResults = ageTypeMapper.map2DTOList(results);
-		
+
 		when(ageTypeManagerMock.getAgeType())
-			.thenReturn(results);
-		
+				.thenReturn(results);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(parsedResults))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(parsedResults))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -85,47 +106,45 @@ private final Logger logger = LoggerFactory.getLogger(AdmissionTypeControllerTes
 	public void testUpdateAgeType_200() throws Exception {
 		String request = "/agetypes";
 		AgeTypeDTO body = ageTypeMapper.map2DTO(AgeTypeHelper.setup());
-		
+
 		ArrayList<AgeType> ageTypes = new ArrayList<AgeType>();
 		ageTypes.add(AgeTypeHelper.setup());
-				
-		
+
 		when(ageTypeManagerMock.updateAgeType(ageTypes))
-			.thenReturn(true);
-		
-		
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(AgeTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(AgeTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetAgeTypeCodeByAge_200() throws Exception {
-				
+
 		String request = "/agetypes/code?age={age}";
 		int age = 10;
 		String responseString = "resultString";
-	
+
 		when(ageTypeManagerMock.getTypeByAge(age))
-			.thenReturn(responseString);
-		
+				.thenReturn(responseString);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request,age))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(responseString)))
-			.andExpect(content().string(containsString("code")))
-			.andReturn();
-		
+				.perform(get(request, age))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(responseString)))
+				.andExpect(content().string(containsString("code")))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -133,19 +152,19 @@ private final Logger logger = LoggerFactory.getLogger(AdmissionTypeControllerTes
 	public void testGetAgeTypeByIndex_200() throws JsonProcessingException, Exception {
 		String request = "/agetypes/{index}";
 		int index = 10;
-		AgeType ageType = AgeTypeHelper.setup(index); 
-	
+		AgeType ageType = AgeTypeHelper.setup(index);
+
 		when(ageTypeManagerMock.getTypeByCode(index))
-			.thenReturn(ageType);
-		
+				.thenReturn(ageType);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request,index))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(ageType))))
-			.andReturn();
-		
+				.perform(get(request, index))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(ageType))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/disctype/data/DischargeTypeHelper.java
+++ b/src/test/java/org/isf/disctype/data/DischargeTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disctype.data;
 
 import java.util.ArrayList;
@@ -29,16 +50,17 @@ public class DischargeTypeHelper {
 		}
 		return null;
 	}
-	
+
 	public static ArrayList<DischargeType> setupDischargeTypeList(int size) {
 		return (ArrayList<DischargeType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return DischargeTypeHelper.setup(""+i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return DischargeTypeHelper.setup("" + i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
 }

--- a/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
+++ b/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disctype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,55 +58,55 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DischargeTypeControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(DischargeTypeControllerTest.class);
-	
+
 	@Mock
 	protected DischargeTypeBrowserManager discTypeManagerMock;
-	
+
 	protected DischargeTypeMapper dischargeTypeMapper = new DischargeTypeMapper();
 
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new DischargeTypeController(discTypeManagerMock, dischargeTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(dischargeTypeMapper, "modelMapper", modelMapper);
-    }
-
+	}
 
 	@Test
 	public void testNewDischargeType_201() throws Exception {
 		String request = "/dischargetypes";
 		String code = "ZZ";
-		DischargeTypeDTO  body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
-		
+		DischargeTypeDTO body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
+
 		boolean isCreated = true;
 		when(discTypeManagerMock.newDischargeType(dischargeTypeMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
-		DischargeType dischargeType =  new DischargeType("ZZ","aDescription");
+				.thenReturn(isCreated);
+
+		DischargeType dischargeType = new DischargeType("ZZ", "aDescription");
 		ArrayList<DischargeType> dischTypeFounds = new ArrayList<DischargeType>();
 		dischTypeFounds.add(dischargeType);
 		when(discTypeManagerMock.getDischargeType())
-			.thenReturn(dischTypeFounds);
-		
+				.thenReturn(dischTypeFounds);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DischargeTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DischargeTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -93,52 +114,51 @@ public class DischargeTypeControllerTest {
 	public void testUpdateDischargeTypet_200() throws Exception {
 		String request = "/dischargetypes";
 		String code = "ZZ";
-		DischargeTypeDTO  body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
+		DischargeTypeDTO body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
 
-		
 		when(discTypeManagerMock.codeControl(body.getCode()))
-			.thenReturn(true);
-		
-		DischargeType dischargeType =  new DischargeType("ZZ","aDescription");
+				.thenReturn(true);
+
+		DischargeType dischargeType = new DischargeType("ZZ", "aDescription");
 		ArrayList<DischargeType> admtFounds = new ArrayList<DischargeType>();
 		admtFounds.add(dischargeType);
 		boolean isUpdated = true;
 		when(discTypeManagerMock.updateDischargeType(dischargeTypeMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DischargeTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DischargeTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDischargeTypes_200() throws Exception {
 		String request = "/dischargetypes";
-		
-		DischargeType dischargeType =  new DischargeType("ZZ","aDescription");
+
+		DischargeType dischargeType = new DischargeType("ZZ", "aDescription");
 		ArrayList<DischargeType> dischTypes = new ArrayList<DischargeType>();
 		dischTypes.add(dischargeType);
 		when(discTypeManagerMock.getDischargeType())
-			.thenReturn(dischTypes);
-		
+				.thenReturn(dischTypes);
+
 		List<DischargeTypeDTO> expectedDischTypeDTOs = dischargeTypeMapper.map2DTOList(dischTypes);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedDischTypeDTOs))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedDischTypeDTOs))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -146,29 +166,29 @@ public class DischargeTypeControllerTest {
 	public void testDeleteDischargeType_200() throws Exception {
 		String request = "/dischargetypes/{code}";
 		String code = "ZZ";
-		DischargeTypeDTO  body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
-		
+		DischargeTypeDTO body = dischargeTypeMapper.map2DTO(DischargeTypeHelper.setup(code));
+
 		when(discTypeManagerMock.codeControl(body.getCode()))
-		.thenReturn(true);
-		
-		DischargeType dischargeType =  new DischargeType("ZZ","aDescription");
+				.thenReturn(true);
+
+		DischargeType dischargeType = new DischargeType("ZZ", "aDescription");
 		ArrayList<DischargeType> dischTypeFounds = new ArrayList<DischargeType>();
 		dischTypeFounds.add(dischargeType);
 		when(discTypeManagerMock.getDischargeType())
-			.thenReturn(dischTypeFounds);
-		
+				.thenReturn(dischTypeFounds);
+
 		when(discTypeManagerMock.deleteDischargeType(dischTypeFounds.get(0)))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/disease/data/DiseaseHelper.java
+++ b/src/test/java/org/isf/disease/data/DiseaseHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disease.data;
 
 import java.util.ArrayList;
@@ -17,29 +38,29 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class DiseaseHelper {
 
 	public static Disease setup() throws OHException {
-		TestDiseaseType testDiseaseType = new  TestDiseaseType();
-		DiseaseType diseaseType = testDiseaseType.setup(false); 
+		TestDiseaseType testDiseaseType = new TestDiseaseType();
+		DiseaseType diseaseType = testDiseaseType.setup(false);
 		TestDisease td = new TestDisease();
 		return td.setup(diseaseType, false);
 	}
-	
+
 	public static Disease setup(DiseaseType diseaseType) throws OHException {
 		TestDisease td = new TestDisease();
 		return td.setup(diseaseType, false);
 	}
-	
+
 	public static ArrayList<Disease> setupDiseaseList(int size) {
 		return (ArrayList<Disease>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return DiseaseHelper.setup();
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return DiseaseHelper.setup();
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
-	
 	public static String asJsonString(DiseaseDTO diseaseDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(diseaseDTO);

--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.disease.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,313 +58,313 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DiseaseControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(DiseaseControllerTest.class);
-	
+
 	@Mock
 	private DiseaseBrowserManager diseaseBrowserManagerMock;
-	
-	private DiseaseMapper diseaseMapper= new  DiseaseMapper();
+
+	private DiseaseMapper diseaseMapper = new DiseaseMapper();
 
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new DiseaseController(diseaseBrowserManagerMock, diseaseMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(diseaseMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetDiseasesOpd_200() throws Exception {
 		String request = "/diseases/opd";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseOpd())
-			.thenReturn(diseases);
-		
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDiseasesOpdByCode_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/opd/{typecode}";
-		
+
 		String typeCode = "1";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseOpd(typeCode))
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request, typeCode))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDiseasesIpdOut_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/ipd/out";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut())
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testGetDiseasesIpdOutByCode_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/ipd/out/{typecode}";
-		
+
 		String typeCode = "1";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut(typeCode))
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request, typeCode))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testGetDiseasesIpdIn_200() throws JsonProcessingException, Exception {
-		
+
 		String request = "/diseases/ipd/in";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseIpdIn())
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDiseasesIpdInByCode_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/ipd/out/{typecode}";
-		
+
 		String typeCode = "1";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut(typeCode))
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request, typeCode))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDiseases_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/both";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDisease())
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testGetDiseasesString_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/both/{typecode}";
-		
+
 		String typeCode = "1";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDisease(typeCode))
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request, typeCode))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
-		
-		
+
 	}
 
 	@Test
 	public void testGetAllDiseases_200() throws JsonProcessingException, Exception {
 		String request = "/diseases/all";
-		
-		ArrayList<Disease> diseases =  DiseaseHelper.setupDiseaseList(3);
+
+		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
 		when(diseaseBrowserManagerMock.getDiseaseAll())
-			.thenReturn(diseases);
-			
+				.thenReturn(diseases);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTOList(diseases)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
-	public void testGetDiseaseByCode() throws JsonProcessingException, Exception {	
+	public void testGetDiseaseByCode() throws JsonProcessingException, Exception {
 		String request = "/diseases/{code}";
-		
+
 		int code = 1;
-		
-		Disease disease =  DiseaseHelper.setup();
+
+		Disease disease = DiseaseHelper.setup();
 		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
-			.thenReturn(disease);
-			
+				.thenReturn(disease);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTO(disease)))))
-			.andReturn();
-		
+				.perform(get(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(diseaseMapper.map2DTO(disease)))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testNewDisease_200() throws JsonProcessingException, Exception {
 		String request = "/diseases";
-		
-		Disease disease =  DiseaseHelper.setup();
+
+		Disease disease = DiseaseHelper.setup();
 		DiseaseDTO body = diseaseMapper.map2DTO(disease);
-		
+
 		when(diseaseBrowserManagerMock.codeControl(disease.getCode()))
-		.thenReturn(false);
-	
+				.thenReturn(false);
+
 		when(diseaseBrowserManagerMock.descriptionControl(disease.getDescription(), disease.getType().getCode()))
-		.thenReturn(false);
-		
+				.thenReturn(false);
+
 		when(diseaseBrowserManagerMock.newDisease(disease))
-			.thenReturn(true);
-			
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
 				.perform(post(request)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(DiseaseHelper.asJsonString(body))
-						)
+				)
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isCreated())	
+				.andExpect(status().isCreated())
 				.andReturn();
-		
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testUpdateDisease_201() throws Exception {
 		String request = "/diseases";
-		
-		Disease disease =  DiseaseHelper.setup();
+
+		Disease disease = DiseaseHelper.setup();
 		DiseaseDTO body = diseaseMapper.map2DTO(disease);
-		
+
 		when(diseaseBrowserManagerMock.codeControl(disease.getCode()))
-		.thenReturn(true);
+				.thenReturn(true);
 
 		when(diseaseBrowserManagerMock.updateDisease(disease))
-			.thenReturn(true);
-			
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
 				.perform(put(request)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(DiseaseHelper.asJsonString(body))
-						)
+				)
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isOk())	
+				.andExpect(status().isOk())
 				.andReturn();
-		
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testDeleteDisease() throws Exception {
 		String request = "/diseases/{code}";
-		
-		int code  = 1;
-		
-		Disease disease =  DiseaseHelper.setup();
+
+		int code = 1;
+
+		Disease disease = DiseaseHelper.setup();
 		DiseaseDTO body = diseaseMapper.map2DTO(disease);
-		
+
 		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
-		.thenReturn(disease);
+				.thenReturn(disease);
 
 		when(diseaseBrowserManagerMock.deleteDisease(disease))
-			.thenReturn(true);
-			
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
 				.perform(delete(request, code)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(DiseaseHelper.asJsonString(body))
-						)
+				)
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isOk())	
+				.andExpect(status().isOk())
 				.andExpect(content().string(containsString("true")))
 
 				.andReturn();
-		
+
 		logger.debug("result: {}", result);
 	}
-	
+
 }

--- a/src/test/java/org/isf/distype/data/DiseaseTypeHelper.java
+++ b/src/test/java/org/isf/distype/data/DiseaseTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.distype.data;
 
 import java.util.ArrayList;
@@ -17,29 +38,29 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class DiseaseTypeHelper {
 
 	public static DiseaseType setup(int i) throws OHException {
-		TestDiseaseType testDiseaseType = new  TestDiseaseType();
+		TestDiseaseType testDiseaseType = new TestDiseaseType();
 		DiseaseType diseaseType = testDiseaseType.setup(false);
-		diseaseType.setCode(diseaseType.getCode()+i);
+		diseaseType.setCode(diseaseType.getCode() + i);
 		return diseaseType;
 	}
-	
+
 	public static Disease setup(DiseaseType diseaseType) throws OHException {
 		TestDisease td = new TestDisease();
 		return td.setup(diseaseType, false);
 	}
-	
+
 	public static ArrayList<DiseaseType> setupDiseaseTypeList(int size) {
 		return (ArrayList<DiseaseType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return DiseaseTypeHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return DiseaseTypeHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
-	
 	public static String asJsonString(DiseaseTypeDTO body) {
 		try {
 			return new ObjectMapper().writeValueAsString(body);

--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.distype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,77 +59,74 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DiseaseTypeControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(DiseaseTypeControllerTest.class);
-	
+
 	@Mock
 	protected DiseaseTypeBrowserManager diseaseTypeBrowserManager;
-	
+
 	protected DiseaseTypeMapper diseaseTypeMapper = new DiseaseTypeMapper();
 
 	private MockMvc mockMvc;
-	
-	
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new DiseaseTypeController(diseaseTypeBrowserManager, diseaseTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(diseaseTypeMapper, "modelMapper", modelMapper);
-    }
-	
+	}
 
 	@Test
 	public void testGetAllDiseaseTypes_200() throws JsonProcessingException, Exception {
 		String request = "/diseasetypes";
-		
+
 		ArrayList<DiseaseType> results = DiseaseTypeHelper.setupDiseaseTypeList(3);
-		
-		List<DiseaseTypeDTO> parsedResults=diseaseTypeMapper.map2DTOList(results);
-		
+
+		List<DiseaseTypeDTO> parsedResults = diseaseTypeMapper.map2DTOList(results);
+
 		when(diseaseTypeBrowserManager.getDiseaseType())
-			.thenReturn(results);
-				
+				.thenReturn(results);
+
 		MvcResult result = this.mockMvc
 				.perform(get(request))
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isOk())	
+				.andExpect(status().isOk())
 				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(parsedResults))))
 				.andReturn();
-			
-			logger.debug("result: {}", result);
+
+		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testNewDiseaseType_201() throws Exception {
 		String request = "/diseasetypes";
 		int code = 123;
-		DiseaseTypeDTO  body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(code));
-		
-		
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(code));
+
 		when(diseaseTypeBrowserManager.codeControl(body.getCode()))
 				.thenReturn(false);
-				
+
 		boolean isCreated = true;
 		when(diseaseTypeBrowserManager.newDiseaseType(diseaseTypeMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
-	
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DiseaseTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DiseaseTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -116,54 +134,52 @@ public class DiseaseTypeControllerTest {
 	public void testUpdateDiseaseType_200() throws Exception {
 		String request = "/diseasetypes";
 		int code = 456;
-		
-		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
-		DiseaseTypeDTO  body = diseaseTypeMapper.map2DTO(diseaseType);
 
-		
+		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(diseaseType);
+
 		when(diseaseTypeBrowserManager.codeControl(body.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		boolean isUpdated = true;
 		when(diseaseTypeBrowserManager.updateDiseaseType(diseaseTypeMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DiseaseTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DiseaseTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testDeleteDiseaseType_200() throws Exception {
 		String request = "/diseasetypes/{code}";
-		
-		DiseaseTypeDTO  body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(0));
+
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(0));
 		String code = body.getCode();
-		
+
 		when(diseaseTypeBrowserManager.getDiseaseType())
-		.thenReturn(DiseaseTypeHelper.setupDiseaseTypeList(1));
-		
-	
+				.thenReturn(DiseaseTypeHelper.setupDiseaseTypeList(1));
+
 		when(diseaseTypeBrowserManager.deleteDiseaseType(diseaseTypeMapper.map2Model(body)))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/dlvrrestype/data/DeliveryResultTypeHelper.java
+++ b/src/test/java/org/isf/dlvrrestype/data/DeliveryResultTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrrestype.data;
 
 import java.util.ArrayList;
@@ -13,25 +34,25 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DeliveryResultTypeHelper {
-	
+
 	public static DeliveryResultType setup(int i) throws OHException {
-		TestDeliveryResultType testDeliveryResultType = new  TestDeliveryResultType();
+		TestDeliveryResultType testDeliveryResultType = new TestDeliveryResultType();
 		DeliveryResultType deliveryResultType = testDeliveryResultType.setup(false);
-		deliveryResultType.setCode(deliveryResultType.getCode()+i);
+		deliveryResultType.setCode(deliveryResultType.getCode() + i);
 		return deliveryResultType;
 	}
 
 	public static ArrayList<DeliveryResultType> setupDeliveryResultTypeList(int size) {
 		return (ArrayList<DeliveryResultType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return DeliveryResultTypeHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return DeliveryResultTypeHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
-
 
 	public static String asJsonString(DeliveryResultTypeDTO body) {
 		try {

--- a/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrrestype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,59 +59,56 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DeliveryResultTypeControllerTest {
-	
-private final Logger logger = LoggerFactory.getLogger(DeliveryResultTypeControllerTest.class);
-	
+
+	private final Logger logger = LoggerFactory.getLogger(DeliveryResultTypeControllerTest.class);
+
 	@Mock
 	protected DeliveryResultTypeBrowserManager deliveryResultTypeBrowserManagerMock;
-	
+
 	protected DeliveryResultTypeMapper deliveryResultTypeMapper = new DeliveryResultTypeMapper();
 
 	private MockMvc mockMvc;
-	
-	
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new DeliveryResultTypeController(deliveryResultTypeBrowserManagerMock, deliveryResultTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(deliveryResultTypeMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testNewDeliveryResultType_201() throws Exception {
 		String request = "/deliveryresulttypes";
 		int code = 123;
 		DeliveryResultType deliveryResultType = DeliveryResultTypeHelper.setup(code);
-		DeliveryResultTypeDTO  body = deliveryResultTypeMapper.map2DTO(deliveryResultType);
-		
-		
+		DeliveryResultTypeDTO body = deliveryResultTypeMapper.map2DTO(deliveryResultType);
+
 		ArrayList<DeliveryResultType> results = new ArrayList<DeliveryResultType>();
 		results.add(deliveryResultType);
-		
+
 		when(deliveryResultTypeBrowserManagerMock.getDeliveryResultType())
 				.thenReturn(results);
-				
+
 		boolean isCreated = true;
 		when(deliveryResultTypeBrowserManagerMock.newDeliveryResultType(deliveryResultTypeMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
-	
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DeliveryResultTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DeliveryResultTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -98,78 +116,77 @@ private final Logger logger = LoggerFactory.getLogger(DeliveryResultTypeControll
 	public void testUpdateDeliveryResultTypet_200() throws Exception {
 		String request = "/deliveryresulttypes";
 		int code = 456;
-		
-		DeliveryResultType deliveryResultType = DeliveryResultTypeHelper.setup(code);
-		DeliveryResultTypeDTO  body = deliveryResultTypeMapper.map2DTO(deliveryResultType);
 
-		
+		DeliveryResultType deliveryResultType = DeliveryResultTypeHelper.setup(code);
+		DeliveryResultTypeDTO body = deliveryResultTypeMapper.map2DTO(deliveryResultType);
+
 		when(deliveryResultTypeBrowserManagerMock.codeControl(body.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		boolean isUpdated = true;
 		when(deliveryResultTypeBrowserManagerMock.updateDeliveryResultType(deliveryResultTypeMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DeliveryResultTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DeliveryResultTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDeliveryResultTypes_200() throws JsonProcessingException, Exception {
 		String request = "/deliveryresulttypes";
-		
+
 		ArrayList<DeliveryResultType> results = DeliveryResultTypeHelper.setupDeliveryResultTypeList(3);
-		
+
 		List<DeliveryResultTypeDTO> dlvrrestTypeDTOs = deliveryResultTypeMapper.map2DTOList(results);
-		
+
 		when(deliveryResultTypeBrowserManagerMock.getDeliveryResultType())
-			.thenReturn(results);
-				
+				.thenReturn(results);
+
 		MvcResult result = this.mockMvc
 				.perform(get(request))
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isOk())	
+				.andExpect(status().isOk())
 				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(dlvrrestTypeDTOs))))
 				.andReturn();
-			
-			logger.debug("result: {}", result);
+
+		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testDeleteDeliveryResultType() throws Exception {
 		String request = "/deliveryresulttypes/{code}";
-		
-		DeliveryResultTypeDTO  body = deliveryResultTypeMapper.map2DTO(DeliveryResultTypeHelper.setup(0));
+
+		DeliveryResultTypeDTO body = deliveryResultTypeMapper.map2DTO(DeliveryResultTypeHelper.setup(0));
 		String code = body.getCode();
-		
+
 		when(deliveryResultTypeBrowserManagerMock.codeControl(code))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		when(deliveryResultTypeBrowserManagerMock.getDeliveryResultType())
-		.thenReturn(DeliveryResultTypeHelper.setupDeliveryResultTypeList(1));
-			
+				.thenReturn(DeliveryResultTypeHelper.setupDeliveryResultTypeList(1));
+
 		when(deliveryResultTypeBrowserManagerMock.deleteDeliveryResultType(deliveryResultTypeMapper.map2Model(body)))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/dlvrtype/data/DeliveryTypeHelper.java
+++ b/src/test/java/org/isf/dlvrtype/data/DeliveryTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrtype.data;
 
 import java.util.ArrayList;
@@ -13,22 +34,24 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DeliveryTypeHelper {
+
 	public static DeliveryType setup(int i) throws OHException {
-		TestDeliveryType testDeliveryType = new  TestDeliveryType();
+		TestDeliveryType testDeliveryType = new TestDeliveryType();
 		DeliveryType deliveryType = testDeliveryType.setup(false);
-		deliveryType.setCode(deliveryType.getCode()+i);
+		deliveryType.setCode(deliveryType.getCode() + i);
 		return deliveryType;
 	}
 
 	public static ArrayList<DeliveryType> setupDeliveryTypeList(int size) {
 		return (ArrayList<DeliveryType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return DeliveryTypeHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return DeliveryTypeHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
 	public static String asJsonString(DeliveryTypeDTO body) {

--- a/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.dlvrtype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,58 +59,56 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DeliveryTypeControllerTest {
-	
+
 	private final Logger logger = LoggerFactory.getLogger(DeliveryTypeControllerTest.class);
-	
+
 	@Mock
 	protected DeliveryTypeBrowserManager deliveryTypeBrowserManagerMock;
-	
+
 	protected DeliveryTypeMapper deliveryTypeMapper = new DeliveryTypeMapper();
 
 	private MockMvc mockMvc;
-	
-	
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new DeliveryTypeController(deliveryTypeBrowserManagerMock, deliveryTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(deliveryTypeMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testNewDeliveryType_201() throws Exception {
 		String request = "/deliverytypes";
 		int code = 123;
 		DeliveryType deliveryType = DeliveryTypeHelper.setup(code);
-		DeliveryTypeDTO  body = deliveryTypeMapper.map2DTO(deliveryType);
-		
-		
+		DeliveryTypeDTO body = deliveryTypeMapper.map2DTO(deliveryType);
+
 		ArrayList<DeliveryType> results = new ArrayList<DeliveryType>();
 		results.add(deliveryType);
-		
+
 		when(deliveryTypeBrowserManagerMock.getDeliveryType())
 				.thenReturn(results);
-				
+
 		boolean isCreated = true;
 		when(deliveryTypeBrowserManagerMock.newDeliveryType(deliveryTypeMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DeliveryTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DeliveryTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -97,78 +116,77 @@ public class DeliveryTypeControllerTest {
 	public void testUpdateDeliveryTypet_200() throws Exception {
 		String request = "/deliverytypes/{code}";
 		int code = 456;
-		
-		DeliveryType deliveryType = DeliveryTypeHelper.setup(code);
-		DeliveryTypeDTO  body = deliveryTypeMapper.map2DTO(deliveryType);
 
-		
+		DeliveryType deliveryType = DeliveryTypeHelper.setup(code);
+		DeliveryTypeDTO body = deliveryTypeMapper.map2DTO(deliveryType);
+
 		when(deliveryTypeBrowserManagerMock.codeControl(body.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		boolean isUpdated = true;
 		when(deliveryTypeBrowserManagerMock.updateDeliveryType(deliveryTypeMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request,"ZZ"+code)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(DeliveryTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request, "ZZ" + code)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(DeliveryTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetDeliveryTypes_200() throws JsonProcessingException, Exception {
 		String request = "/deliverytypes";
-		
+
 		ArrayList<DeliveryType> results = DeliveryTypeHelper.setupDeliveryTypeList(3);
-		
+
 		List<DeliveryTypeDTO> dlvrrestTypeDTOs = deliveryTypeMapper.map2DTOList(results);
-		
+
 		when(deliveryTypeBrowserManagerMock.getDeliveryType())
-			.thenReturn(results);
-				
+				.thenReturn(results);
+
 		MvcResult result = this.mockMvc
 				.perform(get(request))
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
-				.andExpect(status().isOk())	
+				.andExpect(status().isOk())
 				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(dlvrrestTypeDTOs))))
 				.andReturn();
-			
-			logger.debug("result: {}", result);
+
+		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testDeleteDeliveryType_200() throws Exception {
-	String request = "/deliverytypes/{code}";
-		
-		DeliveryTypeDTO  body = deliveryTypeMapper.map2DTO(DeliveryTypeHelper.setup(0));
+		String request = "/deliverytypes/{code}";
+
+		DeliveryTypeDTO body = deliveryTypeMapper.map2DTO(DeliveryTypeHelper.setup(0));
 		String code = body.getCode();
-		
+
 		when(deliveryTypeBrowserManagerMock.codeControl(code))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		when(deliveryTypeBrowserManagerMock.getDeliveryType())
-		.thenReturn(DeliveryTypeHelper.setupDeliveryTypeList(1));
-			
+				.thenReturn(DeliveryTypeHelper.setupDeliveryTypeList(1));
+
 		when(deliveryTypeBrowserManagerMock.deleteDeliveryType(deliveryTypeMapper.map2Model(body)))
-		.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/operation/data/OperationHelper.java
+++ b/src/test/java/org/isf/operation/data/OperationHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.operation.data;
 
 import java.util.ArrayList;
@@ -11,13 +32,13 @@ import org.isf.opetype.test.TestOperationType;
 import org.isf.utils.exception.OHException;
 
 public class OperationHelper {
-	
+
 	public static Operation setup() throws OHException {
-		TestOperationType testOperationType = new  TestOperationType();
-		OperationType operationType = testOperationType.setup(false); 
+		TestOperationType testOperationType = new TestOperationType();
+		OperationType operationType = testOperationType.setup(false);
 		return OperationHelper.setup(operationType);
 	}
-	
+
 	public static Operation setup(OperationType operationType) throws OHException {
 		TestOperation testOperation = new TestOperation();
 		return testOperation.setup(operationType, false);
@@ -25,13 +46,14 @@ public class OperationHelper {
 
 	public static ArrayList<Operation> setupOperationList(int size) {
 		return (ArrayList<Operation>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return OperationHelper.setup();
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return OperationHelper.setup();
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
 }

--- a/src/test/java/org/isf/patient/data/PatientHelper.java
+++ b/src/test/java/org/isf/patient/data/PatientHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patient.data;
 
 import java.util.ArrayList;
@@ -17,14 +38,14 @@ import org.isf.utils.exception.OHException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class PatientHelper{
-	
-	public static PatientDTO setup(PatientMapper patientMapper) throws OHException{
+public class PatientHelper {
+
+	public static PatientDTO setup(PatientMapper patientMapper) throws OHException {
 		Patient patient = setup();
 		return patientMapper.map2DTO(patient);
 	}
-	
-	public static String asJsonString(PatientDTO patientDTO){
+
+	public static String asJsonString(PatientDTO patientDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(patientDTO);
 		} catch (JsonProcessingException e) {
@@ -33,21 +54,22 @@ public class PatientHelper{
 		return null;
 	}
 
-	public static Patient setup() throws OHException{
-		return  new TestPatient().setup(true);
+	public static Patient setup() throws OHException {
+		return new TestPatient().setup(true);
 	}
-	
+
 	public static ArrayList<Patient> setupPatientList(int size) {
-		return (ArrayList<Patient>) IntStream.range(1, size+1)
-				.mapToObj(i -> {	Patient ep = null;
-									try {
-										ep = PatientHelper.setup();
-										ep.setCode(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return ep;
-								}
+		return (ArrayList<Patient>) IntStream.range(1, size + 1)
+				.mapToObj(i -> {
+							Patient ep = null;
+							try {
+								ep = PatientHelper.setup();
+								ep.setCode(i);
+							} catch (OHException e) {
+								e.printStackTrace();
+							}
+							return ep;
+						}
 				).collect(Collectors.toList());
 	}
 
@@ -55,13 +77,13 @@ public class PatientHelper{
 		ArrayList<Patient> patientList = setupPatientList(size);
 		ArrayList<Admission> admissionList = AdmissionHelper.setupAdmissionList(size);
 		return (ArrayList<AdmittedPatient>) IntStream.range(0, size)
-				
-				.mapToObj(i ->new AdmittedPatient(patientList.get(i),admissionList.get(i))
-								
+
+				.mapToObj(i -> new AdmittedPatient(patientList.get(i), admissionList.get(i))
+
 				).collect(Collectors.toList());
 	}
-	
-	public static String asJsonString(List<?> list){
+
+	public static String asJsonString(List<?> list) {
 		try {
 			return new ObjectMapper().writeValueAsString(list);
 		} catch (JsonProcessingException e) {

--- a/src/test/java/org/isf/patient/rest/PatientControllerTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.patient.rest;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -15,9 +36,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,237 +68,244 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 
-
 /**
  * @author ecastaneda1
- *
  */
 
 public class PatientControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(PatientControllerTest.class);
 
 	@Mock
-    private PatientBrowserManager patientBrowserManagerMock;
-	
+	private PatientBrowserManager patientBrowserManagerMock;
+
 	private PatientMapper patientMapper = new PatientMapper();
 
-    private MockMvc mockMvc;
+	private MockMvc mockMvc;
 
-    @Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new PatientController(patientBrowserManagerMock, patientMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
 		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(patientMapper, "modelMapper", modelMapper);
-    }
-	
+	}
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#newPatient(org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_post_patients_is_call_without_contentType_header_then_HttpMediaTypeNotSupportedException() throws Exception {
 		String request = "/patients";
-		
+
 		MvcResult result = this.mockMvc
-			.perform(post(request).content(new byte[]{'a', 'b', 'c'}))
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isUnsupportedMediaType())
-			.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
-			.andReturn();
-		
+				.perform(post(request).content(new byte[] { 'a', 'b', 'c' }))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isUnsupportedMediaType())
+				.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
+				.andReturn();
+
 		Optional<HttpMediaTypeNotSupportedException> exception = Optional.ofNullable((HttpMediaTypeNotSupportedException) result.getResolvedException());
 		logger.debug("exception: {}", exception);
-		exception.ifPresent( (se) -> assertThat(se, notNullValue()));
-		exception.ifPresent( (se) -> assertThat(se, instanceOf(HttpMediaTypeNotSupportedException.class)));
+		exception.ifPresent((se) -> assertThat(se, notNullValue()));
+		exception.ifPresent((se) -> assertThat(se, instanceOf(HttpMediaTypeNotSupportedException.class)));
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#newPatient(org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_post_patients_is_call_with_empty_body_then_BadRequest_HttpMessageNotReadableException() throws Exception {
 		String request = "/patients";
 		String empty_body = "";
-				
+
 		MvcResult result = this.mockMvc
-			.perform(
-				post(request)
-				.content(empty_body.getBytes())
-				.contentType(MediaType.APPLICATION_JSON)
-			)
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest())
-			.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
-			.andReturn();
-		
+				.perform(
+						post(request)
+								.content(empty_body.getBytes())
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(anyOf(nullValue(), equalTo(""))))
+				.andReturn();
+
 		Optional<HttpMessageNotReadableException> exception = Optional.ofNullable((HttpMessageNotReadableException) result.getResolvedException());
 		logger.debug("exception: {}", exception);
-		exception.ifPresent( (se) -> assertThat(se, notNullValue()));
-		exception.ifPresent( (se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
+		exception.ifPresent((se) -> assertThat(se, notNullValue()));
+		exception.ifPresent((se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#newPatient(org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_post_patients_PatientBrowserManager_getPatient_returns_null_then_OHAPIException_BadRequest() throws Exception {
 		String request = "/patients";
-		PatientDTO newPatientDTO =  PatientHelper.setup(patientMapper);
-		
+		PatientDTO newPatientDTO = PatientHelper.setup(patientMapper);
+
 		when(patientBrowserManagerMock.getPatientByName(any(String.class))).thenReturn(null);  //FIXME: why we were searching by name?
-		
+
 		MvcResult result = this.mockMvc
-			.perform(
-				post(request)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(PatientHelper.asJsonString(newPatientDTO))
-			)
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
-			.andExpect(content().string(containsString("Patient is not created!")))
-			.andReturn();
-		
+				.perform(
+						post(request)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(PatientHelper.asJsonString(newPatientDTO))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest()) //TODO Create OHCreateAPIException
+				.andExpect(content().string(containsString("Patient is not created!")))
+				.andReturn();
+
 		//TODO Create OHCreateAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#newPatient(org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_post_patients_PatientBrowserManager_newPatient_returns_false_then_Created() throws Exception {
-		Integer code= 12345;
+		Integer code = 12345;
 		String request = "/patients";
-		PatientDTO newPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO newPatientDTO = PatientHelper.setup(patientMapper);
 		newPatientDTO.setCode(code);
-		
+
 		when(patientBrowserManagerMock.savePatient(any(Patient.class))).thenReturn(patientMapper.map2Model(newPatientDTO)); //TODO: verify if it's correct
-		
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(PatientHelper.asJsonString(newPatientDTO)))
-			.andDo(log())
-			.andExpect(status().isCreated())
-			.andExpect(content().string(containsString(code.toString())))
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(PatientHelper.asJsonString(newPatientDTO)))
+				.andDo(log())
+				.andExpect(status().isCreated())
+				.andExpect(content().string(containsString(code.toString())))
+				.andReturn();
+
 		//TODO Create OHCreateAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#newPatient(org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_post_patients_and_both_calls_to_PatientBrowserManager_success_then_Created() throws Exception {
-		Integer code= 12345;
+		Integer code = 12345;
 		String request = "/patients";
-		PatientDTO newPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO newPatientDTO = PatientHelper.setup(patientMapper);
 		newPatientDTO.setCode(code);
-		Patient	newPatient = PatientHelper.setup();
+		Patient newPatient = PatientHelper.setup();
 		newPatient.setCode(code);
-		
+
 		when(patientBrowserManagerMock.savePatient(any(Patient.class))).thenReturn(newPatient);
 		when(patientBrowserManagerMock.getPatientByName(any(String.class))).thenReturn(newPatient);
-		
+
 		this.mockMvc
-			.perform(
-					post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(PatientHelper.asJsonString(newPatientDTO)))
-			.andDo(log())
-			.andExpect(status().isCreated())
-			.andExpect(content().string(containsString(code.toString())));
-	}
-	
-	/**
-	 * Test method for {@link org.isf.patient.rest.PatientController#updatePatient(int, org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
-	 */
-	@Test
-	public void when_put_update_patient_with_valid_body_and_existent_code_then_BadRequest() throws Exception {
-		Integer code= 12345;
-		String request = "/patients/{code}";
-		PatientDTO newPatientDTO =  PatientHelper.setup(patientMapper);
-		newPatientDTO.setCode(code);
-		Patient	newPatient = PatientHelper.setup();
-		newPatient.setCode(code);
-	
-		when(patientBrowserManagerMock.savePatient(any(Patient.class))).thenReturn(newPatient);
-				
-		this.mockMvc
-			.perform(
-					put(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(PatientHelper.asJsonString(newPatientDTO)))
-			.andDo(log())
-			.andDo(print())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest()) 
-			.andExpect(content().string(containsString("Patient is not updated!")));
-			
+				.perform(
+						post(request)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(PatientHelper.asJsonString(newPatientDTO)))
+				.andDo(log())
+				.andExpect(status().isCreated())
+				.andExpect(content().string(containsString(code.toString())));
 	}
 
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#updatePatient(int, org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void when_put_update_patient_with_valid_body_and_existent_code_then_BadRequest() throws Exception {
+		Integer code = 12345;
+		String request = "/patients/{code}";
+		PatientDTO newPatientDTO = PatientHelper.setup(patientMapper);
+		newPatientDTO.setCode(code);
+		Patient newPatient = PatientHelper.setup();
+		newPatient.setCode(code);
+
+		when(patientBrowserManagerMock.savePatient(any(Patient.class))).thenReturn(newPatient);
+
+		this.mockMvc
+				.perform(
+						put(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(PatientHelper.asJsonString(newPatientDTO)))
+				.andDo(log())
+				.andDo(print())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Patient is not updated!")));
+
+	}
+
+	/**
+	 * Test method for {@link org.isf.patient.rest.PatientController#updatePatient(int, org.isf.patient.dto.PatientDTO)}.
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_put_update_patient_with_invalid_body_and_existent_code_then_HttpMessageNotReadableException_BadRequest() throws Exception {
-		Integer code= 12345;
+		Integer code = 12345;
 		String request = "/patients/{code}";
-					
+
 		MvcResult result = this.mockMvc
-			.perform(
-					put(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(new byte[3]))
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest())
-			.andReturn();
-		
+				.perform(
+						put(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(new byte[3]))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andReturn();
+
 		Optional<HttpMessageNotReadableException> exception = Optional.ofNullable((HttpMessageNotReadableException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", exception);
-		exception.ifPresent( (se) -> assertThat(se, notNullValue()));
-		exception.ifPresent( (se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
+		exception.ifPresent((se) -> assertThat(se, notNullValue()));
+		exception.ifPresent((se) -> assertThat(se, instanceOf(HttpMessageNotReadableException.class)));
 	}
-		
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#updatePatient(int, org.isf.patient.dto.PatientDTO)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_put_update_patient_with_valid_body_and_unexistent_code_then_OHAPIException_BadRequest() throws Exception {
-		Integer code= 12345;
+		Integer code = 12345;
 		String request = "/patients/{code}";
-		PatientDTO newPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO newPatientDTO = PatientHelper.setup(patientMapper);
 		newPatientDTO.setCode(code);
-		Patient	newPatient = PatientHelper.setup();
+		Patient newPatient = PatientHelper.setup();
 		newPatient.setCode(code);
-		
+
 		when(patientBrowserManagerMock.savePatient(any(Patient.class))).thenReturn(newPatient);
-		
+
 		MvcResult result = this.mockMvc
 				.perform(put(request, code).contentType(MediaType.APPLICATION_JSON)
 						.content(PatientHelper.asJsonString(newPatientDTO)))
@@ -289,257 +317,264 @@ public class PatientControllerTest {
 		//TODO Create OHUpdateAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
-	
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#getPatients(java.lang.Integer, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void whet_get_patients_non_parameters_then_return_list_of_PatientDTO_page_0_default_size_and_OK() throws Exception {
 		String request = "/patients";
-		
-		int expectedPageSize = Integer.parseInt(PatientController.DEFAULT_PAGE_SIZE);
-		
-		ArrayList<Patient> patientList = PatientHelper.setupPatientList(expectedPageSize);
-		
-        List<PatientDTO> expectedPatienDTOList = patientMapper.map2DTOList(patientList);
 
-	
-		when(patientBrowserManagerMock.getPatient(any(Integer.class),any(Integer.class)))
-			.thenReturn(patientList);
-				
+		int expectedPageSize = Integer.parseInt(PatientController.DEFAULT_PAGE_SIZE);
+
+		ArrayList<Patient> patientList = PatientHelper.setupPatientList(expectedPageSize);
+
+		List<PatientDTO> expectedPatienDTOList = patientMapper.map2DTOList(patientList);
+
+		when(patientBrowserManagerMock.getPatient(any(Integer.class), any(Integer.class)))
+				.thenReturn(patientList);
+
 		this.mockMvc
-			.perform(
-					get(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					)
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatienDTOList))))
-			.andReturn();
+				.perform(
+						get(request)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatienDTOList))))
+				.andReturn();
 	}
 
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#getPatient(java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_with_existent_code_then_response_PatientDTO_and_OK() throws Exception {
 		Integer code = 123;
 		String request = "/patients/{code}";
-		PatientDTO expectedPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO expectedPatientDTO = PatientHelper.setup(patientMapper);
 		expectedPatientDTO.setCode(code);
-		Patient	patient = PatientHelper.setup();
+		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
-				
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(patient);
-		
+
 		this.mockMvc
-			.perform(
-					get(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
-			.andReturn();
+				.perform(
+						get(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
+				.andReturn();
 	}
 
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#searchPatient(java.lang.String, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_search_with_existent_name_non_code_then_response_PatientDTO_and_OK() throws Exception {
 		Integer code = 456;
 		String name = "TestFirstName";
 		String request = "/patients/search";
-		PatientDTO expectedPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO expectedPatientDTO = PatientHelper.setup(patientMapper);
 		expectedPatientDTO.setCode(code);
-		Patient	patient = PatientHelper.setup();
+		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
-				
-		when(patientBrowserManagerMock.getPatientByName(eq(name))).thenReturn(patient); 
-		
+
+		when(patientBrowserManagerMock.getPatientByName(eq(name))).thenReturn(patient);
+
 		this.mockMvc
-			.perform(
-					get(request)
-					.param("name", name)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
-			.andReturn();
+				.perform(
+						get(request)
+								.param("name", name)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
+				.andReturn();
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#searchPatient(java.lang.String, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_search_without_name_and_existent_code_then_response_PatientDTO_and_OK() throws Exception {
 		Integer code = 678;
 		String request = "/patients/search";
-		PatientDTO expectedPatientDTO =  PatientHelper.setup(patientMapper);
+		PatientDTO expectedPatientDTO = PatientHelper.setup(patientMapper);
 		expectedPatientDTO.setCode(code);
-		Patient	patient = PatientHelper.setup();
+		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
-				
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(patient);
-		
+
 		this.mockMvc
-			.perform(
-					get(request)
-					.param("code", code.toString())
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
-			.andReturn();
+				.perform(
+						get(request)
+								.param("code", code.toString())
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(PatientHelper.asJsonString(expectedPatientDTO))))
+				.andReturn();
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#searchPatient(java.lang.String, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_search_without_name_and_unexistent_code_then_response_null_and_NO_Content() throws Exception {
 		Integer code = 1000;
 		String request = "/patients/search";
-		
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(null);
-		
+
 		this.mockMvc
-		.perform(
-				get(request)
-				.param("code", code.toString())
-				.contentType(MediaType.APPLICATION_JSON)
-				)		
-		.andDo(log())
-		.andExpect(status().isNoContent());
+				.perform(
+						get(request)
+								.param("code", code.toString())
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNoContent());
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#searchPatient(java.lang.String, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_search_without_name_and_witout_code_then_response_null_and_NO_Content() throws Exception {
 		String request = "/patients/search";
 
 		this.mockMvc
-			.perform(
-					get(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isNoContent());
+				.perform(
+						get(request)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNoContent());
 	}
-	
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#searchPatient(java.lang.String, java.lang.Integer)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_get_patients_search_with_unexistent_name_and_witout_code_then_response_null_and_NO_Content() throws Exception {
 		String name = "unexistent_name";
 		String request = "/patients/search";
-				
+
 		when(patientBrowserManagerMock.getPatientByName(eq(name))).thenReturn(null);
-		
+
 		this.mockMvc
-			.perform(
-					get(request)
-					.param("name", name)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isNoContent());
+				.perform(
+						get(request)
+								.param("name", name)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNoContent());
 	}
 
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#deletePatient(int)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_delete_patients_with_existent_code_then_response_true_and_OK() throws Exception {
 		Integer code = 123;
 		String request = "/patients/{code}";
-		Patient	patient = PatientHelper.setup();
+		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
-				
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(patient);
 
 		when(patientBrowserManagerMock.deletePatient(eq(patient))).thenReturn(true);
-		
+
 		this.mockMvc
-			.perform(
-					delete(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("true")));
+				.perform(
+						delete(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("true")));
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#deletePatient(int)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_delete_patients_with_unexistent_code_then_response_Not_Found() throws Exception {
 		Integer code = 111;
 		String request = "/patients/{code}";
-				
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(null);
-		
+
 		this.mockMvc
-			.perform(
-					delete(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().isNotFound());
+				.perform(
+						delete(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNotFound());
 	}
-	
+
 	/**
 	 * Test method for {@link org.isf.patient.rest.PatientController#deletePatient(int)}.
-	 * @throws Exception 
+	 *
+	 * @throws Exception
 	 */
 	@Test
 	public void when_delete_patients_with_existent_code_but_fail_deletion_then_OHAPIException_BadRequest() throws Exception {
 		Integer code = 123;
 		String request = "/patients/{code}";
-		Patient	patient = PatientHelper.setup();
+		Patient patient = PatientHelper.setup();
 		patient.setCode(code);
-				
+
 		when(patientBrowserManagerMock.getPatientById(eq(code))).thenReturn(patient);
 
 		when(patientBrowserManagerMock.deletePatient(eq(patient))).thenReturn(false);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(
-					delete(request, code)
-					.contentType(MediaType.APPLICATION_JSON)
-					)		
-			.andDo(log())
-			.andExpect(status().is4xxClientError())
-			.andExpect(status().isBadRequest()) //TODO Create OHDeleteAPIException
-			.andExpect(content().string(containsString("Patient is not deleted!")))
-			.andReturn();
-		
+				.perform(
+						delete(request, code)
+								.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest()) //TODO Create OHDeleteAPIException
+				.andExpect(content().string(containsString("Patient is not deleted!")))
+				.andReturn();
+
 		//TODO Create OHDeleteAPIException
 		Optional<OHAPIException> oHAPIException = Optional.ofNullable((OHAPIException) result.getResolvedException());
 		logger.debug("oHAPIException: {}", oHAPIException);
-		oHAPIException.ifPresent( (se) -> assertThat(se, notNullValue()));
-		oHAPIException.ifPresent( (se) -> assertThat(se, instanceOf(OHAPIException.class)));
+		oHAPIException.ifPresent((se) -> assertThat(se, notNullValue()));
+		oHAPIException.ifPresent((se) -> assertThat(se, instanceOf(OHAPIException.class)));
 	}
 
 }

--- a/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
+++ b/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.pregtreattype.data;
 
 import java.util.ArrayList;
@@ -9,7 +30,7 @@ import org.isf.pregtreattype.test.TestPregnantTreatmentType;
 import org.isf.utils.exception.OHException;
 
 public class PregnantTreatmentTypeHelper {
-	
+
 	public static PregnantTreatmentType setup() throws OHException {
 		TestPregnantTreatmentType testPregnantTreatmentType = new TestPregnantTreatmentType();
 		return testPregnantTreatmentType.setup(false);
@@ -17,13 +38,14 @@ public class PregnantTreatmentTypeHelper {
 
 	public static ArrayList<PregnantTreatmentType> setupPregnantTreatmentTypeList(int size) {
 		return (ArrayList<PregnantTreatmentType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return PregnantTreatmentTypeHelper.setup();
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return PregnantTreatmentTypeHelper.setup();
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
 
 }

--- a/src/test/java/org/isf/testing/rest/ControllerBaseTest.java
+++ b/src/test/java/org/isf/testing/rest/ControllerBaseTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.testing.rest;
 
 import org.isf.accounting.rest.BillControllerTest;

--- a/src/test/java/org/isf/vaccine/data/VaccineHelper.java
+++ b/src/test/java/org/isf/vaccine/data/VaccineHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vaccine.data;
 
 import java.util.ArrayList;
@@ -14,11 +35,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VaccineHelper {
-	
+
 	public static Vaccine setup(String code) throws OHException {
 		TestVaccine testVaccine = new TestVaccine();
 		TestVaccineType testVaccineType = new TestVaccineType();
-		Vaccine vaccine = testVaccine.setup(testVaccineType.setup(false),false);
+		Vaccine vaccine = testVaccine.setup(testVaccineType.setup(false), false);
 		vaccine.setCode(code);
 		return vaccine;
 	}
@@ -31,16 +52,17 @@ public class VaccineHelper {
 		}
 		return null;
 	}
-	
+
 	public static ArrayList<Vaccine> setupVaccineList(int size) {
 		return (ArrayList<Vaccine>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return VaccineHelper.setup(""+i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return VaccineHelper.setup("" + i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
-	
+
 }

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vaccine.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,93 +59,94 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VaccineControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(VaccineControllerTest.class);
-	
+
 	@Mock
 	protected VaccineBrowserManager vaccineBrowserManagerMock;
-	
+
 	protected VaccineMapper vaccineMapper = new VaccineMapper();
-	
+
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new VaccineController(vaccineBrowserManagerMock, vaccineMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(vaccineMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetVaccines_200() throws JsonProcessingException, Exception {
 		String request = "/vaccines";
-		
+
 		String code = "AA";
 		ArrayList<Vaccine> vaccinesList = VaccineHelper.setupVaccineList(4);
 
 		when(vaccineBrowserManagerMock.getVaccine())
-			.thenReturn(vaccinesList);
-		
+				.thenReturn(vaccinesList);
+
 		List<VaccineDTO> expectedVaccineDTOs = vaccineMapper.map2DTOList(vaccinesList);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVaccineDTOs))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVaccineDTOs))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testGetVaccinesByVaccineTypeCode_200() throws JsonProcessingException, Exception {
 		String request = "/vaccines/{vaccineTypeCode}";
-				
+
 		ArrayList<Vaccine> vaccinesList = VaccineHelper.setupVaccineList(4);
 		String vaccineTypeCode = vaccinesList.get(0).getVaccineType().getCode();
-		
+
 		when(vaccineBrowserManagerMock.getVaccine(vaccineTypeCode))
-			.thenReturn(vaccinesList);
-		
+				.thenReturn(vaccinesList);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, vaccineTypeCode))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(new ObjectMapper().writeValueAsString(vaccineMapper.map2DTOList(vaccinesList))))
-			.andReturn();
-		
-		logger.debug("result: {}", result);	
+				.perform(get(request, vaccineTypeCode))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(new ObjectMapper().writeValueAsString(vaccineMapper.map2DTOList(vaccinesList))))
+				.andReturn();
+
+		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testNewVaccine_201() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
-		VaccineDTO  body = vaccineMapper.map2DTO(VaccineHelper.setup(code));
-		
+		VaccineDTO body = vaccineMapper.map2DTO(VaccineHelper.setup(code));
+
 		boolean isCreated = true;
 		when(vaccineBrowserManagerMock.newVaccine(vaccineMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VaccineHelper.asJsonString(body))
-					)
-			.andDo(log())
-			//.andDo(print())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VaccineHelper.asJsonString(body))
+				)
+				.andDo(log())
+				//.andDo(print())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -132,22 +154,22 @@ public class VaccineControllerTest {
 	public void testUpdateVaccine_200() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
-		VaccineDTO  body = vaccineMapper.map2DTO(VaccineHelper.setup(code));
+		VaccineDTO body = vaccineMapper.map2DTO(VaccineHelper.setup(code));
 
 		boolean isUpdated = true;
 		when(vaccineBrowserManagerMock.updateVaccine(vaccineMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VaccineHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VaccineHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -155,47 +177,48 @@ public class VaccineControllerTest {
 	public void testDeleteVaccine_200() throws Exception {
 		String request = "/vaccines/{code}";
 		String basecode = "0";
-		
+
 		Vaccine vaccine = VaccineHelper.setup(basecode);
-		VaccineDTO  body = vaccineMapper.map2DTO(vaccine);
+		VaccineDTO body = vaccineMapper.map2DTO(vaccine);
 		String code = body.getCode();
-		
+
 		when(vaccineBrowserManagerMock.findVaccine(code))
-			.thenReturn(vaccine);
+				.thenReturn(vaccine);
 
 		when(vaccineBrowserManagerMock.deleteVaccine(vaccineMapper.map2Model(body)))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testCheckVaccineCode_200() throws JsonProcessingException, Exception {
 		String request = "/vaccines/check/{code}";
-		
+
 		String code = "AA";
 		Vaccine vaccine = VaccineHelper.setup(code);
 
 		when(vaccineBrowserManagerMock.codeControl(vaccine.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string("true"))
-			.andReturn();
-		
-		logger.debug("result: {}", result);	}
+				.perform(get(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string("true"))
+				.andReturn();
+
+		logger.debug("result: {}", result);
+	}
 
 }

--- a/src/test/java/org/isf/vactype/data/VaccineTypeHelper.java
+++ b/src/test/java/org/isf/vactype/data/VaccineTypeHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vactype.data;
 
 import java.util.ArrayList;
@@ -13,7 +34,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VaccineTypeHelper {
-	
+
 	public static VaccineType setup(String code) throws OHException {
 		TestVaccineType testVaccineType = new TestVaccineType();
 		VaccineType vaccineType = testVaccineType.setup(false);
@@ -29,16 +50,17 @@ public class VaccineTypeHelper {
 		}
 		return null;
 	}
-	
+
 	public static ArrayList<VaccineType> setupVaccineList(int size) {
 		return (ArrayList<VaccineType>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return VaccineTypeHelper.setup(""+i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return VaccineTypeHelper.setup("" + i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
-	
+
 }

--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.vactype.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,47 +59,48 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VaccineTypeControllerTest {
+
 	private final Logger logger = LoggerFactory.getLogger(VaccineTypeControllerTest.class);
-	
+
 	@Mock
 	protected VaccineTypeBrowserManager vaccineTypeBrowserManagerMock;
-	
+
 	protected VaccineTypeMapper vaccineTypeMapper = new VaccineTypeMapper();
-	
+
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new VaccineTypeController(vaccineTypeBrowserManagerMock, vaccineTypeMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(vaccineTypeMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetVaccineType_200() throws JsonProcessingException, Exception {
 		String request = "/vaccinetype";
-		
+
 		ArrayList<VaccineType> vaccinesTypeList = VaccineTypeHelper.setupVaccineList(4);
 
 		when(vaccineTypeBrowserManagerMock.getVaccineType())
-			.thenReturn(vaccinesTypeList);
-		
+				.thenReturn(vaccinesTypeList);
+
 		List<VaccineTypeDTO> expectedVaccineTypeDTOs = vaccineTypeMapper.map2DTOList(vaccinesTypeList);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVaccineTypeDTOs))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVaccineTypeDTOs))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -86,22 +108,22 @@ public class VaccineTypeControllerTest {
 	public void testNewVaccineType_200() throws Exception {
 		String request = "/vaccinetype";
 		String code = "ZZ";
-		VaccineTypeDTO  body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
-		
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
+
 		boolean isCreated = true;
 		when(vaccineTypeBrowserManagerMock.newVaccineType(vaccineTypeMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VaccineTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VaccineTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -109,22 +131,22 @@ public class VaccineTypeControllerTest {
 	public void testUpdateVaccineType_200() throws Exception {
 		String request = "/vaccinetype";
 		String code = "ZZ";
-		VaccineTypeDTO  body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
 
 		boolean isUpdated = true;
 		when(vaccineTypeBrowserManagerMock.updateVaccineType(vaccineTypeMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VaccineTypeHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VaccineTypeHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -132,48 +154,48 @@ public class VaccineTypeControllerTest {
 	public void testDeleteVaccineType_200() throws Exception {
 		String request = "/vaccinetype/{code}";
 		String basecode = "0";
-		
+
 		VaccineType vaccineType = VaccineTypeHelper.setup(basecode);
-		VaccineTypeDTO  body = vaccineTypeMapper.map2DTO(vaccineType);
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(vaccineType);
 		String code = body.getCode();
-		
+
 		when(vaccineTypeBrowserManagerMock.findVaccineType(code))
-			.thenReturn(vaccineType);
+				.thenReturn(vaccineType);
 
 		when(vaccineTypeBrowserManagerMock.deleteVaccineType(vaccineTypeMapper.map2Model(body)))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testCheckVaccineTypeCode_200() throws Exception {
-	String request = "/vaccinetype/check/{code}";
-		
+		String request = "/vaccinetype/check/{code}";
+
 		String code = "AA";
 		VaccineType vaccineType = VaccineTypeHelper.setup(code);
 
 		when(vaccineTypeBrowserManagerMock.codeControl(vaccineType.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string("true"))
-			.andReturn();
-		
-		logger.debug("result: {}", result);	
+				.perform(get(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string("true"))
+				.andReturn();
+
+		logger.debug("result: {}", result);
 	}
 
 }

--- a/src/test/java/org/isf/visits/data/VisitHelper.java
+++ b/src/test/java/org/isf/visits/data/VisitHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.visits.data;
 
 import java.util.ArrayList;
@@ -19,7 +40,7 @@ public class VisitHelper {
 
 	public static Visit setup(int id) throws OHException {
 		TestVisit testVisits = new TestVisit();
-		Visit visit = testVisits.setup(PatientHelper.setup(),false, WardHelper.setup());
+		Visit visit = testVisits.setup(PatientHelper.setup(), false, WardHelper.setup());
 		visit.setVisitID(id);
 		return visit;
 	}
@@ -32,7 +53,7 @@ public class VisitHelper {
 		}
 		return null;
 	}
-	
+
 	public static String asJsonString(List<VisitDTO> visitDTOList) {
 		try {
 			return new ObjectMapper().writeValueAsString(visitDTOList);
@@ -41,16 +62,17 @@ public class VisitHelper {
 		}
 		return null;
 	}
-	
+
 	public static ArrayList<Visit> setupVisitList(int size) {
 		return (ArrayList<Visit>) IntStream.range(0, size)
-				.mapToObj(i -> {	try {
-										return VisitHelper.setup(i);
-									} catch (OHException e) {
-										e.printStackTrace();
-									}
-									return null;
-								}).collect(Collectors.toList());
+				.mapToObj(i -> {
+					try {
+						return VisitHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
 	}
-	
+
 }

--- a/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
+++ b/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.visits.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,27 +58,28 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VisitsControllerTest {
-private final Logger logger = LoggerFactory.getLogger(VisitsControllerTest.class);
-	
+
+	private final Logger logger = LoggerFactory.getLogger(VisitsControllerTest.class);
+
 	@Mock
 	protected VisitManager visitManagerMock;
-	
+
 	protected VisitMapper visitMapper = new VisitMapper();
-	
+
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new VisitsController(visitManagerMock, visitMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(visitMapper, "modelMapper", modelMapper);
-    }
+	}
 
 	@Test
 	public void testGetVisit_200() throws JsonProcessingException, Exception {
@@ -67,18 +89,18 @@ private final Logger logger = LoggerFactory.getLogger(VisitsControllerTest.class
 		ArrayList<Visit> visitsList = VisitHelper.setupVisitList(4);
 
 		when(visitManagerMock.getVisits(patID))
-			.thenReturn(visitsList);
-		
+				.thenReturn(visitsList);
+
 		List<VisitDTO> expectedVisitsDTOs = visitMapper.map2DTOList(visitsList);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, patID))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVisitsDTOs))))
-			.andReturn();
-		
+				.perform(get(request, patID))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedVisitsDTOs))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -86,68 +108,68 @@ private final Logger logger = LoggerFactory.getLogger(VisitsControllerTest.class
 	public void testNewVisit_201() throws Exception {
 		String request = "/visit";
 		int id = 1;
-		VisitDTO  body = visitMapper.map2DTO(VisitHelper.setup(id));
+		VisitDTO body = visitMapper.map2DTO(VisitHelper.setup(id));
 
 		when(visitManagerMock.newVisit(visitMapper.map2Model(body)))
-			.thenReturn(visitMapper.map2Model(body));
-		
+				.thenReturn(visitMapper.map2Model(body));
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VisitHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())	
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VisitHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testNewVisits_201() throws Exception {
 		String request = "/visits";
-		
+
 		ArrayList<Visit> visitsList = VisitHelper.setupVisitList(4);
 
 		List<VisitDTO> body = visitMapper.map2DTOList(visitsList);
-	
+
 		Boolean isCreated = true;
 		when(visitManagerMock.newVisits(visitsList))
-			.thenReturn(isCreated);
-		
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(VisitHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())
-			.andExpect(content().string(containsString(isCreated.toString())))
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(VisitHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andExpect(content().string(containsString(isCreated.toString())))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testDeleteVisitsRelatedToPatient_200() throws Exception {
 		String request = "/visit/{patId}";
-	
+
 		int id = 1;
-		
+
 		Boolean isDeleted = true;
 		when(visitManagerMock.deleteAllVisits(id))
-			.thenReturn(isDeleted);
-		
+				.thenReturn(isDeleted);
+
 		MvcResult result = this.mockMvc
-			.perform(delete(request, id))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())	
-			.andExpect(content().string(containsString(isDeleted.toString())))
-			.andReturn();
-		
+				.perform(delete(request, id))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted.toString())))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 

--- a/src/test/java/org/isf/ward/data/WardHelper.java
+++ b/src/test/java/org/isf/ward/data/WardHelper.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.ward.data;
 
 import java.util.ArrayList;
@@ -13,13 +34,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class WardHelper {
-	
+
 	public static Ward setup() throws OHException {
 		TestWard testWard = new TestWard();
 		Ward ward = testWard.setup(false);
 		return ward;
 	}
-	
+
 	public static Ward setup(int id) throws OHException {
 		TestWard testWard = new TestWard();
 		Ward ward = testWard.setup(false);
@@ -29,16 +50,17 @@ public class WardHelper {
 
 	public static ArrayList<Ward> setupWardList(int size) {
 		return (ArrayList<Ward>) IntStream.range(0, size)
-					.mapToObj(i -> {	try {
-											return WardHelper.setup(i);
-										} catch (OHException e) {
-											e.printStackTrace();
-										}
-										return null;
-									}).collect(Collectors.toList());
-			
+				.mapToObj(i -> {
+					try {
+						return WardHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
+
 	}
-	
+
 	public static String asJsonString(WardDTO wardDTO) {
 		try {
 			return new ObjectMapper().writeValueAsString(wardDTO);

--- a/src/test/java/org/isf/ward/rest/WardControllerTest.java
+++ b/src/test/java/org/isf/ward/rest/WardControllerTest.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2020 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.isf.ward.rest;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,28 +59,29 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class WardControllerTest {
-private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
-	
+
+	private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
+
 	@Mock
 	protected WardBrowserManager wardBrowserManagerMock;
-	
+
 	protected WardMapper wardMapper = new WardMapper();
-	
+
 	private MockMvc mockMvc;
-		
+
 	@Before
-    public void setup() {
-    	MockitoAnnotations.initMocks(this);
-    	this.mockMvc = MockMvcBuilders
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new WardController(wardBrowserManagerMock, wardMapper))
-   				.setControllerAdvice(new OHResponseEntityExceptionHandler())
-   				.build();
-    	ModelMapper modelMapper = new ModelMapper();
+				.setControllerAdvice(new OHResponseEntityExceptionHandler())
+				.build();
+		ModelMapper modelMapper = new ModelMapper();
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		ReflectionTestUtils.setField(wardMapper, "modelMapper", modelMapper);
-    }
-	
+	}
+
 	@Test
 	public void testGetWards_200() throws JsonProcessingException, Exception {
 		String request = "/wards";
@@ -67,18 +89,18 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 		ArrayList<Ward> wardList = WardHelper.setupWardList(4);
 
 		when(wardBrowserManagerMock.getWards())
-			.thenReturn(wardList);
-		
+				.thenReturn(wardList);
+
 		List<WardDTO> expectedWardDTOs = wardMapper.map2DTOList(wardList);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedWardDTOs))))
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedWardDTOs))))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -89,19 +111,19 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 		ArrayList<Ward> wardList = WardHelper.setupWardList(4);
 
 		when(wardBrowserManagerMock.getWardsNoMaternity()) //TODO OP-6 BUG (CORE) on WardIoOperationRepository.java line 15 about method name
-			.thenReturn(wardList);
-		
+				.thenReturn(wardList);
+
 		List<WardDTO> expectedWardDTOs = wardMapper.map2DTOList(wardList);
-		
+
 		MvcResult result = this.mockMvc
-			.perform(get(request))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedWardDTOs))))
-			// TODO assert that all wards on list are WRD_ID_A <> M 
-			.andReturn();
-		
+				.perform(get(request))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(new ObjectMapper().writeValueAsString(expectedWardDTOs))))
+				// TODO assert that all wards on list are WRD_ID_A <> M
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -110,25 +132,25 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 		String request = "/wards/occupation/{code}";
 
 		Integer code = 4;
-		
+
 		Ward ward = WardHelper.setup(code);
 
 		Integer numberOfPatients = 6;
 
 		when(wardBrowserManagerMock.findWard(ward.getCode()))
-		.thenReturn(ward);
-		
+				.thenReturn(ward);
+
 		when(wardBrowserManagerMock.getCurrentOccupation(ward))
-			.thenReturn(numberOfPatients);
-		
+				.thenReturn(numberOfPatients);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, ward.getCode()))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(numberOfPatients.toString())))
-			.andReturn();
-		
+				.perform(get(request, ward.getCode()))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(numberOfPatients.toString())))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -136,22 +158,22 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 	public void testNewWard_200() throws Exception {
 		String request = "/wards";
 		int code = 1;
-		WardDTO  body = wardMapper.map2DTO(WardHelper.setup(code));
-		
+		WardDTO body = wardMapper.map2DTO(WardHelper.setup(code));
+
 		boolean isCreated = true;
 		when(wardBrowserManagerMock.newWard(wardMapper.map2Model(body)))
-			.thenReturn(isCreated);
-		
+				.thenReturn(isCreated);
+
 		MvcResult result = this.mockMvc
-			.perform(post(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(WardHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isCreated())
-			.andReturn();
-		
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(WardHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isCreated())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -159,22 +181,22 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 	public void testUpdateWard_200() throws Exception {
 		String request = "/wards";
 		int code = 1;
-		WardDTO  body = wardMapper.map2DTO(WardHelper.setup(code));
+		WardDTO body = wardMapper.map2DTO(WardHelper.setup(code));
 
 		boolean isUpdated = true;
 		when(wardBrowserManagerMock.updateWard(wardMapper.map2Model(body)))
-			.thenReturn(isUpdated);
-		
+				.thenReturn(isUpdated);
+
 		MvcResult result = this.mockMvc
-			.perform(put(request)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(WardHelper.asJsonString(body))
-					)
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andReturn();
-		
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(WardHelper.asJsonString(body))
+				)
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
@@ -182,89 +204,90 @@ private final Logger logger = LoggerFactory.getLogger(WardControllerTest.class);
 	public void testDeleteWard() throws Exception {
 		String request = "/wards/{code}";
 		int basecode = 1;
-		
+
 		Ward ward = WardHelper.setup(basecode);
-		WardDTO  body = wardMapper.map2DTO(ward);
+		WardDTO body = wardMapper.map2DTO(ward);
 		String code = body.getCode();
-		
+
 		when(wardBrowserManagerMock.findWard(code))
-			.thenReturn(ward);
+				.thenReturn(ward);
 
 		when(wardBrowserManagerMock.deleteWard(wardMapper.map2Model(body)))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-		
-		logger.debug("result: {}", result);	}
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
+		logger.debug("result: {}", result);
+	}
 
 	@Test
 	public void testCheckWardCode() throws Exception {
 		String request = "/wards/check/{code}";
-		
+
 		int basecode = 1;
-		
+
 		Ward ward = WardHelper.setup(basecode);
-		
+
 		String code = ward.getCode();
 
 		when(wardBrowserManagerMock.codeControl(ward.getCode()))
-			.thenReturn(true);
-		
+				.thenReturn(true);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, code))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string("true"))
-			.andReturn();
-		
+				.perform(get(request, code))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string("true"))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 
 	@Test
 	public void testCheckWardMaternityCode_true_200() throws Exception {
 		String request = "/wards/check/maternity/{createIfNotExist}";
-		
+
 		Boolean createIfNotExist = true;
-	
+
 		when(wardBrowserManagerMock.maternityControl(createIfNotExist))
-			.thenReturn(createIfNotExist);
-		
+				.thenReturn(createIfNotExist);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, createIfNotExist))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(createIfNotExist.toString()))
-			.andReturn();
-		
+				.perform(get(request, createIfNotExist))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(createIfNotExist.toString()))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
-	
+
 	@Test
 	public void testCheckWardMaternityCode_false_200() throws Exception {
 		String request = "/wards/check/maternity/{createIfNotExist}";
-		
+
 		Boolean createIfNotExist = false;
-	
+
 		when(wardBrowserManagerMock.maternityControl(createIfNotExist))
-			.thenReturn(createIfNotExist);
-		
+				.thenReturn(createIfNotExist);
+
 		MvcResult result = this.mockMvc
-			.perform(get(request, createIfNotExist))
-			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
-			.andExpect(status().isOk())
-			.andExpect(content().string(createIfNotExist.toString()))
-			.andReturn();
-		
+				.perform(get(request, createIfNotExist))
+				.andDo(log())
+				.andExpect(status().is2xxSuccessful())
+				.andExpect(status().isOk())
+				.andExpect(content().string(createIfNotExist.toString()))
+				.andReturn();
+
 		logger.debug("result: {}", result);
 	}
 


### PR DESCRIPTION
Per discussion in core's [PR 165](https://github.com/informatici/openhospital-core/pull/165) and opened up [OP-265](https://openhospital.atlassian.net/jira/software/c/projects/OP/issues/OP-256) to define an the license header comment.

The license plugin uses the same exclusion list as the one in the Core repository. 