### PR TITLE
Chore: remove unnecessary call to `super()`

### DIFF
--- a/src/main/java/org/isf/login/dto/LoginResponse.java
+++ b/src/main/java/org/isf/login/dto/LoginResponse.java
@@ -36,7 +36,6 @@ public class LoginResponse {
 	private String username;
 
 	public LoginResponse() {
-		super();
 	}
 
 	public LoginResponse(String token, String username) {

--- a/src/main/java/org/isf/shared/pagination/PageInfoDTO.java
+++ b/src/main/java/org/isf/shared/pagination/PageInfoDTO.java
@@ -32,7 +32,6 @@ public class PageInfoDTO {
 	boolean hasNextPage;
 
 	public PageInfoDTO() {
-		super();
 	}
 
 	public int getSize() {


### PR DESCRIPTION
The class doesn't extend any base class so there is no `super()`.