### PR TITLE
OP-376 Swagger 2 generated spec compliance fixes 

### DIFF
--- a/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
+++ b/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
@@ -93,7 +93,7 @@ public class DeliveryTypeController {
 	 * @return <code>true</code> if the {@link DeliveryType} has been updated, <code>false</code> otherwise.
 	 * @throws OHServiceException
 	 */
-	@PutMapping(value = "/deliverytypes/{code}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@PutMapping(value = "/deliverytypes", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<String> updateDeliveryTypet(@RequestBody DeliveryTypeDTO dlvrTypeDTO) throws OHServiceException {
 		LOGGER.info("Update deliverytypes code: {}", dlvrTypeDTO.getCode());
 		DeliveryType dlvrType = deliveryTypeMapper.map2Model(dlvrTypeDTO);

--- a/src/main/java/org/isf/exam/rest/ExamController.java
+++ b/src/main/java/org/isf/exam/rest/ExamController.java
@@ -113,7 +113,7 @@ public class ExamController {
     }
 
 
-    @GetMapping(value = "/exams/{description:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/exams/description/{description:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ExamDTO>> getExams(@PathVariable String description) throws OHServiceException {
         List<ExamDTO> exams = examMapper.map2DTOList(examManager.getExams(description));
 

--- a/src/main/java/org/isf/security/LoginApi.java
+++ b/src/main/java/org/isf/security/LoginApi.java
@@ -43,7 +43,7 @@ public class LoginApi {
      * Implemented by Spring Security
      */
     @ApiOperation(value = "Login", notes = "Login with the given credentials.")
-    @ApiResponses({@ApiResponse(code = 200, message = "", response = Authentication.class)})
+    @ApiResponses({@ApiResponse(code = 200, message = "")})
     @PostMapping(value = "/auth/login")
     void login(
         @RequestParam("username") String username,

--- a/src/main/java/org/isf/stats/rest/ReportsController.java
+++ b/src/main/java/org/isf/stats/rest/ReportsController.java
@@ -21,8 +21,13 @@
  */
 package org.isf.stats.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.poi.util.IOUtils;
 import org.isf.shared.exceptions.OHAPIException;
 import org.isf.stat.dto.JasperReportResultDto;
@@ -39,58 +44,55 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
 
 @RestController
 @Api(value = "/reports", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})
 public class ReportsController {
-    @Autowired
-    private JasperReportsManager reportsManager;
+	@Autowired
+	private JasperReportsManager reportsManager;
 
-    @GetMapping(value = "/reports/exams-list", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<byte[]> printExamsListPdf(HttpServletRequest request) throws OHServiceException, IOException {
-        return getReport(reportsManager.getExamsListPdf(), request);
-    }
+	@GetMapping(value = "/reports/exams-list", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<byte[]> printExamsListPdf(HttpServletRequest request) throws OHServiceException, IOException {
+		return getReport(reportsManager.getExamsListPdf(), request);
+	}
 
-    @GetMapping(value = "/reports/diseases-list", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<byte[]> printDiseasesListPdf(HttpServletRequest request) throws OHServiceException, IOException {
-        return getReport(reportsManager.getDiseasesListPdf(), request);
-    }
+	@GetMapping(value = "/reports/diseases-list", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<byte[]> printDiseasesListPdf(HttpServletRequest request) throws OHServiceException, IOException {
+		return getReport(reportsManager.getDiseasesListPdf(), request);
+	}
 
-    private ResponseEntity<byte[]> getReport(JasperReportResultDto resultDto, HttpServletRequest request) throws OHServiceException, IOException {
-        Path report = Paths.get(resultDto.getFilename()).normalize();
-        Resource resource;
-        try {
-            resource = new UrlResource(report.toUri());
-            if (!resource.exists()) {
-                throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
-            }
-        } catch (MalformedURLException e) {
-            throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
-        }
+	private ResponseEntity<byte[]> getReport(JasperReportResultDto resultDto, HttpServletRequest request) throws OHServiceException, IOException {
+		Path report = Paths.get(resultDto.getFilename()).normalize();
+		Resource resource;
+		try {
+			resource = new UrlResource(report.toUri());
+			if (!resource.exists()) {
+				throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
+			}
+		} catch (MalformedURLException e) {
+			throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
+		}
 
-        String contentType = null;
-        try {
-            contentType = request.getServletContext().getMimeType(resource.getFile().getAbsolutePath());
-        } catch (IOException ex) {
-            throw new OHAPIException(new OHExceptionMessage(null, "Failed to load the file's type", OHSeverityLevel.ERROR));
-        }
+		String contentType = null;
+		try {
+			contentType = request.getServletContext().getMimeType(resource.getFile().getAbsolutePath());
+		} catch (IOException ex) {
+			throw new OHAPIException(new OHExceptionMessage(null, "Failed to load the file's type", OHSeverityLevel.ERROR));
+		}
 
-        // Fallback to the default content type if type could not be determined
-        if (contentType == null) {
-            contentType = "application/octet-stream";
-        }
+		// Fallback to the default content type if type could not be determined
+		if (contentType == null) {
+			contentType = "application/octet-stream";
+		}
 
-        byte[] out = IOUtils.toByteArray(resource.getInputStream());
+		byte[] out = IOUtils.toByteArray(resource.getInputStream());
 
-        return ResponseEntity.ok()
-                .contentType(MediaType.parseMediaType(contentType))
-                .header(HttpHeaders.CONTENT_DISPOSITION,
-                        "attachment; filename=\"" + resource.getFilename() + "\"")
-                .body(out);
-    }
+		return ResponseEntity.ok()
+				.contentType(MediaType.parseMediaType(contentType))
+				.header(HttpHeaders.CONTENT_DISPOSITION,
+						"attachment; filename=\"" + resource.getFilename() + "\"")
+				.body(out);
+	}
 }

--- a/src/main/java/org/isf/stats/rest/ReportsController.java
+++ b/src/main/java/org/isf/stats/rest/ReportsController.java
@@ -21,13 +21,9 @@
  */
 package org.isf.stats.rest;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import javax.servlet.http.HttpServletRequest;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.Authorization;
+import org.apache.poi.util.IOUtils;
 import org.isf.shared.exceptions.OHAPIException;
 import org.isf.stat.dto.JasperReportResultDto;
 import org.isf.stat.manager.JasperReportsManager;
@@ -43,53 +39,58 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.Authorization;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @RestController
-@Api(value="/reports",produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value="basicAuth")})
+@Api(value = "/reports", produces = MediaType.APPLICATION_JSON_VALUE, authorizations = {@Authorization(value = "basicAuth")})
 public class ReportsController {
-	@Autowired
-	private JasperReportsManager reportsManager;
-	
-	@GetMapping(value = "/reports/exams-list", produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<Resource> printExamsListPdf(HttpServletRequest request) throws OHServiceException {
-		return getReport(reportsManager.getExamsListPdf(), request);
-	}
-	
-	@GetMapping(value = "/reports/diseases-list", produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<Resource> printDiseasesListPdf(HttpServletRequest request) throws OHServiceException {
-		return getReport(reportsManager.getDiseasesListPdf(), request);
-	}
-	
-	private ResponseEntity<Resource> getReport(JasperReportResultDto resultDto, HttpServletRequest request) throws OHServiceException {
-		Path report = Paths.get(resultDto.getFilename()).normalize();
-		Resource resource;
-		try {
-			resource = new UrlResource(report.toUri());
-			if (!resource.exists()) {
-            	throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
+    @Autowired
+    private JasperReportsManager reportsManager;
+
+    @GetMapping(value = "/reports/exams-list", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<byte[]> printExamsListPdf(HttpServletRequest request) throws OHServiceException, IOException {
+        return getReport(reportsManager.getExamsListPdf(), request);
+    }
+
+    @GetMapping(value = "/reports/diseases-list", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<byte[]> printDiseasesListPdf(HttpServletRequest request) throws OHServiceException, IOException {
+        return getReport(reportsManager.getDiseasesListPdf(), request);
+    }
+
+    private ResponseEntity<byte[]> getReport(JasperReportResultDto resultDto, HttpServletRequest request) throws OHServiceException, IOException {
+        Path report = Paths.get(resultDto.getFilename()).normalize();
+        Resource resource;
+        try {
+            resource = new UrlResource(report.toUri());
+            if (!resource.exists()) {
+                throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
             }
-		} catch (MalformedURLException e) {
-			throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
-		}
-		
-		String contentType = null;
+        } catch (MalformedURLException e) {
+            throw new OHAPIException(new OHExceptionMessage(null, "File not found", OHSeverityLevel.ERROR));
+        }
+
+        String contentType = null;
         try {
             contentType = request.getServletContext().getMimeType(resource.getFile().getAbsolutePath());
         } catch (IOException ex) {
-        	throw new OHAPIException(new OHExceptionMessage(null, "Failed to load the file's type", OHSeverityLevel.ERROR));
+            throw new OHAPIException(new OHExceptionMessage(null, "Failed to load the file's type", OHSeverityLevel.ERROR));
         }
 
         // Fallback to the default content type if type could not be determined
         if (contentType == null) {
             contentType = "application/octet-stream";
         }
-        
+
+        byte[] out = IOUtils.toByteArray(resource.getInputStream());
+
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))
-                .header(HttpHeaders.CONTENT_DISPOSITION, 
-                		"attachment; filename=\"" + resource.getFilename() + "\"")
-                .body(resource);
-	}
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + resource.getFilename() + "\"")
+                .body(out);
+    }
 }

--- a/src/main/java/org/isf/vaccine/rest/VaccineController.java
+++ b/src/main/java/org/isf/vaccine/rest/VaccineController.java
@@ -91,7 +91,7 @@ public class VaccineController {
      * @return NO_CONTENT if there aren't vaccines related to code, {@code List<VaccineDTO>} otherwise
      * @throws OHServiceException
      */
-    @GetMapping(value = "/vaccines/{vaccineTypeCode}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/vaccines/type-code/{vaccineTypeCode}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VaccineDTO>> getVaccinesByVaccineTypeCode(@PathVariable String vaccineTypeCode) throws OHServiceException {
 	    LOGGER.info("Get vaccine by code: {}", vaccineTypeCode);
         ArrayList<Vaccine> vaccines = vaccineManager.getVaccine(vaccineTypeCode);

--- a/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
@@ -113,7 +113,7 @@ public class DeliveryTypeControllerTest {
 
 	@Test
 	public void testUpdateDeliveryTypet_200() throws Exception {
-		String request = "/deliverytypes/{code}";
+		String request = "/deliverytypes/";
 		int code = 456;
 
 		DeliveryType deliveryType = DeliveryTypeHelper.setup(code);

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -106,7 +106,7 @@ public class VaccineControllerTest {
 
 	@Test
 	public void testGetVaccinesByVaccineTypeCode_200() throws Exception {
-		String request = "/vaccines/{vaccineTypeCode}";
+		String request = "/vaccines/type-code/{vaccineTypeCode}";
 
 		ArrayList<Vaccine> vaccinesList = VaccineHelper.setupVaccineList(4);
 		String vaccineTypeCode = vaccinesList.get(0).getVaccineType().getCode();


### PR DESCRIPTION
https://openhospital.atlassian.net/browse/OP-376

Due to some mistakes mainly on SpringFox annotations and REST controllers paths definitions, the autogenerated api-docs has some errors against the Swagger 2 specification.To check that, I copy the generated api-docs (from /oh-api/v2/api-docs) and paste it in swagger editor. Those are the reported errors:

![oh-opeapi-spec-errors](https://user-images.githubusercontent.com/12557970/100549109-47123180-3271-11eb-8de5-59f1a76bf750.png)
