### PR TITLE
Chore Only need general Exception defined

### DIFF
--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -80,7 +80,7 @@ public class AgeTypeControllerTest {
 	}
 
 	@Test
-	public void testGetAllAgeTypes_200() throws JsonProcessingException, Exception {
+	public void testGetAllAgeTypes_200() throws Exception {
 		String request = "/agetypes";
 
 		ArrayList<AgeType> results = AgeTypeHelper.genArrayList(5);
@@ -147,7 +147,7 @@ public class AgeTypeControllerTest {
 	}
 
 	@Test
-	public void testGetAgeTypeByIndex_200() throws JsonProcessingException, Exception {
+	public void testGetAgeTypeByIndex_200() throws Exception {
 		String request = "/agetypes/{index}";
 		int index = 10;
 		AgeType ageType = AgeTypeHelper.setup(index);

--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -99,7 +99,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesOpdByCode_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesOpdByCode_200() throws Exception {
 		String request = "/diseases/opd/{typecode}";
 
 		String typeCode = "1";
@@ -120,7 +120,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesIpdOut_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesIpdOut_200() throws Exception {
 		String request = "/diseases/ipd/out";
 
 		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
@@ -139,7 +139,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesIpdOutByCode_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesIpdOutByCode_200() throws Exception {
 		String request = "/diseases/ipd/out/{typecode}";
 
 		String typeCode = "1";
@@ -160,7 +160,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesIpdIn_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesIpdIn_200() throws Exception {
 
 		String request = "/diseases/ipd/in";
 
@@ -180,7 +180,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesIpdInByCode_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesIpdInByCode_200() throws Exception {
 		String request = "/diseases/ipd/out/{typecode}";
 
 		String typeCode = "1";
@@ -201,7 +201,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseases_200() throws JsonProcessingException, Exception {
+	public void testGetDiseases_200() throws Exception {
 		String request = "/diseases/both";
 
 		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
@@ -220,7 +220,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseasesString_200() throws JsonProcessingException, Exception {
+	public void testGetDiseasesString_200() throws Exception {
 		String request = "/diseases/both/{typecode}";
 
 		String typeCode = "1";
@@ -242,7 +242,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetAllDiseases_200() throws JsonProcessingException, Exception {
+	public void testGetAllDiseases_200() throws Exception {
 		String request = "/diseases/all";
 
 		ArrayList<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
@@ -261,7 +261,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testGetDiseaseByCode() throws JsonProcessingException, Exception {
+	public void testGetDiseaseByCode() throws Exception {
 		String request = "/diseases/{code}";
 
 		int code = 1;
@@ -282,7 +282,7 @@ public class DiseaseControllerTest {
 	}
 
 	@Test
-	public void testNewDisease_200() throws JsonProcessingException, Exception {
+	public void testNewDisease_200() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();

--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -82,7 +82,7 @@ public class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	public void testGetAllDiseaseTypes_200() throws JsonProcessingException, Exception {
+	public void testGetAllDiseaseTypes_200() throws Exception {
 		String request = "/diseasetypes";
 
 		ArrayList<DiseaseType> results = DiseaseTypeHelper.setupDiseaseTypeList(3);

--- a/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
@@ -140,7 +140,7 @@ public class DeliveryResultTypeControllerTest {
 	}
 
 	@Test
-	public void testGetDeliveryResultTypes_200() throws JsonProcessingException, Exception {
+	public void testGetDeliveryResultTypes_200() throws Exception {
 		String request = "/deliveryresulttypes";
 
 		ArrayList<DeliveryResultType> results = DeliveryResultTypeHelper.setupDeliveryResultTypeList(3);

--- a/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
@@ -140,7 +140,7 @@ public class DeliveryTypeControllerTest {
 	}
 
 	@Test
-	public void testGetDeliveryTypes_200() throws JsonProcessingException, Exception {
+	public void testGetDeliveryTypes_200() throws Exception {
 		String request = "/deliverytypes";
 
 		ArrayList<DeliveryType> results = DeliveryTypeHelper.setupDeliveryTypeList(3);

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -82,7 +82,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	public void testGetVaccines_200() throws JsonProcessingException, Exception {
+	public void testGetVaccines_200() throws Exception {
 		String request = "/vaccines";
 
 		String code = "AA";
@@ -105,7 +105,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	public void testGetVaccinesByVaccineTypeCode_200() throws JsonProcessingException, Exception {
+	public void testGetVaccinesByVaccineTypeCode_200() throws Exception {
 		String request = "/vaccines/{vaccineTypeCode}";
 
 		ArrayList<Vaccine> vaccinesList = VaccineHelper.setupVaccineList(4);
@@ -200,7 +200,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	public void testCheckVaccineCode_200() throws JsonProcessingException, Exception {
+	public void testCheckVaccineCode_200() throws Exception {
 		String request = "/vaccines/check/{code}";
 
 		String code = "AA";

--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -82,7 +82,7 @@ public class VaccineTypeControllerTest {
 	}
 
 	@Test
-	public void testGetVaccineType_200() throws JsonProcessingException, Exception {
+	public void testGetVaccineType_200() throws Exception {
 		String request = "/vaccinetype";
 
 		ArrayList<VaccineType> vaccinesTypeList = VaccineTypeHelper.setupVaccineList(4);

--- a/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
+++ b/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
@@ -81,7 +81,7 @@ public class VisitsControllerTest {
 	}
 
 	@Test
-	public void testGetVisit_200() throws JsonProcessingException, Exception {
+	public void testGetVisit_200() throws Exception {
 		String request = "/visit/{patID}";
 
 		int patID = 0;

--- a/src/test/java/org/isf/ward/rest/WardControllerTest.java
+++ b/src/test/java/org/isf/ward/rest/WardControllerTest.java
@@ -82,7 +82,7 @@ public class WardControllerTest {
 	}
 
 	@Test
-	public void testGetWards_200() throws JsonProcessingException, Exception {
+	public void testGetWards_200() throws Exception {
 		String request = "/wards";
 
 		ArrayList<Ward> wardList = WardHelper.setupWardList(4);
@@ -104,7 +104,7 @@ public class WardControllerTest {
 	}
 
 	@Test
-	public void testGetWardsNoMaternity_200() throws JsonProcessingException, Exception {
+	public void testGetWardsNoMaternity_200() throws Exception {
 		String request = "/wardsNoMaternity";
 
 		ArrayList<Ward> wardList = WardHelper.setupWardList(4);
@@ -127,7 +127,7 @@ public class WardControllerTest {
 	}
 
 	@Test
-	public void testGetCurrentOccupation() throws JsonProcessingException, Exception {
+	public void testGetCurrentOccupation() throws Exception {
 		String request = "/wards/occupation/{code}";
 
 		Integer code = 4;


### PR DESCRIPTION
With method signature: `throws JsonProcessingException, Exception` there is no need for the `JsonProcessingException` given the more general `Exception`.