### PR TITLE
Chore: single call instead of new() followed by addAll()

### DIFF
--- a/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
+++ b/src/main/java/org/isf/medicalstock/rest/StockMovementController.java
@@ -84,8 +84,7 @@ public class StockMovementController {
 	@PostMapping(value = "/stockmovements/charge", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> newMultipleChargingMovements(@RequestBody List<MovementDTO> movementDTOs, 
 			@RequestParam(name="ref", required=true) String referenceNumber) throws OHServiceException {
-		List<Movement> movements = new ArrayList<>();
-		movements.addAll(movMapper.map2ModelList(movementDTOs));
+		List<Movement> movements = new ArrayList<>(movMapper.map2ModelList(movementDTOs));
 		boolean done = movInsertingManager.newMultipleChargingMovements(movements, referenceNumber);
 		return ResponseEntity.status(HttpStatus.CREATED).body(done);
 	}
@@ -102,8 +101,7 @@ public class StockMovementController {
 	@PostMapping(value = "/stockmovements/discharge", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Boolean> newMultipleDischargingMovements(@RequestBody List<MovementDTO> movementDTOs, 
 			@RequestParam(name="ref", required=true) String referenceNumber) throws OHServiceException {
-		List<Movement> movements = new ArrayList<>();
-		movements.addAll(movMapper.map2ModelList(movementDTOs));
+		List<Movement> movements = new ArrayList<>(movMapper.map2ModelList(movementDTOs));
 		boolean done = movInsertingManager.newMultipleDischargingMovements(movements, referenceNumber);
 		return ResponseEntity.status(HttpStatus.CREATED).body(done);
 	}

--- a/src/main/java/org/isf/menu/rest/UserController.java
+++ b/src/main/java/org/isf/menu/rest/UserController.java
@@ -258,8 +258,7 @@ public class UserController {
 			@PathVariable("group_code") String code, 
 			@Valid @RequestBody List<UserMenuItemDTO> menusDTO) throws OHServiceException {
 		UserGroup group = loadUserGroup(code);
-        List<UserMenuItem> menus = new ArrayList<>();
-		menus.addAll(userMenuItemMapper.map2ModelList(menusDTO));
+		List<UserMenuItem> menus = new ArrayList<>(userMenuItemMapper.map2ModelList(menusDTO));
         boolean done = userManager.setGroupMenu(group, menus);
         if (done) {
         	return ResponseEntity.ok(done);

--- a/src/test/java/org/isf/accounting/rest/BillControllerTest.java
+++ b/src/test/java/org/isf/accounting/rest/BillControllerTest.java
@@ -316,8 +316,8 @@ public class BillControllerTest extends ControllerBaseTest {
 		FullBillDTO newFullBillDTO = FullBillDTOHelper.setup(patientMapper, billItemsMapper, billPaymentsMapper);
 		newFullBillDTO.getBill().setId(id);
 
-		List<BillItems> itemsDTOSExpected = new ArrayList<>();
-		itemsDTOSExpected.addAll(newFullBillDTO.getBillItems().stream().map(it -> billItemsMapper.map2Model(it)).collect(Collectors.toList()));
+		List<BillItems> itemsDTOSExpected = new ArrayList<>(
+				newFullBillDTO.getBillItems().stream().map(it -> billItemsMapper.map2Model(it)).collect(Collectors.toList()));
 
 		when(billManagerMock.getItems(id)).thenReturn(itemsDTOSExpected);
 


### PR DESCRIPTION
Use a single call to a parameterized constructor which simplifies the code.   For some collection types the replacement is more performant.