### PR TITLE
Chore - remove unnecessary toString()

### DIFF
--- a/src/main/java/org/isf/accounting/rest/BillController.java
+++ b/src/main/java/org/isf/accounting/rest/BillController.java
@@ -106,7 +106,7 @@ public class BillController {
 	@PostMapping(value = "/bills", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<FullBillDTO> newBill(@RequestBody FullBillDTO newBillDto) throws OHServiceException {
 
-		log.info("Create Bill {}", newBillDto.toString());
+		log.info("Create Bill {}", newBillDto);
       
         Bill bill = billMapper.map2Model(newBillDto.getBillDTO());
         
@@ -152,7 +152,7 @@ public class BillController {
 	@PutMapping(value = "/bills/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<FullBillDTO> updateBill(@PathVariable Integer id, @RequestBody FullBillDTO odBillDto) throws OHServiceException {
 
-		log.info("updated Bill {}", odBillDto.toString());
+		log.info("updated Bill {}", odBillDto);
         Bill bill = billMapper.map2Model(odBillDto.getBillDTO());
         
         bill.setId(id);

--- a/src/main/java/org/isf/vaccine/rest/VaccineController.java
+++ b/src/main/java/org/isf/vaccine/rest/VaccineController.java
@@ -111,7 +111,7 @@ public class VaccineController {
      */
     @PostMapping(value = "/vaccines", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity newVaccine(@RequestBody VaccineDTO newVaccine) throws OHServiceException {
-	    log.info("Create vaccine: {}", newVaccine.toString());
+	    log.info("Create vaccine: {}", newVaccine);
         boolean isCreated;
         try {
              isCreated = vaccineManager.newVaccine(mapper.map2Model(newVaccine));
@@ -133,7 +133,7 @@ public class VaccineController {
      */
     @PutMapping(value = "/vaccines", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity updateVaccine(@RequestBody VaccineDTO updateVaccine) throws OHServiceException {
-	    log.info("Update vaccine: {}", updateVaccine.toString());
+	    log.info("Update vaccine: {}", updateVaccine);
         boolean isUpdated = vaccineManager.updateVaccine(mapper.map2Model(updateVaccine));
         if (!isUpdated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Vaccine is not updated!", OHSeverityLevel.ERROR));

--- a/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
+++ b/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
@@ -92,7 +92,7 @@ public class VaccineTypeController {
      */
     @PostMapping(value = "/vaccinetype", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity newVaccineType(@RequestBody VaccineTypeDTO newVaccineType) throws OHServiceException {
-	    log.info("Create vaccine type: {}", newVaccineType.toString());
+	    log.info("Create vaccine type: {}", newVaccineType);
         boolean isCreated;
         try {
             isCreated = vaccineTypeManager.newVaccineType(mapper.map2Model(newVaccineType));
@@ -114,7 +114,7 @@ public class VaccineTypeController {
      */
     @PutMapping(value = "/vaccinetype", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity updateVaccineType(@RequestBody VaccineTypeDTO updateVaccineType) throws OHServiceException {
-	    log.info("Update vaccine type: {}", updateVaccineType.toString());
+	    log.info("Update vaccine type: {}", updateVaccineType);
         boolean isUpdated = vaccineTypeManager.updateVaccineType(mapper.map2Model(updateVaccineType));
         if (!isUpdated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Vaccine type is not updated!", OHSeverityLevel.ERROR));

--- a/src/main/java/org/isf/visits/dto/VisitDTO.java
+++ b/src/main/java/org/isf/visits/dto/VisitDTO.java
@@ -93,7 +93,7 @@ public class VisitDTO {
     @Override
     public String toString() {
         return "VisitDTO{" +
-                ", patient=" + patient.toString() +
+                ", patient=" + patient +
                 ", date=" + date +
                 ", note='" + note + '\'' +
                 ", sms=" + sms +


### PR DESCRIPTION
The method itself takes care of the conversion to a String object.

BTW, in the last case:
```
    @Override
    public String toString() {
        return "VisitDTO{" +
                ", patient=" + patient +
                ", date=" + date +
                ", note='" + note + '\'' +
                ", sms=" + sms +
```
the `patient` `toString()` method is not overridden so it will just object an object id.