### PR TITLE
Chore - remove useless object creation/store

### DIFF
--- a/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
+++ b/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
@@ -112,8 +112,6 @@ public class AdmissionTypeControllerTest {
 				.thenReturn(true);
 
 		AdmissionType admissionType = new AdmissionType("ZZ", "aDescription");
-		ArrayList<AdmissionType> admtFounds = new ArrayList<AdmissionType>();
-		admtFounds.add(admissionType);
 		boolean isUpdated = true;
 		when(admtManagerMock.updateAdmissionType(admissionTypemapper.map2Model(body)))
 				.thenReturn(isUpdated);

--- a/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
+++ b/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
@@ -119,8 +119,6 @@ public class DischargeTypeControllerTest {
 				.thenReturn(true);
 
 		DischargeType dischargeType = new DischargeType("ZZ", "aDescription");
-		ArrayList<DischargeType> admtFounds = new ArrayList<DischargeType>();
-		admtFounds.add(dischargeType);
 		boolean isUpdated = true;
 		when(discTypeManagerMock.updateDischargeType(dischargeTypeMapper.map2Model(body)))
 				.thenReturn(isUpdated);


### PR DESCRIPTION
The array `admtFounds` is created and stored into but never used.  Remove the code and the tests pass.