### PR TITLE
Chore: unnecessary unboxing

### DIFF
--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -423,8 +423,8 @@ public class AdmissionController {
 				? newAdmission.getPatient().getFirstName() + " " + newAdmission.getPatient().getSecondName()
 				: newAdmission.getPatient().getName();
 		LOGGER.info("Create admission for patient {}", name);
-		Integer aId = admissionManager.newAdmissionReturnKey(newAdmission);
-		if (aId != null && aId.intValue() > 0) {
+		int aId = admissionManager.newAdmissionReturnKey(newAdmission);
+		if (aId > 0) {
 			return ResponseEntity.status(HttpStatus.CREATED).body(aId);
 		}
 		throw new OHAPIException(new OHExceptionMessage(null, "Admission is not created!", OHSeverityLevel.ERROR));


### PR DESCRIPTION
The method `admissionManager.newAdmissionReturnKey(newAdmission)` returns an `int` and not an `Integer` thus making the test for null and `aId.intValue()` unnecessary.

`Unboxing`,  that is the explicit unwrapping of wrapped primitive values,  is unnecessary under Java 5 and newer, and can be safely removed.

Found with IntelliJ Analyze plugin.