### PR TITLE
Bump spring-boot-starter-parent from 1.4.0.RELEASE to 1.5.22.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.0.RELEASE</version>
+        <version>1.5.22.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.isf</groupId>


### PR DESCRIPTION
We aren't ready to move to spring boot 2.x train yet but at least we can move to the latest 1.x version in the meantime.