### PR TITLE
OP-1130 improve JPA methods - vactype package fix

### DIFF
--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -166,9 +166,6 @@ public class VaccineTypeControllerTest {
 		when(vaccineTypeBrowserManagerMock.findVaccineType(code))
 				.thenReturn(vaccineType);
 
-		when(vaccineTypeBrowserManagerMock.deleteVaccineType(vaccineTypeMapper.map2Model(body)))
-				.thenReturn(true);
-
 		String isDeleted = "true";
 		MvcResult result = this.mockMvc
 				.perform(delete(request, code))


### PR DESCRIPTION
See OP-1130

When incorporating the recent changes one of the test files in `vactype` failed to compile; this fixes the issue.

I don't understand how this wasn't caught sooner.