### PR TITLE
Chore Use bulk method instead of loop

### DIFF
--- a/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
+++ b/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
@@ -85,9 +85,7 @@ public class StockMovementController {
 	public ResponseEntity<Boolean> newMultipleChargingMovements(@RequestBody List<MovementDTO> movementDTOs, 
 			@RequestParam(name="ref", required=true) String referenceNumber) throws OHServiceException {
 		ArrayList<Movement> movements = new ArrayList<>();
-		movMapper.map2ModelList(movementDTOs).forEach(mov -> {
-			movements.add(mov);
-		});
+		movements.addAll(movMapper.map2ModelList(movementDTOs));
 		boolean done = movInsertingManager.newMultipleChargingMovements(movements, referenceNumber);
 		return ResponseEntity.status(HttpStatus.CREATED).body(done);
 	}
@@ -105,9 +103,7 @@ public class StockMovementController {
 	public ResponseEntity<Boolean> newMultipleDischargingMovements(@RequestBody List<MovementDTO> movementDTOs, 
 			@RequestParam(name="ref", required=true) String referenceNumber) throws OHServiceException {
 		ArrayList<Movement> movements = new ArrayList<>();
-		movMapper.map2ModelList(movementDTOs).forEach(mov -> {
-			movements.add(mov);
-		});
+		movements.addAll(movMapper.map2ModelList(movementDTOs));
 		boolean done = movInsertingManager.newMultipleDischargingMovements(movements, referenceNumber);
 		return ResponseEntity.status(HttpStatus.CREATED).body(done);
 	}

--- a/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
+++ b/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
@@ -229,9 +229,7 @@ public class MedicalStockWardController {
 	@PostMapping(value = "/medicalstockward/movements/all", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> newMovementWard(@Valid @RequestBody List<MovementWardDTO> newMovementDTOs) throws OHServiceException {
 		ArrayList<MovementWard> newMovements = new ArrayList<>();
-		movementWardMapper.map2ModelList(newMovementDTOs).forEach(mov -> {
-			newMovements.add(mov);
-		});
+		newMovements.addAll(movementWardMapper.map2ModelList(newMovementDTOs));
 		boolean arePersisted = movWardBrowserManager.newMovementWard(newMovements);
 		if (!arePersisted) {
             throw new OHAPIException(new OHExceptionMessage(null, "Movements ward are not created!", OHSeverityLevel.ERROR));

--- a/src/main/java/org/isf/menu/rest/UserController.java
+++ b/src/main/java/org/isf/menu/rest/UserController.java
@@ -244,7 +244,7 @@ public class UserController {
 			@Valid @RequestBody List<UserMenuItemDTO> menusDTO) throws OHServiceException {
 		UserGroup group = loadUserGroup(code);
         ArrayList<UserMenuItem> menus = new ArrayList<>();
-        userMenuItemMapper.map2ModelList(menusDTO).forEach(m -> menus.add(m));
+		menus.addAll(userMenuItemMapper.map2ModelList(menusDTO));
         boolean done = userManager.setGroupMenu(group, menus);
         if(done) {
         	return ResponseEntity.ok(done);


### PR DESCRIPTION
When calling a method in a loop (e.g. `collection.add(x)`) it can  be replaced with calling a bulk method (e.g. `collection.addAll(listOfX)`.
