### PR TITLE
Chore: combine two recent dependabot updates for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,14 +124,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-modules-java8</artifactId>
-            <version>2.14.2</version>
+            <version>2.15.0</version>
             <type>pom</type>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.2</version>
+            <version>3.19.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Combine recent updates for `jackson-modules-java8` (to match core update) and `java-jwt`.   For `java-jwt` did not go all the way to version 4.4.0 but rather stayed at 3.19.4 because the CHANGELOG indicated breaking changes.   Someone who understands the use of `jwt` in this project needs to review [the Migration Guide](https://github.com/auth0/java-jwt/blob/master/MIGRATION_GUIDE.md) before moving to 4.X.X.

Ran `mvn clean test` successfully. 