### PR TITLE
Upgrade to Spring Boot 2.7.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.13</version>
+        <version>2.7.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.isf</groupId>


### PR DESCRIPTION
Upgrade to Spring Boot 2.7.14

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.14 

Matches changes in:
CORE: https://github.com/informatici/openhospital-core/pull/1044 
GUI: https://github.com/informatici/openhospital-gui/pull/1799