### PR TITLE
Chore Fix possible null dereference

### DIFF
--- a/src/main/java/org/isf/accounting/rest/BillController.java
+++ b/src/main/java/org/isf/accounting/rest/BillController.java
@@ -107,7 +107,10 @@ public class BillController {
 	@PostMapping(value = "/bills", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<FullBillDTO> newBill(@RequestBody FullBillDTO newBillDto) throws OHServiceException {
 
-		LOGGER.info("Create Bill {}", newBillDto.toString());
+		if (newBillDto == null) {
+			throw new OHAPIException(new OHExceptionMessage(null, "Bill is null!", OHSeverityLevel.ERROR));
+		}
+		LOGGER.info("Create Bill {}", newBillDto);
       
         Bill bill = billMapper.map2Model(newBillDto.getBill());
         
@@ -138,7 +141,7 @@ public class BillController {
         
         boolean isCreated = billManager.newBill(bill, billItems, billPayments);
         
-        if(!isCreated || newBillDto == null){
+        if (!isCreated) {
             throw new OHAPIException(new OHExceptionMessage(null, "Bill is not created!", OHSeverityLevel.ERROR));
         }
         return ResponseEntity.status(HttpStatus.CREATED).body(newBillDto);


### PR DESCRIPTION
Found using SpotBugs (successor to FindBugs).

The issue that was found:
````
Nullcheck of value previously dereferenced 
A value is checked here to see whether it is null, but this value can't be null because it was previously dereferenced 
and if it were null a null pointer exception would have occurred at the earlier dereference. Essentially, this code 
and the previous dereference disagree as to whether this value is allowed to be null. Either the check is 
redundant or the previous dereference is erroneous.
````

Changes:
The logging of `newBillDto` at the start of the method if it was null would be a NPE.   Added a null check before the logging, removed the `toString()` in the logger call as the log method handles that, and then removed the null check near the end of the method just leaving the `if (!isCreated)` as the `newBillDto` check was already done above.

FYI @emecas 