### PR TITLE
Chore - remove redundant cast

### DIFF
--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -263,7 +263,7 @@ public class AdmissionController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 	/**

--- a/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
+++ b/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
@@ -145,7 +145,7 @@ public class AdmissionTypeController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
+++ b/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
@@ -143,7 +143,7 @@ public class DischargeTypeController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
+++ b/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
@@ -149,7 +149,7 @@ public class DeliveryResultTypeController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
+++ b/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
@@ -143,7 +143,7 @@ public class DeliveryTypeController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/opd/rest/OpdController.java
+++ b/src/main/java/org/isf/opd/rest/OpdController.java
@@ -199,7 +199,7 @@ public class OpdController {
 		if (!isDeleted) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Opd is not deleted!", OHSeverityLevel.ERROR));
 		}
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 	
 	/**

--- a/src/main/java/org/isf/patvac/rest/PatVacController.java
+++ b/src/main/java/org/isf/patvac/rest/PatVacController.java
@@ -167,7 +167,7 @@ public class PatVacController {
 		if (!isDeleted) {
 			throw new OHAPIException(new OHExceptionMessage(null, "Opd is not deleted!", OHSeverityLevel.ERROR));
 		}
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
+++ b/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
@@ -138,7 +138,7 @@ public class PregnantTreatmentTypeController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
 
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }

--- a/src/main/java/org/isf/priceslist/rest/PriceListController.java
+++ b/src/main/java/org/isf/priceslist/rest/PriceListController.java
@@ -154,7 +154,7 @@ public class PriceListController {
 		else {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 	
 	/**

--- a/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
+++ b/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
@@ -134,7 +134,7 @@ public class PricesOthersController {
 		else {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		}
-		return (ResponseEntity<Boolean>) ResponseEntity.ok(isDeleted);
+		return ResponseEntity.ok(isDeleted);
 	}
 
 }


### PR DESCRIPTION
Casting `ResponseEntity.ok()` to `ResponseEntity<Boolean>` is redundant.