### PR TITLE
Chore: upgrade to Spring Boot 2.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>2.7.10</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.isf</groupId>


### PR DESCRIPTION
To match Core and GUI updates to 2.7.10

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.10