### PR TITLE
Chore Fix reference comparison

### DIFF
--- a/src/main/java/org/isf/lab/rest/LaboratoryController.java
+++ b/src/main/java/org/isf/lab/rest/LaboratoryController.java
@@ -179,11 +179,11 @@ public class LaboratoryController {
         LaboratoryDTO laboratoryDTO = labWithRowsDTO.getLaboratoryDTO();
         List<String> labRow = labWithRowsDTO.getLaboratoryRowList();
 
-        if (code != laboratoryDTO.getCode()) {
+        if (!code.equals(laboratoryDTO.getCode())) {
             throw new OHAPIException(new OHExceptionMessage(null, "Laboratory code mismatch!", OHSeverityLevel.ERROR));
         }
 
-        if (laboratoryManager.getLaboratory().stream().noneMatch(l -> l.getCode() == code)) {
+        if (laboratoryManager.getLaboratory().stream().noneMatch(l -> l.getCode().equals(code))) {
             throw new OHAPIException(new OHExceptionMessage(null, "Laboratory Not Found!", OHSeverityLevel.ERROR));
         }
         Patient patient = patientBrowserManager.getPatientById(laboratoryDTO.getPatientCode());
@@ -215,7 +215,7 @@ public class LaboratoryController {
 
     @DeleteMapping(value = "/laboratories/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity deleteExam(@PathVariable Integer code) throws OHServiceException {
-        Laboratory labToDelete = laboratoryManager.getLaboratory().stream().filter(l -> l.getCode() == code).findFirst().orElse(null);
+        Laboratory labToDelete = laboratoryManager.getLaboratory().stream().filter(l -> l.getCode().equals(code)).findFirst().orElse(null);
         if (labToDelete == null) {
             throw new OHAPIException(new OHExceptionMessage(null, "Laboratory Not Found!", OHSeverityLevel.ERROR));
         }


### PR DESCRIPTION
Found using SpotBugs (the successor to FindBugs).

The description of the issue:
````
Suspicious reference comparison
This method compares two reference values using the == or != operator, where the correct way to compare instances of this 
type is generally with the equals() method. It is possible to create distinct instances that are equal but do not 
compare as == since they are different objects. Examples of classes which should generally not be compared by
reference are java.lang.Integer, java.lang.Float, etc.
````

So I changed the `==` or `!=` into the corresponding version using `equals()`.

FYI @emecas 