### PR TITLE
Chore: upgrade to Spring Boot 2.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.11</version>
+        <version>2.7.12</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.isf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-modules-java8</artifactId>
-            <version>2.15.0</version>
+            <version>2.15.1</version>
             <type>pom</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
This release includes a fix for [CVE-2023-20883: Spring Boot Welcome Page DoS Vulnerability](http://spring.io/security/cve-2023-20883).

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.12

Matches change in: https://github.com/informatici/openhospital-core/pull/994 and https://github.com/informatici/openhospital-gui/pull/1774