### PR TITLE
Chore Public modifiers not used in Interfaces

### DIFF
--- a/src/main/java/org/isf/shared/Mapper.java
+++ b/src/main/java/org/isf/shared/Mapper.java
@@ -24,8 +24,8 @@ package org.isf.shared;
 import java.util.List;
 
 public interface Mapper <FromType, ToType> {
-    public ToType map2DTO(FromType fromObj);
-    public FromType map2Model(ToType toObj);
-    public List<ToType> map2DTOList(List<FromType> list);
-    public List<FromType> map2ModelList(List<ToType> list);
+    ToType map2DTO(FromType fromObj);
+    FromType map2Model(ToType toObj);
+    List<ToType> map2DTOList(List<FromType> list);
+    List<FromType> map2ModelList(List<ToType> list);
 }


### PR DESCRIPTION
`Public` modifier are not used/needed in Interface definitions.