### PR TITLE
Chore: consistency

### DIFF
--- a/src/main/java/org/isf/agetype/rest/AgeTypeController.java
+++ b/src/main/java/org/isf/agetype/rest/AgeTypeController.java
@@ -143,7 +143,7 @@ public class AgeTypeController {
 			return ResponseEntity.ok(result);
         }else{
         	LOGGER.info("No corresponding age code for the given index");
-        	return ResponseEntity.status(HttpStatus.NO_CONTENT).body(result);
+        	return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
         }
 	}
 	


### PR DESCRIPTION
This was the only occurrence in the code where the `body` value was a variable and not `null` when there was no content.   It doesn't change the code but makes it consistent.

This was found with Spotbugs where it complained about loading a known null value.