### PR TITLE
Chore: use a parameterized log message

### DIFF
--- a/src/main/java/org/isf/accounting/rest/BillController.java
+++ b/src/main/java/org/isf/accounting/rest/BillController.java
@@ -105,8 +105,8 @@ public class BillController {
      */
 	@PostMapping(value = "/bills", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<FullBillDTO> newBill(@RequestBody FullBillDTO newBillDto) throws OHServiceException {
-        
-		log.info("Create Bill "  + newBillDto.toString()); 
+
+		log.info("Create Bill {}", newBillDto.toString());
       
         Bill bill = billMapper.map2Model(newBillDto.getBillDTO());
         
@@ -151,8 +151,8 @@ public class BillController {
      */
 	@PutMapping(value = "/bills/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<FullBillDTO> updateBill(@PathVariable Integer id, @RequestBody FullBillDTO odBillDto) throws OHServiceException {
-        
-		log.info("updated Bill "  + odBillDto.toString()); 
+
+		log.info("updated Bill {}", odBillDto.toString());
         Bill bill = billMapper.map2Model(odBillDto.getBillDTO());
         
         bill.setId(id);
@@ -218,12 +218,12 @@ public class BillController {
         List<BillDTO> billDTOS = new ArrayList<BillDTO>();
         
         if(code == null) {
-        	log.info("Get payments datefrom:"  +  datefrom + " dateTo:" + dateto);
+	        log.info("Get payments datefrom: {}  dateTo: {}", datefrom, dateto);
         	bills = billManager.getBills(datefrom, dateto);
         } else {
         	Patient pat = patientManager.getPatientById(code);
-             
-            log.info("Get Bills datefrom:"  +  datefrom + " dateTo:" + dateto +"patient: "+pat);
+
+	        log.info("Get Bills datefrom: {}  dateTo: {} patient: {}", datefrom, dateto, pat);
              
      	    bills = billManager.getBills(datefrom, dateto, pat);
         }
@@ -249,7 +249,7 @@ public class BillController {
 	public ResponseEntity<List<BillPaymentsDTO>> searchBillsPayments(
 			@RequestParam(value="datefrom") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") Date dateFrom,
 			@RequestParam(value="dateto")@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") Date dateTo, @RequestParam(value="patient_code", required=false, defaultValue="") Integer code) throws OHServiceException {
-        log.info("Get Payments datefrom:"  +  dateFrom + " dateTo:" + dateTo +"patient: "+code);
+		log.info("Get Payments datefrom: {}  dateTo: {} patient: {}", dateFrom, dateTo, code);
         
         ArrayList<BillPayments> payments = new ArrayList<BillPayments>();
         
@@ -259,9 +259,9 @@ public class BillController {
         datefrom.setTime(dateFrom);
         
         GregorianCalendar dateto = new GregorianCalendar();
-        dateto.setTime(dateTo); 
-        
-        log.info("Get getPayments datefrom:"  +  datefrom + " dateTo:" + dateto);
+        dateto.setTime(dateTo);
+
+		log.info("Get getPayments datefrom: {}  dateTo: {}", datefrom, dateto);
         
         if(code == null) {
         	payments = billManager.getPayments(datefrom, dateto);
@@ -287,7 +287,7 @@ public class BillController {
 	 */
 	@GetMapping(value = "/bills/payments/{bill_id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<BillPaymentsDTO>> getPaymentsByBillId(@PathVariable(value="bill_id") Integer id) throws OHServiceException {
-        log.info("Get getPayments for bill with id:"  + id);
+		log.info("Get getPayments for bill with id: {}", id);
            
 	    ArrayList<BillPayments> billPayments = billManager.getPayments(id);
 	    
@@ -308,7 +308,7 @@ public class BillController {
 	 */
 	@GetMapping(value = "/bills/items/{bill_id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<BillItemsDTO>> getItems(@PathVariable(value="bill_id")Integer id) throws OHServiceException {
-        log.info("Get Items for bill with id:"  + id);
+		log.info("Get Items for bill with id: {}", id);
            
 	    ArrayList<BillItems> items = billManager.getItems(id);
 	    
@@ -329,7 +329,7 @@ public class BillController {
 	 */
 	@GetMapping(value = "/bills/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<BillDTO> getBill(@PathVariable Integer id) throws OHServiceException {
-        log.info("Get bill with id:"  + id);
+		log.info("Get bill with id: {}", id);
            
 	    Bill bill = billManager.getBill(id);
 	    
@@ -350,7 +350,7 @@ public class BillController {
 	 */
 	@GetMapping(value = "/bills/pending/affiliate", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<BillDTO>> getPendingBillsAffiliate(@RequestParam(value="patient_code") Integer code) throws OHServiceException {
-        log.info("Get bill with id:"  + code);
+		log.info("Get bill with id: {}", code);
            
 	    List<Bill> bills = billManager.getPendingBillsAffiliate(code);
 	    
@@ -371,7 +371,7 @@ public class BillController {
 	 */
 	@GetMapping(value = "/bills/pending", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<BillDTO>> getPendingBills(@RequestParam(value="patient_code") Integer code) throws OHServiceException {
-        log.info("Get bill with id:"  + code);
+		log.info("Get bill with id: {}", code);
            
 	    List<Bill> bills = billManager.getPendingBills(code);
 	    
@@ -405,8 +405,8 @@ public class BillController {
         dateto.setTime(dateTo);
                
         BillItems billItem = billItemsMapper.map2Model(billItemDTO);
-        	
-        log.info("Get Bills datefrom:"  +  datefrom + " dateTo:" + dateto + " Bill ITEM ID: "+billItem.getId());
+
+		log.info("Get Bills datefrom: {}  dateTo: {}  Bill ITEM ID: {}", datefrom, dateto, billItem.getId());
              
         ArrayList<Bill> bills = billManager.getBills(datefrom, dateto, billItem);
         
@@ -443,7 +443,7 @@ public class BillController {
 	
 	@DeleteMapping(value = "/bills/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity deleteBill(@PathVariable Integer id) throws OHServiceException {
-        log.info("Delete bill id:"  +  id);
+		log.info("Delete bill id: {}", id);
         Bill bill = billManager.getBill(id);
         boolean isDeleted = false;
         if (bill != null) {

--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -132,12 +132,12 @@ public class AdmissionController {
 	 */
 	@GetMapping(value = "/admissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<AdmissionDTO> getAdmissions(@PathVariable int id) throws OHServiceException {
-		log.info("Get admission by id:" + id);
+		log.info("Get admission by id: {}", id);
 		Admission admission = admissionManager.getAdmission(id);
 		if (admission == null) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
 		}
-		System.out.println("admissiontype code" + admission.getAdmType().getCode());
+		log.info("admissiontype code: {}", admission.getAdmType().getCode());
 		return ResponseEntity.ok(admissionMapper.map2DTO(admission));
 	}
 
@@ -152,7 +152,7 @@ public class AdmissionController {
 	@GetMapping(value = "/admissions/current", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<AdmissionDTO> getCurrentAdmission(@RequestParam("patientcode") Integer patientCode)
 			throws OHServiceException {
-		log.info("Get admission by patient code:" + patientCode);
+		log.info("Get admission by patient code: {}", patientCode);
 		Patient patient = patientManager.getPatientById(patientCode);
 		if (patient == null)
 			throw new OHAPIException(new OHExceptionMessage(null, "Patient not found!", OHSeverityLevel.ERROR),
@@ -178,7 +178,7 @@ public class AdmissionController {
 			@RequestParam(name = "admissionrange", required = false) GregorianCalendar[] admissionRange,
 			@RequestParam(name = "dischargerange", required = false) GregorianCalendar[] dischargeRange)
 			throws OHServiceException {
-		log.info("Get admitted patients search terms:" + searchTerms);
+		log.info("Get admitted patients search terms: {}", searchTerms);
 		
 		List<AdmittedPatient> amittedPatients = admissionManager
 				.getAdmittedPatients(admissionRange, dischargeRange, searchTerms);
@@ -198,7 +198,7 @@ public class AdmissionController {
 	@GetMapping(value = "/admissions", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<AdmissionDTO>> getPatientAdmissions(@RequestParam("patientcode") Integer patientCode)
 			throws OHServiceException {
-		log.info("Get patient admissions by patient code:" + patientCode);
+		log.info("Get patient admissions by patient code: {}", patientCode);
 		Patient patient = patientManager.getPatientById(patientCode);
 		if (patient == null)
 			throw new OHAPIException(new OHExceptionMessage(null, "Patient not found!", OHSeverityLevel.ERROR),
@@ -220,7 +220,7 @@ public class AdmissionController {
 	@GetMapping(value = "/admissions/getNextProgressiveIdInYear", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Integer> getNextYProg(@RequestParam("wardcode") String wardCode)
 			throws OHServiceException {
-		log.info("get the next prog in the year for ward code:" + wardCode);
+		log.info("get the next prog in the year for ward code: {}", wardCode);
 		
 		if (wardCode.trim().isEmpty() || !wardManager.codeControl(wardCode)) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Ward not found for code:" + wardCode, OHSeverityLevel.ERROR));
@@ -237,7 +237,7 @@ public class AdmissionController {
 	 */
 	@GetMapping(value = "/admissions/getBedsOccupationInWard", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Integer> getUsedWardBed(@RequestParam("wardid") String wardCode) throws OHServiceException {
-		log.info("Counts the number of used bed for ward code:" + wardCode);
+		log.info("Counts the number of used bed for ward code: {}", wardCode);
 
 		if (wardCode.trim().isEmpty() || !wardManager.codeControl(wardCode)) {
 			throw new OHAPIException( new OHExceptionMessage(null, "Ward not found for code:" + wardCode, OHSeverityLevel.ERROR));
@@ -254,7 +254,7 @@ public class AdmissionController {
 	 */
 	@DeleteMapping(value = "/admissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteAdmissionType(@PathVariable int id) throws OHServiceException {
-		log.info("setting admission to deleted:" + id);
+		log.info("setting admission to deleted: {}", id);
 		boolean isDeleted = false;
 		Admission admission = admissionManager.getAdmission(id);
 		if (admission != null) {
@@ -421,7 +421,7 @@ public class AdmissionController {
 		String name = StringUtils.isEmpty(newAdmission.getPatient().getName())
 				? newAdmission.getPatient().getFirstName() + " " + newAdmission.getPatient().getSecondName()
 				: newAdmission.getPatient().getName();
-		log.info("Create admission for patient " + name);
+		log.info("Create admission for patient {}", name);
 		Integer aId = admissionManager.newAdmissionReturnKey(newAdmission);
 		if (aId != null && aId.intValue() > 0) {
 			return ResponseEntity.status(HttpStatus.CREATED).body(aId);
@@ -588,7 +588,7 @@ public class AdmissionController {
 		String name = StringUtils.isEmpty(updAdmission.getPatient().getName())
 				? updAdmission.getPatient().getFirstName() + " " + updAdmission.getPatient().getSecondName()
 				: updAdmission.getPatient().getName();
-		log.info("update admission for patient " + name);
+		log.info("update admission for patient {}", name);
 		boolean isUpdated = admissionManager.updateAdmission(updAdmission);
 		if (isUpdated) {
 			return ResponseEntity.ok(updAdmission.getId());

--- a/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
+++ b/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
@@ -72,7 +72,7 @@ public class AdmissionTypeController {
 	@PostMapping(value = "/admissiontypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newAdmissionType(@RequestBody AdmissionTypeDTO admissionTypeDTO) throws OHServiceException {
 		String code = admissionTypeDTO.getCode();
-		log.info("Create Admission Type " + code);
+		log.info("Create Admission Type {}", code);
 		boolean isCreated = admtManager.newAdmissionType(mapper.map2Model(admissionTypeDTO));
 		AdmissionType admtCreated = null;
 		List<AdmissionType> admtFounds = admtManager.getAdmissionType().stream().filter(ad -> ad.getCode().equals(code))
@@ -96,7 +96,7 @@ public class AdmissionTypeController {
 	@PutMapping(value = "/admissiontypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateAdmissionTypet(@RequestBody AdmissionTypeDTO admissionTypeDTO)
 			throws OHServiceException {
-		log.info("Update admissiontypes code:" + admissionTypeDTO.getCode());
+		log.info("Update admissiontypes code: {}", admissionTypeDTO.getCode());
 		AdmissionType admt = mapper.map2Model(admissionTypeDTO);
 		if (!admtManager.codeControl(admt.getCode()))
 			throw new OHAPIException(new OHExceptionMessage(null, "Admission Type not found!", OHSeverityLevel.ERROR));
@@ -133,7 +133,7 @@ public class AdmissionTypeController {
 	 */
 	@DeleteMapping(value = "/admissiontypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteAdmissionType(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete Admission Type code:" + code);
+		log.info("Delete Admission Type code: {}", code);
 		boolean isDeleted = false;
 		if (admtManager.codeControl(code)) {
 			List<AdmissionType> admts = admtManager.getAdmissionType();

--- a/src/main/java/org/isf/agetype/rest/AgeTypeController.java
+++ b/src/main/java/org/isf/agetype/rest/AgeTypeController.java
@@ -117,7 +117,7 @@ public class AgeTypeController {
 	 */
 	@GetMapping(value = "/agetypes/code", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Map<String, String>> getAgeTypeCodeByAge(@RequestParam("age") int age) throws OHServiceException {
-		log.info("Get age type by age: " + age);
+		log.info("Get age type by age: {}", age);
 		String result = ageTypeManager.getTypeByAge(age);
 		Map<String, String> responseBody = new HashMap<String, String>();
 		if(result != null){
@@ -137,7 +137,7 @@ public class AgeTypeController {
 	 */
 	@GetMapping(value = "/agetypes/{index}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<AgeType> getAgeTypeByIndex(@PathVariable int index) throws OHServiceException {
-		log.info("Get age type by index: " + index);
+		log.info("Get age type by index: {}", index);
 		AgeType result = ageTypeManager.getTypeByCode(index);
 		if(result != null){
 			return ResponseEntity.ok(result);

--- a/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
+++ b/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
@@ -72,7 +72,7 @@ public class DischargeTypeController {
 	@PostMapping(value = "/dischargetypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newDischargeType(@RequestBody DischargeTypeDTO dischTypeDTO) throws OHServiceException {
 		String code = dischTypeDTO.getCode();
-		log.info("Create discharge type " + code);
+		log.info("Create discharge type {}", code);
 		boolean isCreated = discTypeManager.newDischargeType(mapper.map2Model(dischTypeDTO));
 		DischargeType dischTypeCreated = null;
 		List<DischargeType> dischTypeFounds = discTypeManager.getDischargeType().stream().filter(ad -> ad.getCode().equals(code))
@@ -94,7 +94,7 @@ public class DischargeTypeController {
 	 */
 	@PutMapping(value = "/dischargetypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateDischargeTypet(@RequestBody DischargeTypeDTO dischTypeDTO) throws OHServiceException {
-		log.info("Update dischargetypes code:" + dischTypeDTO.getCode());
+		log.info("Update dischargetypes code: {}", dischTypeDTO.getCode());
 		DischargeType dischType = mapper.map2Model(dischTypeDTO);
 		if(!discTypeManager.codeControl(dischTypeDTO.getCode())) 
 			throw new OHAPIException(
@@ -131,7 +131,7 @@ public class DischargeTypeController {
 	 */
 	@DeleteMapping(value = "/dischargetypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteDischargeType(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete discharge type code:" + code);
+		log.info("Delete discharge type code: {}", code);
 		boolean isDeleted = false;
 		if (discTypeManager.codeControl(code)) {
 			List<DischargeType> dischTypes = discTypeManager.getDischargeType();

--- a/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
+++ b/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
@@ -73,7 +73,7 @@ public class DeliveryResultTypeController {
 	ResponseEntity<String> newDeliveryResultType(@RequestBody DeliveryResultTypeDTO dlvrrestTypeDTO)
 			throws OHServiceException {
 		String code = dlvrrestTypeDTO.getCode();
-		log.info("Create Delivery result type " + code);
+		log.info("Create Delivery result type {}", code);
 		boolean isCreated = dlvrrestManager
 				.newDeliveryResultType(mapper.map2Model(dlvrrestTypeDTO));
 		DeliveryResultType dlvrrestTypeCreated = null;
@@ -98,7 +98,7 @@ public class DeliveryResultTypeController {
 	@PutMapping(value = "/deliveryresulttypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateDeliveryResultTypet(@RequestBody DeliveryResultTypeDTO dlvrrestTypeDTO)
 			throws OHServiceException {
-		log.info("Update deliveryresulttypes code:" + dlvrrestTypeDTO.getCode());
+		log.info("Update deliveryresulttypes code: {}", dlvrrestTypeDTO.getCode());
 		DeliveryResultType dlvrrestType = mapper.map2Model(dlvrrestTypeDTO);
 		if (!dlvrrestManager.codeControl(dlvrrestType.getCode()))
 			throw new OHAPIException(
@@ -137,7 +137,7 @@ public class DeliveryResultTypeController {
 	@DeleteMapping(value = "/deliveryresulttypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteDeliveryResultType(@PathVariable("code") String code)
 			throws OHServiceException {
-		log.info("Delete Delivery result type code:" + code);
+		log.info("Delete Delivery result type code: {}", code);
 		boolean isDeleted = false;
 		if (dlvrrestManager.codeControl(code)) {
 			List<DeliveryResultType> dlvrrestTypes = dlvrrestManager.getDeliveryResultType();

--- a/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
+++ b/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
@@ -72,7 +72,7 @@ public class DeliveryTypeController {
 	@PostMapping(value = "/deliverytypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newDeliveryType(@RequestBody DeliveryTypeDTO dlvrTypeDTO) throws OHServiceException {
 		String code = dlvrTypeDTO.getCode();
-		log.info("Create Delivery type " + code);
+		log.info("Create Delivery type {}", code);
 		boolean isCreated = dlvrtypeManager.newDeliveryType(deliveryTypeMapper.map2Model(dlvrTypeDTO));
 		DeliveryType dlvrTypeCreated = null;
 		List<DeliveryType> dlvrTypeFounds = dlvrtypeManager.getDeliveryType().stream().filter(ad -> ad.getCode().equals(code))
@@ -94,7 +94,7 @@ public class DeliveryTypeController {
 	 */
 	@PutMapping(value = "/deliverytypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateDeliveryTypet(@RequestBody DeliveryTypeDTO dlvrTypeDTO) throws OHServiceException {
-		log.info("Update deliverytypes code:" + dlvrTypeDTO.getCode());
+		log.info("Update deliverytypes code: {}", dlvrTypeDTO.getCode());
 		DeliveryType dlvrType = deliveryTypeMapper.map2Model(dlvrTypeDTO);
 		if(!dlvrtypeManager.codeControl(dlvrType.getCode())) 
 			throw new OHAPIException(
@@ -131,7 +131,7 @@ public class DeliveryTypeController {
 	 */
 	@DeleteMapping(value = "/deliverytypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteDeliveryType(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete Delivery type code:" + code);
+		log.info("Delete Delivery type code: {}", code);
 		boolean isDeleted = false;
 		if (dlvrtypeManager.codeControl(code)) {
 			List<DeliveryType> dlvrTypes = dlvrtypeManager.getDeliveryType();

--- a/src/main/java/org/isf/exatype/rest/ExamTypeController.java
+++ b/src/main/java/org/isf/exatype/rest/ExamTypeController.java
@@ -108,7 +108,7 @@ public class ExamTypeController {
 
     @DeleteMapping(value = "/examtypes/{code:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity deleteExamType(@PathVariable String code) throws OHServiceException {
-        log.info("Delete exams code:" + code);
+	    log.info("Delete exams code: {}", code);
         Optional<ExamType> examType = examTypeBrowserManager.getExamType().stream().filter(e -> e.getCode().equals(code)).findFirst();
         if (!examType.isPresent()) {
             throw new OHAPIException(new OHExceptionMessage(null, "Exam type not Found!", OHSeverityLevel.WARNING));

--- a/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
+++ b/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
@@ -88,7 +88,7 @@ public class MalnutritionController {
 	 */
 	@GetMapping(value = "/malnutritions/{id_admission}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<MalnutritionDTO>> getMalnutrition(@PathVariable("id_admission") String admissionID) throws OHServiceException{
-		log.info("Looking for malnutrition controls. Admission ID is " + admissionID);
+		log.info("Looking for malnutrition controls. Admission ID is {}", admissionID);
 		List<Malnutrition> malnutritions = manager.getMalnutrition(admissionID);
 		if(malnutritions == null) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Error while retrieving malnutrition controls!", OHSeverityLevel.ERROR));
@@ -98,7 +98,7 @@ public class MalnutritionController {
 			log.info("No malnutrition control found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMalnutritions);
 		} else {
-			log.info("Found " + mappedMalnutritions.size() + " malnutrition controls");
+			log.info("Found {} malnutrition controls", mappedMalnutritions.size());
 			return ResponseEntity.ok(mappedMalnutritions);
 		}
 	}

--- a/src/main/java/org/isf/medical/rest/MedicalController.java
+++ b/src/main/java/org/isf/medical/rest/MedicalController.java
@@ -70,7 +70,7 @@ public class MedicalController {
 	 */
 	@GetMapping(value = "/medicals/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<MedicalDTO> getMedical(@PathVariable int code) throws OHServiceException {
-		log.info("Retrieving medical with code "+ code + " ...");
+		log.info("Retrieving medical with code {} ...", code);
 		Medical medical = medicalManager.getMedical(code);
 		if(medical == null) {
 			log.info("Medical not found");
@@ -108,7 +108,7 @@ public class MedicalController {
 			log.info("No medical found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMedicals);
 		} else {
-			log.info("Found " + mappedMedicals.size() + " medicals");
+			log.info("Found {} medicals", mappedMedicals.size());
 			return ResponseEntity.ok(mappedMedicals);
 		}
 	}
@@ -154,7 +154,7 @@ public class MedicalController {
 			log.info("No medical found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMedicals);
 		} else {
-			log.info("Found " + mappedMedicals.size() + " medicals");
+			log.info("Found {} medicals", mappedMedicals.size());
 			return ResponseEntity.ok(mappedMedicals);
 		}
 	}

--- a/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
+++ b/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
@@ -93,7 +93,7 @@ public class MedicalStockWardController {
 			log.info("No medical found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMedWards);
 		} else {
-			log.info("Found " + mappedMedWards.size() + " medicals");
+			log.info("Found {} medicals", mappedMedWards.size());
 			return ResponseEntity.ok(mappedMedWards);
 		}
 	}

--- a/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
+++ b/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
@@ -75,7 +75,7 @@ public class MedStockMovementTypeController {
 			log.info("No movement type found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMvments);
 		} else {
-			log.info("Found " + mappedMvments.size() + " movement types");
+			log.info("Found {} movement types", mappedMvments.size());
 			return ResponseEntity.ok(mappedMvments);
 		}
 	}

--- a/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
+++ b/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
@@ -73,7 +73,7 @@ public class MedicalTypeController {
 			log.info("No medical type found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMedicalTypes);
 		} else {
-			log.info("Found " + mappedMedicalTypes.size() + " medical types");
+			log.info("Found {} medical types", mappedMedicalTypes.size());
 			return ResponseEntity.ok(mappedMedicalTypes);
 		}
 	}

--- a/src/main/java/org/isf/menu/rest/UserController.java
+++ b/src/main/java/org/isf/menu/rest/UserController.java
@@ -92,7 +92,7 @@ public class UserController {
 			log.info("No user found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedUsers);
 		} else {
-			log.info("Found " + mappedUsers.size() + " users");
+			log.info("Found {} users", mappedUsers.size());
 			return ResponseEntity.ok(mappedUsers);
 		}
 	}
@@ -190,7 +190,7 @@ public class UserController {
 			log.info("No group found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedGroups);
 		} else {
-			log.info("Found " + mappedGroups.size() + " groups");
+	        log.info("Found {} groups", mappedGroups.size());
 			return ResponseEntity.ok(mappedGroups);
 		}
 	}

--- a/src/main/java/org/isf/opd/rest/OpdController.java
+++ b/src/main/java/org/isf/opd/rest/OpdController.java
@@ -79,7 +79,7 @@ public class OpdController {
 	@PostMapping(value = "/opds", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Boolean> newOpd(@RequestBody OpdDTO opdDTO) throws OHServiceException {
 		int code = opdDTO.getCode();
-		log.info("store Out patient " + code);
+		log.info("store Out patient {}", code);
 		Patient patient = patientBrowserManager.getPatientById(opdDTO.getPatientCode());
 		if (patient == null) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Patient not found!", OHSeverityLevel.ERROR));
@@ -103,7 +103,7 @@ public class OpdController {
 	@PutMapping(value = "/opds/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Integer> updateOpd(@PathVariable Integer code, @RequestBody OpdDTO opdDTO)
 			throws OHServiceException {
-		log.info("Update opds code:" + opdDTO.getCode());
+		log.info("Update opds code: {}", opdDTO.getCode());
 		if (opdManager.getOpdList(opdDTO.getPatientCode()).stream().noneMatch(r -> r.getCode() == code)) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Opd not found!", OHSeverityLevel.ERROR));
 		}
@@ -174,7 +174,7 @@ public class OpdController {
 	 */
 	@GetMapping(value = "/opds/patient/{pcode}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<OpdDTO>> getOpdByPatient(@PathVariable("pcode") int patientcode) throws OHServiceException {
-		log.info("Get opd associated to specified patient CODE:" + patientcode);
+		log.info("Get opd associated to specified patient CODE: {}", patientcode);
 		List<Opd> opds = opdManager.getOpdList(patientcode);
 		List<OpdDTO> opdDTOs = mapper.map2DTOList(opds);
 		if (opdDTOs.size() == 0) {
@@ -192,7 +192,7 @@ public class OpdController {
 	 */
 	@DeleteMapping(value = "/opds/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteOpd(@PathVariable int code) throws OHServiceException {
-		log.info("Delete Opd code:" + code);
+		log.info("Delete Opd code: {}", code);
 		Opd toDelete = new Opd();
 		toDelete.setCode(code);
 		boolean isDeleted = opdManager.deleteOpd(toDelete);
@@ -221,7 +221,7 @@ public class OpdController {
 	 */
 	@GetMapping(value = "/opds/last/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<OpdDTO> getLastOpd(@PathVariable int code) throws OHServiceException {
-		log.info("Get the last opp for patien code:" + code);
+		log.info("Get the last opp for patien code: {}", code);
 		Opd lastOpd = opdManager.getLastOpd(code);
 		return ResponseEntity.ok(mapper.map2DTO(lastOpd));
 	}
@@ -233,7 +233,7 @@ public class OpdController {
 	 */
 	@GetMapping(value = "/opds/check/progyear", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> isExistOpdNum(@RequestParam int opdNum, @RequestParam int year) throws OHServiceException {
-		log.info("check if progYear:" + opdNum + " already exist for year :" + year);
+		log.info("check if progYear: {}  already exist for year : {}", opdNum, year);
 		Boolean isExist = opdManager.isExistOpdNum(opdNum, year);
 		return ResponseEntity.ok(isExist);
 	}

--- a/src/main/java/org/isf/operation/rest/OperationController.java
+++ b/src/main/java/org/isf/operation/rest/OperationController.java
@@ -94,7 +94,7 @@ public class OperationController {
 	@PostMapping(value = "/operations", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newOperation(@RequestBody OperationDTO operationDTO) throws OHServiceException {
 		String code = operationDTO.getCode();
-		log.info("Create operation " + code);
+		log.info("Create operation {}", code);
 		if(operationManager.descriptionControl(operationDTO.getDescription(), operationDTO.getType().getCode())) {
 			throw new OHAPIException(new OHExceptionMessage(null, "another operation has already been created with provided description and types!", OHSeverityLevel.ERROR));
 		}
@@ -115,7 +115,7 @@ public class OperationController {
 	@PutMapping(value = "/operations/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateOperation(@PathVariable String code, @RequestBody OperationDTO operationDTO)
 			throws OHServiceException {
-		log.info("Update operations code:" + operationDTO.getCode());
+		log.info("Update operations code: {}", operationDTO.getCode());
 		Operation operation = mapper.map2Model(operationDTO);
 		if (!operationManager.codeControl(code))
 			throw new OHAPIException(new OHExceptionMessage(null, "operation not found!", OHSeverityLevel.ERROR));
@@ -183,7 +183,7 @@ public class OperationController {
 	 */
 	@DeleteMapping(value = "/operations/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteOperation(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete operation code:" + code);
+		log.info("Delete operation code: {}", code);
 		boolean isDeleted = false;
 		Operation operation = operationManager.getOperationByCode(code);
 		if (operation != null) {
@@ -204,7 +204,7 @@ public class OperationController {
 	@PostMapping(value = "/operations/rows", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Integer> newOperationRow(@RequestBody OperationRowDTO operationRowDTO) throws OHServiceException {
 		int code = operationRowDTO.getId();
-		log.info("Create operation " + code);
+		log.info("Create operation {}", code);
 		OperationRow opRow = opRowMapper.map2Model(operationRowDTO);
 		boolean isCreated = operationRowManager.newOperationRow(opRow);
 		List<OperationRow> opRowFounds = operationRowManager.getOperationRowByAdmission(opRow.getAdmission()).stream().filter(op -> op.getId() == code)
@@ -226,7 +226,7 @@ public class OperationController {
 	@PutMapping(value = "/operations/rows", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Integer> updateOperationRow(@RequestBody OperationRowDTO operationRowDTO)
 			throws OHServiceException {
-		log.info("Update operations row code:" + operationRowDTO.getId());
+		log.info("Update operations row code: {}", operationRowDTO.getId());
 		OperationRow opRow = opRowMapper.map2Model(operationRowDTO);
 		List<OperationRow> opRowFounds = operationRowManager.getOperationRowByAdmission(opRow.getAdmission()).stream().filter(op -> op.getId() == opRow.getId())
 				.collect(Collectors.toList());
@@ -281,7 +281,7 @@ public class OperationController {
 	 */
 	@DeleteMapping(value = "/operations/rows/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteOperationRow(@PathVariable int code) throws OHServiceException {
-		log.info("Delete operation row code:" + code);
+		log.info("Delete operation row code: {}", code);
 		OperationRow opRow = new OperationRow();
 		opRow.setId(code);
 		boolean isDeleted = operationRowManager.deleteOperationRow(opRow);

--- a/src/main/java/org/isf/opetype/rest/OperationTypeController.java
+++ b/src/main/java/org/isf/opetype/rest/OperationTypeController.java
@@ -72,7 +72,7 @@ public class OperationTypeController {
 	@PostMapping(value = "/operationtypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newOperationType(@RequestBody OperationTypeDTO operationTypeDTO) throws OHServiceException {
 		String code = operationTypeDTO.getCode();
-		log.info("Create operation Type " + code);
+		log.info("Create operation Type {}", code);
 		boolean isCreated = opeTypeManager.newOperationType(mapper.map2Model(operationTypeDTO));
 		OperationType opeTypeCreated = opeTypeManager.getOperationType().stream().filter(opetype -> opetype.getCode().equals(code))
 				.findFirst().orElse(null);
@@ -91,7 +91,7 @@ public class OperationTypeController {
 	@PutMapping(value = "/operationtypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateOperationTypet(@PathVariable String code, @RequestBody OperationTypeDTO operationTypeDTO)
 			throws OHServiceException {
-		log.info("Update operationtypes code:" + operationTypeDTO.getCode());
+		log.info("Update operationtypes code: {}", operationTypeDTO.getCode());
 		OperationType opeType = mapper.map2Model(operationTypeDTO);
 		if (!opeTypeManager.codeControl(code))
 			throw new OHAPIException(new OHExceptionMessage(null, "operation Type not found!", OHSeverityLevel.ERROR));
@@ -126,7 +126,7 @@ public class OperationTypeController {
 	 */
 	@DeleteMapping(value = "/operationtypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deleteOperationType(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete operation Type code:" + code);
+		log.info("Delete operation Type code: {}", code);
 		boolean isDeleted = false;
 		if (opeTypeManager.codeControl(code)) {
 			List<OperationType> opeTypes = opeTypeManager.getOperationType();

--- a/src/main/java/org/isf/patient/rest/PatientController.java
+++ b/src/main/java/org/isf/patient/rest/PatientController.java
@@ -76,7 +76,7 @@ public class PatientController {
 	@PostMapping(value = "/patients", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<Integer> newPatient(@RequestBody PatientDTO newPatient) throws OHServiceException {
         String name = StringUtils.isEmpty(newPatient.getName()) ? newPatient.getFirstName() + " " + newPatient.getSecondName() : newPatient.getName();
-        log.info("Create patient "  + name);
+		log.info("Create patient {}", name);
         Patient patient = patientManager.savePatient(patientMapper.map2Model(newPatient));
         if(patient == null){
             throw new OHAPIException(new OHExceptionMessage(null, "Patient is not created!", OHSeverityLevel.ERROR));
@@ -86,7 +86,7 @@ public class PatientController {
 
 	@PutMapping(value = "/patients/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<Integer> updatePatient(@PathVariable int code, @RequestBody PatientDTO updatePatient) throws OHServiceException {
-        log.info("Update patient code:"  +  code);
+		log.info("Update patient code: {}", code);
         Patient patient = patientMapper.map2Model(updatePatient);
         patient.setCode(code);
         patient = patientManager.savePatient(patient);
@@ -100,7 +100,7 @@ public class PatientController {
 	public ResponseEntity<List<PatientDTO>> getPatients(
 			@RequestParam(value="page", required=false, defaultValue="0") Integer page,
 			@RequestParam(value="size", required=false, defaultValue=DEFAULT_PAGE_SIZE) Integer size) throws OHServiceException {
-        log.info("Get patients page:"  +  page + " size:" + size);
+		log.info("Get patients page: {}  size: {}", page, size);
 	    ArrayList<Patient> patients = patientManager.getPatient(page, size);
         List<PatientDTO> patientDTOS = patientMapper.map2DTOList(patients);
         if(patientDTOS.size() == 0){
@@ -112,7 +112,7 @@ public class PatientController {
 
 	@GetMapping(value = "/patients/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PatientDTO> getPatient(@PathVariable Integer code) throws OHServiceException {
-        log.info("Get patient code:"  +  code);
+		log.info("Get patient code: {}", code);
 		Patient patient = patientManager.getPatientById(code);
 		if (patient == null) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
@@ -125,7 +125,7 @@ public class PatientController {
 	public ResponseEntity<PatientDTO> searchPatient(
 			@RequestParam(value="name", defaultValue="") String name,
 			@RequestParam(value="code", required=false) Integer code) throws OHServiceException {
-        log.info("Search patient name:" + name + " code:"  +  code);
+		log.info("Search patient name: {}  code: {}", name, code);
 		Patient patient = null;
 		if(code != null) {
             patient = patientManager.getPatientById(code);
@@ -140,7 +140,7 @@ public class PatientController {
 	
 	@GetMapping(value = "/patients/all", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PatientDTO> getPatientAll(@RequestParam Integer code) throws OHServiceException {
-        log.info("get patient for provided code even if logically deleted: " + code);
+		log.info("get patient for provided code even if logically deleted: {}", code);
         Patient patient = patientManager.getPatientAll(code);
         if (patient == null) {
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
@@ -157,7 +157,7 @@ public class PatientController {
 
 	@DeleteMapping(value = "/patients/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deletePatient(@PathVariable int code) throws OHServiceException {
-        log.info("Delete patient code:"  +  code);
+		log.info("Delete patient code: {}", code);
         Patient patient = patientManager.getPatientById(code);
         boolean isDeleted = false;
         if (patient != null) {
@@ -173,7 +173,7 @@ public class PatientController {
 	
 	@GetMapping(value = "/patients/merge", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> mergePatients(@RequestParam Integer mergedcode, @RequestParam Integer code2) throws OHServiceException {
-        log.info("merge patient for code " + code2 + " in patient for code " + mergedcode);
+		log.info("merge patient for code {} in patient for code {}", code2, mergedcode);
         Patient mergedPatient = patientManager.getPatientById(mergedcode);
         Patient patient2 = patientManager.getPatientById(code2);
         if(mergedPatient == null || patient2 == null) {

--- a/src/main/java/org/isf/patvac/rest/PatVacController.java
+++ b/src/main/java/org/isf/patvac/rest/PatVacController.java
@@ -74,7 +74,7 @@ public class PatVacController {
 	@PostMapping(value = "/patientvaccines", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Boolean> newPatientVaccine(@RequestBody PatientVaccineDTO patientVaccineDTO) throws OHServiceException {
 		int code = patientVaccineDTO.getCode();
-		log.info("Create patient vaccine " + code);
+		log.info("Create patient vaccine {}", code);
 		boolean isCreated = patVacManager.newPatientVaccine(mapper.map2Model(patientVaccineDTO));
 		if (!isCreated) {
 			throw new OHAPIException(new OHExceptionMessage(null, "patient vaccine is not created!", OHSeverityLevel.ERROR));
@@ -91,7 +91,7 @@ public class PatVacController {
 	@PutMapping(value = "/patientvaccines/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Integer> updatePatientVaccinet(@PathVariable Integer code, @RequestBody PatientVaccineDTO patientVaccineDTO)
 			throws OHServiceException {
-		log.info("Update patientvaccines code:" + patientVaccineDTO.getCode());
+		log.info("Update patientvaccines code: {}", patientVaccineDTO.getCode());
 		boolean isUpdated = patVacManager.updatePatientVaccine(mapper.map2Model(patientVaccineDTO));
 		if (!isUpdated)
 			throw new OHAPIException(new OHExceptionMessage(null, "patient vaccine is not updated!", OHSeverityLevel.ERROR));
@@ -161,7 +161,7 @@ public class PatVacController {
 	 */
 	@DeleteMapping(value = "/patientvaccines/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deletePatientVaccine(@PathVariable int code) throws OHServiceException {
-		log.info("Delete patient vaccine code:" + code);
+		log.info("Delete patient vaccine code: {}", code);
 		PatientVaccine patVac = new PatientVaccine();
 		patVac.setCode(code);
 		boolean isDeleted = patVacManager.deletePatientVaccine(patVac);

--- a/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
+++ b/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
@@ -72,7 +72,7 @@ public class PregnantTreatmentTypeController {
 	@PostMapping(value = "/pregnanttreatmenttypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newPregnantTreatmentType(@RequestBody PregnantTreatmentTypeDTO pregnantTreatmentTypeDTO) throws OHServiceException {
 		String code = pregnantTreatmentTypeDTO.getCode();
-		log.info("Create pregnant treatment Type " + code);
+		log.info("Create pregnant treatment Type {}", code);
 		boolean isCreated = pregTreatTypeManager.newPregnantTreatmentType(mapper.map2Model(pregnantTreatmentTypeDTO));
 		PregnantTreatmentType pregTreatTypeCreated = pregTreatTypeManager.getPregnantTreatmentType().stream().filter(pregtreattype -> pregtreattype.getCode().equals(code))
 				.findFirst().orElse(null);
@@ -91,7 +91,7 @@ public class PregnantTreatmentTypeController {
 	@PutMapping(value = "/pregnanttreatmenttypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updatePregnantTreatmentTypet(@PathVariable String code, @RequestBody PregnantTreatmentTypeDTO pregnantTreatmentTypeDTO)
 			throws OHServiceException {
-		log.info("Update pregnanttreatmenttypes code:" + pregnantTreatmentTypeDTO.getCode());
+		log.info("Update pregnanttreatmenttypes code: {}", pregnantTreatmentTypeDTO.getCode());
 		PregnantTreatmentType pregTreatType = mapper.map2Model(pregnantTreatmentTypeDTO);
 		if (!pregTreatTypeManager.codeControl(code))
 			throw new OHAPIException(new OHExceptionMessage(null, "pregnantTreatment Type not found!", OHSeverityLevel.ERROR));
@@ -126,7 +126,7 @@ public class PregnantTreatmentTypeController {
 	 */
 	@DeleteMapping(value = "/pregnanttreatmenttypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deletePregnantTreatmentType(@PathVariable("code") String code) throws OHServiceException {
-		log.info("Delete pregnantTreatment Type code:" + code);
+		log.info("Delete pregnantTreatment Type code: {}", code);
 		boolean isDeleted = false;
 		if (pregTreatTypeManager.codeControl(code)) {
 			List<PregnantTreatmentType> pregTreatTypes = pregTreatTypeManager.getPregnantTreatmentType();

--- a/src/main/java/org/isf/priceslist/rest/PriceListController.java
+++ b/src/main/java/org/isf/priceslist/rest/PriceListController.java
@@ -78,7 +78,7 @@ public class PriceListController {
 	 */
 	@PostMapping(value = "/pricelists", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newPriceList(@RequestBody PriceListDTO priceListDTO) throws OHServiceException {
-		log.info("Create price list " + priceListDTO.getCode());
+		log.info("Create price list {}", priceListDTO.getCode());
 		boolean isCreated = priceListManager.newList(mapper.map2Model(priceListDTO));
 		if (!isCreated) {
 			throw new OHAPIException(new OHExceptionMessage(null, "price list is not created!", OHSeverityLevel.ERROR));
@@ -95,7 +95,7 @@ public class PriceListController {
 	@PutMapping(value = "/pricelists/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updatePriceListt(@PathVariable Integer id, @RequestBody PriceListDTO priceListDTO)
 			throws OHServiceException {
-		log.info("Update pricelists code:" + priceListDTO.getCode());
+		log.info("Update pricelists code: {}", priceListDTO.getCode());
 		PriceList priceList = mapper.map2Model(priceListDTO);
 		boolean isUpdated = priceListManager.updateList(priceList);
 		if (!isUpdated)
@@ -145,7 +145,7 @@ public class PriceListController {
 	 */
 	@DeleteMapping(value = "/pricelists/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deletePriceList(@PathVariable int id) throws OHServiceException {
-		log.info("Delete price list id:" + id);
+		log.info("Delete price list id: {}", id);
 		boolean isDeleted = false;
 		List<PriceList> priceLists = priceListManager.getLists();
 		List<PriceList> priceListFounds = priceLists.stream().filter(pl -> pl.getId() == id).collect(Collectors.toList());
@@ -164,7 +164,7 @@ public class PriceListController {
 	 */
 	@GetMapping(value = "/pricelists/duplicate/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> copyList(@PathVariable Long id) throws OHServiceException {
-		log.info("duplicate list for price liste id : " + id);
+		log.info("duplicate list for price liste id : {}", id);
 		List<PriceList> priceLists = priceListManager.getLists();
 		List<PriceList> priceListFounds = priceLists.stream().filter(pl -> pl.getId() == id).collect(Collectors.toList());
 		boolean isCopied = false;
@@ -185,7 +185,7 @@ public class PriceListController {
 	 */
 	@GetMapping(value = "/pricelists/duplicate/byfactor/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> copyByFactorAndStep(@PathVariable Long id, @RequestParam double factor, @RequestParam double step) throws OHServiceException {
-		log.info("duplicate list for price liste id : " + id);
+		log.info("duplicate list for price liste id : {}", id);
 		List<PriceList> priceLists = priceListManager.getLists();
 		List<PriceList> priceListFounds = priceLists.stream().filter(pl -> pl.getId() == id).collect(Collectors.toList());
 		boolean isCopied = false;

--- a/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
+++ b/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
@@ -71,7 +71,7 @@ public class PricesOthersController {
 	 */
 	@PostMapping(value = "/pricesothers", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> newPricesOthers(@RequestBody PricesOthersDTO pricesOthersDTO) throws OHServiceException {
-		log.info("Create prices others " + pricesOthersDTO.getCode());
+		log.info("Create prices others {}", pricesOthersDTO.getCode());
 		boolean isCreated = pricesOthersManager.newOther(mapper.map2Model(pricesOthersDTO));
 		if (!isCreated) {
 			throw new OHAPIException(new OHExceptionMessage(null, "prices others is not created!", OHSeverityLevel.ERROR));
@@ -88,7 +88,7 @@ public class PricesOthersController {
 	@PutMapping(value = "/pricesothers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updatePricesOtherst(@PathVariable Integer id, @RequestBody PricesOthersDTO pricesOthersDTO)
 			throws OHServiceException {
-		log.info("Update pricesothers code:" + pricesOthersDTO.getCode());
+		log.info("Update pricesothers code: {}", pricesOthersDTO.getCode());
 		PricesOthers pricesOthers = mapper.map2Model(pricesOthersDTO);
 		List<PricesOthers> pricesOthersFounds = pricesOthersManager.getOthers().stream().filter(po -> po.getId() == pricesOthersDTO.getId()).collect(Collectors.toList());
 		if (pricesOthersFounds.size() == 0)
@@ -125,7 +125,7 @@ public class PricesOthersController {
 	 */
 	@DeleteMapping(value = "/pricesothers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> deletePricesOthers(@PathVariable int id) throws OHServiceException {
-		log.info("Delete prices others id:" + id);
+		log.info("Delete prices others id: {}", id);
 		boolean isDeleted = false;
 		List<PricesOthers> pricesOtherss = pricesOthersManager.getOthers();
 		List<PricesOthers> pricesOthersFounds = pricesOtherss.stream().filter(po -> po.getId() == id).collect(Collectors.toList());

--- a/src/main/java/org/isf/sms/rest/SmsController.java
+++ b/src/main/java/org/isf/sms/rest/SmsController.java
@@ -86,7 +86,7 @@ public class SmsController {
 			log.info("No sms found");
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedSmsList);
         }else{
-        	log.info("Found " + mappedSmsList.size() + " sms");
+			log.info("Found {} sms", mappedSmsList.size());
             return ResponseEntity.ok(mappedSmsList);
         }
 	}

--- a/src/main/java/org/isf/supplier/rest/SupplierController.java
+++ b/src/main/java/org/isf/supplier/rest/SupplierController.java
@@ -114,7 +114,7 @@ public class SupplierController {
 			log.info("No supplier found");
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedSuppliers);
 		} else {
-			log.info("Found " + mappedSuppliers.size() + " suppliers");
+			log.info("Found {} suppliers", mappedSuppliers.size());
 			return ResponseEntity.ok(mappedSuppliers);
 		}
 	}
@@ -127,7 +127,7 @@ public class SupplierController {
 	 */
 	@GetMapping(value = "/suppliers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<SupplierDTO> getSuppliers(@PathVariable Integer id) throws OHServiceException {
-		log.info("Loading supplier with ID " + id);
+		log.info("Loading supplier with ID {}", id);
 		Supplier supplier = manager.getByID(id);
 		if(supplier == null) {
 			log.info("Supplier not found");

--- a/src/main/java/org/isf/therapy/rest/TherapyController.java
+++ b/src/main/java/org/isf/therapy/rest/TherapyController.java
@@ -129,7 +129,7 @@ public class TherapyController {
 		if(mappedMeds.isEmpty()) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedMeds);
 		} else {
-			log.info("Found " + mappedMeds.size() + " medicals");
+			log.info("Found {} medicals", mappedMeds.size());
 			return ResponseEntity.ok(mappedMeds);
 		}
 	}
@@ -147,7 +147,7 @@ public class TherapyController {
 		if(mappedThRows.isEmpty()) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedThRows);
 		} else {
-			log.info("Found " + mappedThRows.size() + " therapies");
+			log.info("Found {} therapies", mappedThRows.size());
 			return ResponseEntity.ok(mappedThRows);
 		}
 	}
@@ -166,7 +166,7 @@ public class TherapyController {
 		if(mappedTherapies == null || mappedTherapies.isEmpty()) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(mappedTherapies);
 		} else {
-			log.info("Found " + mappedTherapies.size() + " therapies");
+			log.info("Found {} therapies", mappedTherapies.size());
 			return ResponseEntity.ok(mappedTherapies);
 		}
 	}

--- a/src/main/java/org/isf/vaccine/rest/VaccineController.java
+++ b/src/main/java/org/isf/vaccine/rest/VaccineController.java
@@ -92,7 +92,7 @@ public class VaccineController {
      */
     @GetMapping(value = "/vaccines/{vaccineTypeCode}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VaccineDTO>> getVaccinesByVaccineTypeCode(@PathVariable String vaccineTypeCode) throws OHServiceException {
-        log.info("Get vaccine by code:" + vaccineTypeCode);
+	    log.info("Get vaccine by code: {}", vaccineTypeCode);
         ArrayList<Vaccine> vaccines = vaccineManager.getVaccine(vaccineTypeCode);
         List<VaccineDTO> listVaccines = mapper.map2DTOList(vaccines);
         if (listVaccines.size() == 0) {
@@ -111,7 +111,7 @@ public class VaccineController {
      */
     @PostMapping(value = "/vaccines", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity newVaccine(@RequestBody VaccineDTO newVaccine) throws OHServiceException {
-        log.info("Create vaccine: " + newVaccine.toString());
+	    log.info("Create vaccine: {}", newVaccine.toString());
         boolean isCreated;
         try {
              isCreated = vaccineManager.newVaccine(mapper.map2Model(newVaccine));
@@ -133,7 +133,7 @@ public class VaccineController {
      */
     @PutMapping(value = "/vaccines", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity updateVaccine(@RequestBody VaccineDTO updateVaccine) throws OHServiceException {
-        log.info("Update vaccine: " + updateVaccine.toString());
+	    log.info("Update vaccine: {}", updateVaccine.toString());
         boolean isUpdated = vaccineManager.updateVaccine(mapper.map2Model(updateVaccine));
         if (!isUpdated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Vaccine is not updated!", OHSeverityLevel.ERROR));
@@ -174,7 +174,7 @@ public class VaccineController {
      */
     @GetMapping(value = "/vaccines/check/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Boolean> checkVaccineCode(@PathVariable String code) throws OHServiceException {
-        log.info("Check vaccine code: " + code);
+	    log.info("Check vaccine code: {}", code);
         boolean check = vaccineManager.codeControl(code);
         return ResponseEntity.ok(check);
     }

--- a/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
+++ b/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
@@ -92,7 +92,7 @@ public class VaccineTypeController {
      */
     @PostMapping(value = "/vaccinetype", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity newVaccineType(@RequestBody VaccineTypeDTO newVaccineType) throws OHServiceException {
-        log.info("Create vaccine type: " + newVaccineType.toString());
+	    log.info("Create vaccine type: {}", newVaccineType.toString());
         boolean isCreated;
         try {
             isCreated = vaccineTypeManager.newVaccineType(mapper.map2Model(newVaccineType));
@@ -114,7 +114,7 @@ public class VaccineTypeController {
      */
     @PutMapping(value = "/vaccinetype", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity updateVaccineType(@RequestBody VaccineTypeDTO updateVaccineType) throws OHServiceException {
-        log.info("Update vaccine type: " + updateVaccineType.toString());
+	    log.info("Update vaccine type: {}", updateVaccineType.toString());
         boolean isUpdated = vaccineTypeManager.updateVaccineType(mapper.map2Model(updateVaccineType));
         if (!isUpdated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Vaccine type is not updated!", OHSeverityLevel.ERROR));
@@ -155,7 +155,7 @@ public class VaccineTypeController {
      */
     @GetMapping(value = "/vaccinetype/check/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Boolean> checkVaccineTypeCode(@PathVariable String code) throws OHServiceException {
-        log.info("Check vaccine type code: " + code);
+	    log.info("Check vaccine type code: {}", code);
         boolean check = vaccineTypeManager.codeControl(code);
         return ResponseEntity.ok(check);
     }

--- a/src/main/java/org/isf/visits/rest/VisitsController.java
+++ b/src/main/java/org/isf/visits/rest/VisitsController.java
@@ -72,7 +72,7 @@ public class VisitsController {
      */
     @GetMapping(value = "/visit/{patID}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VisitDTO>> getVisit(@PathVariable int patID) throws OHServiceException {
-        log.info("Get visit related to patId: " + patID);
+	    log.info("Get visit related to patId: {}", patID);
         ArrayList<Visit> visit = visitManager.getVisits(patID);
         List<VisitDTO> listVisit = mapper.map2DTOList(visit);
         if (listVisit.size() == 0) {
@@ -91,7 +91,7 @@ public class VisitsController {
      */
     @PostMapping(value = "/visit", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Integer> newVisit(@RequestBody VisitDTO newVisit) throws OHServiceException {
-        log.info("Create Visit: " + newVisit);
+	    log.info("Create Visit: {}", newVisit);
         Visit visit = visitManager.newVisit(mapper.map2Model(newVisit));
         return ResponseEntity.status(HttpStatus.CREATED).body(visit.getVisitID()); //TODO: verify if it's correct
     }
@@ -123,7 +123,7 @@ public class VisitsController {
      */
     @DeleteMapping(value = "/visit/{patID}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity deleteVisitsRelatedToPatient(@PathVariable int patID) throws OHServiceException {
-        log.info("Delete Visit related to patId: " + patID);
+	    log.info("Delete Visit related to patId: {}", patID);
         Boolean areDeleted = visitManager.deleteAllVisits(patID);
         if (!areDeleted) {
             throw new OHAPIException(new OHExceptionMessage(null, "Visits are not deleted!", OHSeverityLevel.ERROR));

--- a/src/main/java/org/isf/ward/rest/WardController.java
+++ b/src/main/java/org/isf/ward/rest/WardController.java
@@ -128,7 +128,7 @@ public class WardController {
      */
     @PostMapping(value = "/wards", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity newWard(@RequestBody WardDTO newWard) throws OHServiceException {
-        log.info("Create Ward: " + newWard);
+	    log.info("Create Ward: {}", newWard);
         boolean isCreated = wardManager.newWard(mapper.map2Model(newWard));
         if (!isCreated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Ward is not created!", OHSeverityLevel.ERROR));
@@ -145,7 +145,7 @@ public class WardController {
      */
     @PutMapping(value = "/wards", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity updateWard(@RequestBody WardDTO updateWard) throws OHServiceException {
-        log.info("Update ward with code: " + updateWard.getCode());
+	    log.info("Update ward with code: {}", updateWard.getCode());
         boolean isUpdated = wardManager.updateWard(mapper.map2Model(updateWard));
         if (!isUpdated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Ward is not updated!", OHSeverityLevel.ERROR));
@@ -186,7 +186,7 @@ public class WardController {
      */
     @GetMapping(value = "/wards/check/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Boolean> checkWardCode(@PathVariable String code) throws OHServiceException {
-        log.info("Check ward code: " + code);
+	    log.info("Check ward code: {}", code);
         boolean check = wardManager.codeControl(code);
         return ResponseEntity.ok(check);
     }


### PR DESCRIPTION
Change non-constant string concatenations used as arguments to SLF4J methods. Non-constant concatenations will be evaluated at runtime even when the logging message is not logged; this can negatively impact performance.  A parameterized log message will not be evaluated when logging is disabled.

Also replaced a `System.out.println` call with a logging call instead.