### PR TITLE
Chore: add 's' to "If not, see <http://www.gnu.org/licenses/>" in header

### DIFF
--- a/.license-header/license-header.txt
+++ b/.license-header/license-header.txt
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/src/main/java/org/isf/OpenHospitalApiApplication.java
+++ b/src/main/java/org/isf/OpenHospitalApiApplication.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf;
 

--- a/src/main/java/org/isf/accounting/dto/BillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.dto;
 

--- a/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.dto;
 

--- a/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.dto;
 

--- a/src/main/java/org/isf/accounting/dto/FullBillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/FullBillDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.dto;
 

--- a/src/main/java/org/isf/accounting/mapper/BillItemsMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillItemsMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.mapper;
 

--- a/src/main/java/org/isf/accounting/mapper/BillMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.mapper;
 

--- a/src/main/java/org/isf/accounting/mapper/BillPaymentsMapper.java
+++ b/src/main/java/org/isf/accounting/mapper/BillPaymentsMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.mapper;
 

--- a/src/main/java/org/isf/accounting/rest/BillController.java
+++ b/src/main/java/org/isf/accounting/rest/BillController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.rest;
 

--- a/src/main/java/org/isf/admission/dto/AdmissionDTO.java
+++ b/src/main/java/org/isf/admission/dto/AdmissionDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.dto;
 

--- a/src/main/java/org/isf/admission/dto/AdmittedPatientDTO.java
+++ b/src/main/java/org/isf/admission/dto/AdmittedPatientDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.dto;
 

--- a/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
+++ b/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.mapper;
 

--- a/src/main/java/org/isf/admission/mapper/AdmittedPatientMapper.java
+++ b/src/main/java/org/isf/admission/mapper/AdmittedPatientMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.mapper;
 

--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.rest;
 

--- a/src/main/java/org/isf/admtype/dto/AdmissionTypeDTO.java
+++ b/src/main/java/org/isf/admtype/dto/AdmissionTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.dto;
 

--- a/src/main/java/org/isf/admtype/mapper/AdmissionTypeMapper.java
+++ b/src/main/java/org/isf/admtype/mapper/AdmissionTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.mapper;
 

--- a/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
+++ b/src/main/java/org/isf/admtype/rest/AdmissionTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.rest;
 

--- a/src/main/java/org/isf/agetype/dto/AgeTypeDTO.java
+++ b/src/main/java/org/isf/agetype/dto/AgeTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.dto;
 

--- a/src/main/java/org/isf/agetype/mapper/AgeTypeMapper.java
+++ b/src/main/java/org/isf/agetype/mapper/AgeTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.mapper;
 

--- a/src/main/java/org/isf/agetype/rest/AgeTypeController.java
+++ b/src/main/java/org/isf/agetype/rest/AgeTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.rest;
 

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.config;
 

--- a/src/main/java/org/isf/config/SpringFoxConfig.java
+++ b/src/main/java/org/isf/config/SpringFoxConfig.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.config;
 

--- a/src/main/java/org/isf/disctype/dto/DischargeTypeDTO.java
+++ b/src/main/java/org/isf/disctype/dto/DischargeTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.dto;
 

--- a/src/main/java/org/isf/disctype/mapper/DischargeTypeMapper.java
+++ b/src/main/java/org/isf/disctype/mapper/DischargeTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.mapper;
 

--- a/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
+++ b/src/main/java/org/isf/disctype/rest/DischargeTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.rest;
 

--- a/src/main/java/org/isf/disease/dto/DiseaseDTO.java
+++ b/src/main/java/org/isf/disease/dto/DiseaseDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.dto;
 

--- a/src/main/java/org/isf/disease/mapper/DiseaseMapper.java
+++ b/src/main/java/org/isf/disease/mapper/DiseaseMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.mapper;
 

--- a/src/main/java/org/isf/disease/rest/DiseaseController.java
+++ b/src/main/java/org/isf/disease/rest/DiseaseController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.rest;
 

--- a/src/main/java/org/isf/distype/dto/DiseaseTypeDTO.java
+++ b/src/main/java/org/isf/distype/dto/DiseaseTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.dto;
 

--- a/src/main/java/org/isf/distype/mapper/DiseaseTypeMapper.java
+++ b/src/main/java/org/isf/distype/mapper/DiseaseTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.mapper;
 

--- a/src/main/java/org/isf/distype/rest/DiseaseTypeController.java
+++ b/src/main/java/org/isf/distype/rest/DiseaseTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.rest;
 

--- a/src/main/java/org/isf/dlvrrestype/dto/DeliveryResultTypeDTO.java
+++ b/src/main/java/org/isf/dlvrrestype/dto/DeliveryResultTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.dto;
 

--- a/src/main/java/org/isf/dlvrrestype/mapper/DeliveryResultTypeMapper.java
+++ b/src/main/java/org/isf/dlvrrestype/mapper/DeliveryResultTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.mapper;
 

--- a/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
+++ b/src/main/java/org/isf/dlvrrestype/rest/DeliveryResultTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.rest;
 

--- a/src/main/java/org/isf/dlvrtype/dto/DeliveryTypeDTO.java
+++ b/src/main/java/org/isf/dlvrtype/dto/DeliveryTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.dto;
 

--- a/src/main/java/org/isf/dlvrtype/mapper/DeliveryTypeMapper.java
+++ b/src/main/java/org/isf/dlvrtype/mapper/DeliveryTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.mapper;
 

--- a/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
+++ b/src/main/java/org/isf/dlvrtype/rest/DeliveryTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.rest;
 

--- a/src/main/java/org/isf/exam/dto/ExamDTO.java
+++ b/src/main/java/org/isf/exam/dto/ExamDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.dto;
 

--- a/src/main/java/org/isf/exam/dto/ExamRowDTO.java
+++ b/src/main/java/org/isf/exam/dto/ExamRowDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.dto;
 

--- a/src/main/java/org/isf/exam/mapper/ExamMapper.java
+++ b/src/main/java/org/isf/exam/mapper/ExamMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.mapper;
 

--- a/src/main/java/org/isf/exam/mapper/ExamRowMapper.java
+++ b/src/main/java/org/isf/exam/mapper/ExamRowMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.mapper;
 

--- a/src/main/java/org/isf/exam/rest/ExamController.java
+++ b/src/main/java/org/isf/exam/rest/ExamController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.rest;
 

--- a/src/main/java/org/isf/exam/rest/ExamRowController.java
+++ b/src/main/java/org/isf/exam/rest/ExamRowController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exam.rest;
 

--- a/src/main/java/org/isf/examination/dto/Ausculation.java
+++ b/src/main/java/org/isf/examination/dto/Ausculation.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.dto;
 

--- a/src/main/java/org/isf/examination/dto/Bowel.java
+++ b/src/main/java/org/isf/examination/dto/Bowel.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.dto;
 

--- a/src/main/java/org/isf/examination/dto/Diurese.java
+++ b/src/main/java/org/isf/examination/dto/Diurese.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.dto;
 

--- a/src/main/java/org/isf/examination/dto/PatientExaminationDTO.java
+++ b/src/main/java/org/isf/examination/dto/PatientExaminationDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.dto;
 

--- a/src/main/java/org/isf/examination/mapper/PatientExaminationMapper.java
+++ b/src/main/java/org/isf/examination/mapper/PatientExaminationMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.mapper;
 

--- a/src/main/java/org/isf/examination/rest/ExaminationController.java
+++ b/src/main/java/org/isf/examination/rest/ExaminationController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.examination.rest;
 

--- a/src/main/java/org/isf/exatype/dto/ExamTypeDTO.java
+++ b/src/main/java/org/isf/exatype/dto/ExamTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.dto;
 

--- a/src/main/java/org/isf/exatype/mapper/ExamTypeMapper.java
+++ b/src/main/java/org/isf/exatype/mapper/ExamTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.mapper;
 

--- a/src/main/java/org/isf/exatype/rest/ExamTypeController.java
+++ b/src/main/java/org/isf/exatype/rest/ExamTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.exatype.rest;
 

--- a/src/main/java/org/isf/hospital/dto/HospitalDTO.java
+++ b/src/main/java/org/isf/hospital/dto/HospitalDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.dto;
 

--- a/src/main/java/org/isf/hospital/mapper/HospitalMapper.java
+++ b/src/main/java/org/isf/hospital/mapper/HospitalMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.mapper;
 

--- a/src/main/java/org/isf/hospital/rest/HospitalController.java
+++ b/src/main/java/org/isf/hospital/rest/HospitalController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.hospital.rest;
 

--- a/src/main/java/org/isf/lab/dto/LabWithRowsDTO.java
+++ b/src/main/java/org/isf/lab/dto/LabWithRowsDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.dto;
 

--- a/src/main/java/org/isf/lab/dto/LaboratoryDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.dto;
 

--- a/src/main/java/org/isf/lab/dto/LaboratoryForPrintDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryForPrintDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.dto;
 

--- a/src/main/java/org/isf/lab/dto/LaboratoryRowDTO.java
+++ b/src/main/java/org/isf/lab/dto/LaboratoryRowDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.dto;
 

--- a/src/main/java/org/isf/lab/mapper/LaboratoryForPrintMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryForPrintMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.mapper;
 

--- a/src/main/java/org/isf/lab/mapper/LaboratoryMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.mapper;
 

--- a/src/main/java/org/isf/lab/mapper/LaboratoryRowMapper.java
+++ b/src/main/java/org/isf/lab/mapper/LaboratoryRowMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.mapper;
 

--- a/src/main/java/org/isf/lab/rest/LaboratoryController.java
+++ b/src/main/java/org/isf/lab/rest/LaboratoryController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.rest;
 

--- a/src/main/java/org/isf/login/dto/LoginRequest.java
+++ b/src/main/java/org/isf/login/dto/LoginRequest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.login.dto;
 

--- a/src/main/java/org/isf/login/dto/LoginResponse.java
+++ b/src/main/java/org/isf/login/dto/LoginResponse.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.login.dto;
 

--- a/src/main/java/org/isf/login/rest/LoginController.java
+++ b/src/main/java/org/isf/login/rest/LoginController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.login.rest;
 

--- a/src/main/java/org/isf/malnutrition/dto/MalnutritionDTO.java
+++ b/src/main/java/org/isf/malnutrition/dto/MalnutritionDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.dto;
 

--- a/src/main/java/org/isf/malnutrition/mapper/MalnutritionMapper.java
+++ b/src/main/java/org/isf/malnutrition/mapper/MalnutritionMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.mapper;
 

--- a/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
+++ b/src/main/java/org/isf/malnutrition/rest/MalnutritionController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.malnutrition.rest;
 

--- a/src/main/java/org/isf/medical/dto/MedicalDTO.java
+++ b/src/main/java/org/isf/medical/dto/MedicalDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medical.dto;
 

--- a/src/main/java/org/isf/medical/dto/MedicalSortBy.java
+++ b/src/main/java/org/isf/medical/dto/MedicalSortBy.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medical.dto;
 

--- a/src/main/java/org/isf/medical/mapper/MedicalMapper.java
+++ b/src/main/java/org/isf/medical/mapper/MedicalMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medical.mapper;
 

--- a/src/main/java/org/isf/medical/rest/MedicalController.java
+++ b/src/main/java/org/isf/medical/rest/MedicalController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medical.rest;
 

--- a/src/main/java/org/isf/medicalstock/dto/LotDTO.java
+++ b/src/main/java/org/isf/medicalstock/dto/LotDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.dto;
 

--- a/src/main/java/org/isf/medicalstock/dto/MovementDTO.java
+++ b/src/main/java/org/isf/medicalstock/dto/MovementDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.dto;
 

--- a/src/main/java/org/isf/medicalstock/mapper/LotMapper.java
+++ b/src/main/java/org/isf/medicalstock/mapper/LotMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.mapper;
 

--- a/src/main/java/org/isf/medicalstock/mapper/MovementMapper.java
+++ b/src/main/java/org/isf/medicalstock/mapper/MovementMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.mapper;
 

--- a/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
+++ b/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstock.rest;
 

--- a/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.dto;
 

--- a/src/main/java/org/isf/medicalstockward/dto/MedicalWardIdDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MedicalWardIdDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.dto;
 

--- a/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.dto;
 

--- a/src/main/java/org/isf/medicalstockward/mapper/MedicalWardIdMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MedicalWardIdMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.mapper;
 

--- a/src/main/java/org/isf/medicalstockward/mapper/MedicalWardMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MedicalWardMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.mapper;
 

--- a/src/main/java/org/isf/medicalstockward/mapper/MovementWardMapper.java
+++ b/src/main/java/org/isf/medicalstockward/mapper/MovementWardMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.mapper;
 

--- a/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
+++ b/src/main/java/org/isf/medicalstockward/rest/MedicalStockWardController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medicalstockward.rest;
 

--- a/src/main/java/org/isf/medstockmovtype/dto/MovementTypeDTO.java
+++ b/src/main/java/org/isf/medstockmovtype/dto/MovementTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.dto;
 

--- a/src/main/java/org/isf/medstockmovtype/mapper/MovementTypeMapper.java
+++ b/src/main/java/org/isf/medstockmovtype/mapper/MovementTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.mapper;
 

--- a/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
+++ b/src/main/java/org/isf/medstockmovtype/rest/MedStockMovementTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medstockmovtype.rest;
 

--- a/src/main/java/org/isf/medtype/dto/MedicalTypeDTO.java
+++ b/src/main/java/org/isf/medtype/dto/MedicalTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.dto;
 

--- a/src/main/java/org/isf/medtype/mapper/MedicalTypeMapper.java
+++ b/src/main/java/org/isf/medtype/mapper/MedicalTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.mapper;
 

--- a/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
+++ b/src/main/java/org/isf/medtype/rest/MedicalTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.medtype.rest;
 

--- a/src/main/java/org/isf/menu/dto/GroupMenuDTO.java
+++ b/src/main/java/org/isf/menu/dto/GroupMenuDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.dto;
 

--- a/src/main/java/org/isf/menu/dto/UserDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.dto;
 

--- a/src/main/java/org/isf/menu/dto/UserGroupDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserGroupDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.dto;
 

--- a/src/main/java/org/isf/menu/dto/UserMenuItemDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserMenuItemDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.dto;
 

--- a/src/main/java/org/isf/menu/dto/UserProfileDTO.java
+++ b/src/main/java/org/isf/menu/dto/UserProfileDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.dto;
 

--- a/src/main/java/org/isf/menu/mapper/GroupMenuMapper.java
+++ b/src/main/java/org/isf/menu/mapper/GroupMenuMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.mapper;
 

--- a/src/main/java/org/isf/menu/mapper/UserGroupMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserGroupMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.mapper;
 

--- a/src/main/java/org/isf/menu/mapper/UserMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.mapper;
 

--- a/src/main/java/org/isf/menu/mapper/UserMenuItemMapper.java
+++ b/src/main/java/org/isf/menu/mapper/UserMenuItemMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.mapper;
 

--- a/src/main/java/org/isf/menu/rest/UserController.java
+++ b/src/main/java/org/isf/menu/rest/UserController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.menu.rest;
 

--- a/src/main/java/org/isf/opd/dto/OpdDTO.java
+++ b/src/main/java/org/isf/opd/dto/OpdDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.dto;
 

--- a/src/main/java/org/isf/opd/dto/OpdWithOperatioRowDTO.java
+++ b/src/main/java/org/isf/opd/dto/OpdWithOperatioRowDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 package org.isf.opd.dto;

--- a/src/main/java/org/isf/opd/mapper/OpdMapper.java
+++ b/src/main/java/org/isf/opd/mapper/OpdMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.mapper;
 

--- a/src/main/java/org/isf/opd/rest/OpdController.java
+++ b/src/main/java/org/isf/opd/rest/OpdController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.rest;
 

--- a/src/main/java/org/isf/operation/dto/OperationDTO.java
+++ b/src/main/java/org/isf/operation/dto/OperationDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.dto;
 

--- a/src/main/java/org/isf/operation/dto/OperationRowDTO.java
+++ b/src/main/java/org/isf/operation/dto/OperationRowDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * To change this license header, choose License Headers in Project Properties.

--- a/src/main/java/org/isf/operation/mapper/OperationMapper.java
+++ b/src/main/java/org/isf/operation/mapper/OperationMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.mapper;
 

--- a/src/main/java/org/isf/operation/mapper/OperationRowMapper.java
+++ b/src/main/java/org/isf/operation/mapper/OperationRowMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.mapper;
 

--- a/src/main/java/org/isf/operation/rest/OperationController.java
+++ b/src/main/java/org/isf/operation/rest/OperationController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.rest;
 

--- a/src/main/java/org/isf/opetype/dto/OperationTypeDTO.java
+++ b/src/main/java/org/isf/opetype/dto/OperationTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.dto;
 

--- a/src/main/java/org/isf/opetype/mapper/OperationTypeMapper.java
+++ b/src/main/java/org/isf/opetype/mapper/OperationTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.mapper;
 

--- a/src/main/java/org/isf/opetype/rest/OperationTypeController.java
+++ b/src/main/java/org/isf/opetype/rest/OperationTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opetype.rest;
 

--- a/src/main/java/org/isf/patient/dto/PatientDTO.java
+++ b/src/main/java/org/isf/patient/dto/PatientDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.dto;
 

--- a/src/main/java/org/isf/patient/dto/PatientSTATUS.java
+++ b/src/main/java/org/isf/patient/dto/PatientSTATUS.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.dto;
 

--- a/src/main/java/org/isf/patient/mapper/PatientMapper.java
+++ b/src/main/java/org/isf/patient/mapper/PatientMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.mapper;
 

--- a/src/main/java/org/isf/patient/rest/PatientController.java
+++ b/src/main/java/org/isf/patient/rest/PatientController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.rest;
 

--- a/src/main/java/org/isf/patvac/dto/PatientVaccineDTO.java
+++ b/src/main/java/org/isf/patvac/dto/PatientVaccineDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.dto;
 

--- a/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
+++ b/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.mapper;
 

--- a/src/main/java/org/isf/patvac/rest/PatVacController.java
+++ b/src/main/java/org/isf/patvac/rest/PatVacController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patvac.rest;
 

--- a/src/main/java/org/isf/permissions/dto/GroupPermissionDTO.java
+++ b/src/main/java/org/isf/permissions/dto/GroupPermissionDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.dto;
 

--- a/src/main/java/org/isf/permissions/dto/LitePermissionDTO.java
+++ b/src/main/java/org/isf/permissions/dto/LitePermissionDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.dto;
 

--- a/src/main/java/org/isf/permissions/dto/PermissionDTO.java
+++ b/src/main/java/org/isf/permissions/dto/PermissionDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.dto;
 

--- a/src/main/java/org/isf/permissions/mapper/LitePermissionMapper.java
+++ b/src/main/java/org/isf/permissions/mapper/LitePermissionMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.mapper;
 

--- a/src/main/java/org/isf/permissions/mapper/PermissionMapper.java
+++ b/src/main/java/org/isf/permissions/mapper/PermissionMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.mapper;
 

--- a/src/main/java/org/isf/permissions/rest/PermissionController.java
+++ b/src/main/java/org/isf/permissions/rest/PermissionController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.permissions.rest;
 

--- a/src/main/java/org/isf/pregtreattype/dto/PregnantTreatmentTypeDTO.java
+++ b/src/main/java/org/isf/pregtreattype/dto/PregnantTreatmentTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.dto;
 

--- a/src/main/java/org/isf/pregtreattype/mapper/PregnantTreatmentTypeMapper.java
+++ b/src/main/java/org/isf/pregtreattype/mapper/PregnantTreatmentTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.mapper;
 

--- a/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
+++ b/src/main/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.rest;
 

--- a/src/main/java/org/isf/priceslist/dto/PriceDTO.java
+++ b/src/main/java/org/isf/priceslist/dto/PriceDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.dto;
 

--- a/src/main/java/org/isf/priceslist/dto/PriceListDTO.java
+++ b/src/main/java/org/isf/priceslist/dto/PriceListDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.dto;
 

--- a/src/main/java/org/isf/priceslist/mapper/PriceListMapper.java
+++ b/src/main/java/org/isf/priceslist/mapper/PriceListMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.mapper;
 

--- a/src/main/java/org/isf/priceslist/mapper/PriceMapper.java
+++ b/src/main/java/org/isf/priceslist/mapper/PriceMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.mapper;
 

--- a/src/main/java/org/isf/priceslist/rest/PriceListController.java
+++ b/src/main/java/org/isf/priceslist/rest/PriceListController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.priceslist.rest;
 

--- a/src/main/java/org/isf/pricesothers/dto/PricesOthersDTO.java
+++ b/src/main/java/org/isf/pricesothers/dto/PricesOthersDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.dto;
 

--- a/src/main/java/org/isf/pricesothers/mapper/PricesOthersMapper.java
+++ b/src/main/java/org/isf/pricesothers/mapper/PricesOthersMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.mapper;
 

--- a/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
+++ b/src/main/java/org/isf/pricesothers/rest/PricesOthersController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pricesothers.rest;
 

--- a/src/main/java/org/isf/security/CustomAuthenticationManager.java
+++ b/src/main/java/org/isf/security/CustomAuthenticationManager.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/CustomLogoutHandler.java
+++ b/src/main/java/org/isf/security/CustomLogoutHandler.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/LoginApi.java
+++ b/src/main/java/org/isf/security/LoginApi.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/LoginResponse.java
+++ b/src/main/java/org/isf/security/LoginResponse.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/OHSimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/org/isf/security/OHSimpleUrlAuthenticationSuccessHandler.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/isf/security/RestAuthenticationEntryPoint.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/UserDetailsServiceImpl.java
+++ b/src/main/java/org/isf/security/UserDetailsServiceImpl.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security;
 

--- a/src/main/java/org/isf/security/jwt/AuthEntryPointJwt.java
+++ b/src/main/java/org/isf/security/jwt/AuthEntryPointJwt.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security.jwt;
 

--- a/src/main/java/org/isf/security/jwt/JWTConfigurer.java
+++ b/src/main/java/org/isf/security/jwt/JWTConfigurer.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security.jwt;
 

--- a/src/main/java/org/isf/security/jwt/JWTFilter.java
+++ b/src/main/java/org/isf/security/jwt/JWTFilter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security.jwt;
 

--- a/src/main/java/org/isf/security/jwt/SecurityConstants.java
+++ b/src/main/java/org/isf/security/jwt/SecurityConstants.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security.jwt;
 

--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.security.jwt;
 

--- a/src/main/java/org/isf/shared/Constants.java
+++ b/src/main/java/org/isf/shared/Constants.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared;
 

--- a/src/main/java/org/isf/shared/GenericMapper.java
+++ b/src/main/java/org/isf/shared/GenericMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared;
 

--- a/src/main/java/org/isf/shared/Mapper.java
+++ b/src/main/java/org/isf/shared/Mapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared;
 

--- a/src/main/java/org/isf/shared/SwaggerVendorExtension.java
+++ b/src/main/java/org/isf/shared/SwaggerVendorExtension.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared;
 

--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.exceptions;
 

--- a/src/main/java/org/isf/shared/exceptions/OHAPIException.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIException.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.exceptions;
 

--- a/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
+++ b/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.exceptions;
 

--- a/src/main/java/org/isf/shared/mapper/OHModelMapper.java
+++ b/src/main/java/org/isf/shared/mapper/OHModelMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.mapper;
 

--- a/src/main/java/org/isf/shared/mapper/converter/BlobToByteArrayConverter.java
+++ b/src/main/java/org/isf/shared/mapper/converter/BlobToByteArrayConverter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.mapper.converter;
 

--- a/src/main/java/org/isf/shared/mapper/converter/ByteArrayToBlobConverter.java
+++ b/src/main/java/org/isf/shared/mapper/converter/ByteArrayToBlobConverter.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.mapper.converter;
 

--- a/src/main/java/org/isf/shared/mapper/converter/ModelMapperConfig.java
+++ b/src/main/java/org/isf/shared/mapper/converter/ModelMapperConfig.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.shared.mapper.converter;
 

--- a/src/main/java/org/isf/sms/dto/SmsDTO.java
+++ b/src/main/java/org/isf/sms/dto/SmsDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.dto;
 

--- a/src/main/java/org/isf/sms/mapper/SmsMapper.java
+++ b/src/main/java/org/isf/sms/mapper/SmsMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.mapper;
 

--- a/src/main/java/org/isf/sms/rest/SmsController.java
+++ b/src/main/java/org/isf/sms/rest/SmsController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.sms.rest;
 

--- a/src/main/java/org/isf/stats/rest/ReportsController.java
+++ b/src/main/java/org/isf/stats/rest/ReportsController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.stats.rest;
 

--- a/src/main/java/org/isf/supplier/dto/SupplierDTO.java
+++ b/src/main/java/org/isf/supplier/dto/SupplierDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.dto;
 

--- a/src/main/java/org/isf/supplier/mapper/SupplierMapper.java
+++ b/src/main/java/org/isf/supplier/mapper/SupplierMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.mapper;
 

--- a/src/main/java/org/isf/supplier/rest/SupplierController.java
+++ b/src/main/java/org/isf/supplier/rest/SupplierController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.supplier.rest;
 

--- a/src/main/java/org/isf/therapy/dto/TherapyDTO.java
+++ b/src/main/java/org/isf/therapy/dto/TherapyDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.dto;
 

--- a/src/main/java/org/isf/therapy/dto/TherapyRowDTO.java
+++ b/src/main/java/org/isf/therapy/dto/TherapyRowDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.dto;
 

--- a/src/main/java/org/isf/therapy/mapper/TherapyMapper.java
+++ b/src/main/java/org/isf/therapy/mapper/TherapyMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.mapper;
 

--- a/src/main/java/org/isf/therapy/mapper/TherapyRowMapper.java
+++ b/src/main/java/org/isf/therapy/mapper/TherapyRowMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.mapper;
 

--- a/src/main/java/org/isf/therapy/rest/TherapyController.java
+++ b/src/main/java/org/isf/therapy/rest/TherapyController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.therapy.rest;
 

--- a/src/main/java/org/isf/vaccine/dto/VaccineDTO.java
+++ b/src/main/java/org/isf/vaccine/dto/VaccineDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.dto;
 

--- a/src/main/java/org/isf/vaccine/mapper/VaccineMapper.java
+++ b/src/main/java/org/isf/vaccine/mapper/VaccineMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.mapper;
 

--- a/src/main/java/org/isf/vaccine/rest/VaccineController.java
+++ b/src/main/java/org/isf/vaccine/rest/VaccineController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.rest;
 

--- a/src/main/java/org/isf/vactype/dto/VaccineTypeDTO.java
+++ b/src/main/java/org/isf/vactype/dto/VaccineTypeDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.dto;
 

--- a/src/main/java/org/isf/vactype/mapper/VaccineTypeMapper.java
+++ b/src/main/java/org/isf/vactype/mapper/VaccineTypeMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.mapper;
 

--- a/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
+++ b/src/main/java/org/isf/vactype/rest/VaccineTypeController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.rest;
 

--- a/src/main/java/org/isf/visits/dto/VisitDTO.java
+++ b/src/main/java/org/isf/visits/dto/VisitDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.dto;
 

--- a/src/main/java/org/isf/visits/mapper/VisitMapper.java
+++ b/src/main/java/org/isf/visits/mapper/VisitMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.mapper;
 

--- a/src/main/java/org/isf/visits/rest/VisitsController.java
+++ b/src/main/java/org/isf/visits/rest/VisitsController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.rest;
 

--- a/src/main/java/org/isf/ward/dto/WardDTO.java
+++ b/src/main/java/org/isf/ward/dto/WardDTO.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.dto;
 

--- a/src/main/java/org/isf/ward/mapper/WardMapper.java
+++ b/src/main/java/org/isf/ward/mapper/WardMapper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.mapper;
 

--- a/src/main/java/org/isf/ward/rest/WardController.java
+++ b/src/main/java/org/isf/ward/rest/WardController.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.rest;
 

--- a/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
+++ b/src/test/java/org/isf/OpenHospitalApiApplicationTests.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf;
 

--- a/src/test/java/org/isf/accounting/data/BillDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillDTOHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.data;
 

--- a/src/test/java/org/isf/accounting/data/BillHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.data;
 

--- a/src/test/java/org/isf/accounting/data/BillItemsDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillItemsDTOHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.data;
 

--- a/src/test/java/org/isf/accounting/data/BillPaymentsDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/BillPaymentsDTOHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.data;
 

--- a/src/test/java/org/isf/accounting/data/FullBillDTOHelper.java
+++ b/src/test/java/org/isf/accounting/data/FullBillDTOHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.data;
 

--- a/src/test/java/org/isf/accounting/rest/BillControllerTest.java
+++ b/src/test/java/org/isf/accounting/rest/BillControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.accounting.rest;
 

--- a/src/test/java/org/isf/admission/data/AdmissionHelper.java
+++ b/src/test/java/org/isf/admission/data/AdmissionHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.data;
 

--- a/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
+++ b/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admission.rest;
 

--- a/src/test/java/org/isf/admtype/data/AdmissionTypeDTOHelper.java
+++ b/src/test/java/org/isf/admtype/data/AdmissionTypeDTOHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.data;
 

--- a/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
+++ b/src/test/java/org/isf/admtype/rest/AdmissionTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.admtype.rest;
 

--- a/src/test/java/org/isf/agetype/data/AgeTypeHelper.java
+++ b/src/test/java/org/isf/agetype/data/AgeTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.data;
 

--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.agetype.rest;
 

--- a/src/test/java/org/isf/disctype/data/DischargeTypeHelper.java
+++ b/src/test/java/org/isf/disctype/data/DischargeTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.data;
 

--- a/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
+++ b/src/test/java/org/isf/disctype/rest/DischargeTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disctype.rest;
 

--- a/src/test/java/org/isf/disease/data/DiseaseHelper.java
+++ b/src/test/java/org/isf/disease/data/DiseaseHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.data;
 

--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.disease.rest;
 

--- a/src/test/java/org/isf/distype/data/DiseaseTypeHelper.java
+++ b/src/test/java/org/isf/distype/data/DiseaseTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.data;
 

--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.distype.rest;
 

--- a/src/test/java/org/isf/dlvrrestype/data/DeliveryResultTypeHelper.java
+++ b/src/test/java/org/isf/dlvrrestype/data/DeliveryResultTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.data;
 

--- a/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrrestype/rest/DeliveryResultTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrrestype.rest;
 

--- a/src/test/java/org/isf/dlvrtype/data/DeliveryTypeHelper.java
+++ b/src/test/java/org/isf/dlvrtype/data/DeliveryTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.data;
 

--- a/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
+++ b/src/test/java/org/isf/dlvrtype/rest/DeliveryTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.dlvrtype.rest;
 

--- a/src/test/java/org/isf/lab/data/LaboratoryForPrintHelper.java
+++ b/src/test/java/org/isf/lab/data/LaboratoryForPrintHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.data;
 

--- a/src/test/java/org/isf/lab/data/LaboratoryHelper.java
+++ b/src/test/java/org/isf/lab/data/LaboratoryHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.data;
 

--- a/src/test/java/org/isf/lab/data/LaboratoryRowHelper.java
+++ b/src/test/java/org/isf/lab/data/LaboratoryRowHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.data;
 

--- a/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
+++ b/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.lab.rest;
 

--- a/src/test/java/org/isf/opd/data/OpdHelper.java
+++ b/src/test/java/org/isf/opd/data/OpdHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.data;
 

--- a/src/test/java/org/isf/opd/rest/OpdControllerTest.java
+++ b/src/test/java/org/isf/opd/rest/OpdControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.opd.rest;
 

--- a/src/test/java/org/isf/operation/data/OperationHelper.java
+++ b/src/test/java/org/isf/operation/data/OperationHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.data;
 

--- a/src/test/java/org/isf/operation/rest/OperationControllerTest.java
+++ b/src/test/java/org/isf/operation/rest/OperationControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.operation.rest;
 

--- a/src/test/java/org/isf/patient/data/PatientHelper.java
+++ b/src/test/java/org/isf/patient/data/PatientHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.data;
 

--- a/src/test/java/org/isf/patient/rest/PatientControllerTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.patient.rest;
 

--- a/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
+++ b/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.pregtreattype.data;
 

--- a/src/test/java/org/isf/testing/rest/ControllerBaseTest.java
+++ b/src/test/java/org/isf/testing/rest/ControllerBaseTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.testing.rest;
 

--- a/src/test/java/org/isf/vaccine/data/VaccineHelper.java
+++ b/src/test/java/org/isf/vaccine/data/VaccineHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.data;
 

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vaccine.rest;
 

--- a/src/test/java/org/isf/vactype/data/VaccineTypeHelper.java
+++ b/src/test/java/org/isf/vactype/data/VaccineTypeHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.data;
 

--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.vactype.rest;
 

--- a/src/test/java/org/isf/visits/data/VisitHelper.java
+++ b/src/test/java/org/isf/visits/data/VisitHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.data;
 

--- a/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
+++ b/src/test/java/org/isf/visits/rest/VisitsControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.visits.rest;
 

--- a/src/test/java/org/isf/ward/data/WardHelper.java
+++ b/src/test/java/org/isf/ward/data/WardHelper.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.data;
 

--- a/src/test/java/org/isf/ward/rest/WardControllerTest.java
+++ b/src/test/java/org/isf/ward/rest/WardControllerTest.java
@@ -17,7 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package org.isf.ward.rest;
 


### PR DESCRIPTION
Change: `If not, see <http://www.gnu.org/licenses/>`
To: `If not, see <https://www.gnu.org/licenses/>`