### PR TITLE
Improvement: separate build and openapi jobs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,6 +50,18 @@ jobs:
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
           
+  generate_openapi:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Copy artifacts from build job
+        run: |
+          cp -r ${{ needs.build.outputs.artifacts }}/* .
+          
       - name: Run API
         run: |
           cd target

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -62,13 +62,13 @@ jobs:
           echo ${{ steps.extract_branch.outputs.branch }}
 
       - name: Upload Maven
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: /root/.m2
           
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openhospital-api
           path: target

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run API
         run: |
-          cd openhospital-core/target
+          cd target
           java -cp "openhospital-api-0.1.0.jar:rsc/:static/" org.springframework.boot.loader.JarLauncher &
           sleep 60
           

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
           
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
-        
+
       - name: Set up Maven Cache
         uses: actions/setup-java@v1
         with:
@@ -25,15 +25,16 @@ jobs:
           cache: 'maven'
 
       - name: Install core dependencies
-        run: cd openhospital-core && mvn dependency:go-offline && cd ..
+        run: cd openhospital-core && mvn -q dependency:go-offline && cd ..
 
       - name: Install core
-        run: cd openhospital-core && mvn install -DskipTests=true && cd ..
+        run: cd openhospital-core && mvn -q install -DskipTests=true && cd ..
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
+#      - name: Debug Maven Local Repository [build]
+#        run: |
+#          echo "User's home directory: $HOME"
+#          echo "Contents of Maven Local Repository:"
+#          ls -R /root/.m2/repository || ls -R /root/.m2 || ls -R /root
           
       - name: Generate JWT Token
         id: jwt
@@ -57,13 +58,19 @@ jobs:
           cp rsc/log4j.properties.dist rsc/log4j.properties
           cp rsc/settings.properties.dist rsc/settings.properties
           sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
-          mvn install -DskipTests=true
+          mvn -q install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
 
-      - name: Upload artifacts
+      - name: Upload Maven
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
+          path: /root/.m2
+          
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: openhospital-api
           path: target
 
   generate_openapi:
@@ -85,14 +92,26 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: artifacts
+          path: /root/.m2
+          
+      - name: Download openhospital-api
+        uses: actions/download-artifact@v3
+        with:
+          name: openhospital-api
           path: target
-
+          
       - name: Run API
         run: |
           cd target
           java -cp "openhospital-api-0.1.0.jar:rsc/:static/" org.springframework.boot.loader.JarLauncher &
           sleep 60
-          
+
+#      - name: Debug Maven Local Repository [generate_openapi]
+#        run: |
+#          echo "User's home directory: $HOME"
+#          echo "Contents of Maven Local Repository:"
+#          ls -R /root/.m2/repository || ls -R /root/.m2 || ls -R /root
+
       - name: Generate OpenAPI yaml
         run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,11 +61,11 @@ jobs:
           mvn -q install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
 
-      - name: Upload Maven
-        uses: actions/upload-artifact@v4
+      - name: Upload Maven Cache
+        uses: actions/cache@v2
         with:
-          name: artifacts
           path: $RUNNER_WORKSPACE/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
           
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -88,11 +88,11 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
+      - name: Download Maven Cache
+        uses: actions/cache@v2
         with:
-          name: artifacts
           path: $RUNNER_WORKSPACE/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
           
       - name: Download openhospital-api
         uses: actions/download-artifact@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,13 @@ jobs:
           sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
-          
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: openhospital-core/target
+
   generate_openapi:
     needs: build
     runs-on: ubuntu-latest
@@ -58,13 +64,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Copy artifacts from build job
-        run: |
-          cp -r ${{ needs.build.outputs.artifacts }}/* .
-          
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: openhospital-core/target
+
       - name: Run API
         run: |
-          cd target
+          cd openhospital-core/target
           java -cp "openhospital-api-0.1.0.jar:rsc/:static/" org.springframework.boot.loader.JarLauncher &
           sleep 60
           

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,9 +13,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-
+          
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
+        
+      - name: Set up Maven Cache
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: 'maven'
+
+      - name: Install core dependencies
+        run: cd openhospital-core && mvn dependency:go-offline && cd ..
 
       - name: Install core
         run: cd openhospital-core && mvn install -DskipTests=true && cd ..
@@ -63,6 +73,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        
+      - name: Set up Maven Cache
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: 'maven'
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'zulu'
           cache: 'maven'
 
       - name: Install core dependencies
@@ -34,7 +34,7 @@ jobs:
 #        run: |
 #          echo "User's home directory: $HOME"
 #          echo "Contents of Maven Local Repository:"
-#          ls -R /root/.m2/repository || ls -R /root/.m2 || ls -R /root
+#          ls -R $RUNNER_WORKSPACE/.m2/repository || ls -R $RUNNER_WORKSPACE/.m2 || ls -R $RUNNER_WORKSPACE
           
       - name: Generate JWT Token
         id: jwt
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: /root/.m2
+          path: $RUNNER_WORKSPACE/.m2/repository
           
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -85,14 +85,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'zulu'
           cache: 'maven'
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
           name: artifacts
-          path: /root/.m2
+          path: $RUNNER_WORKSPACE/.m2/repository
           
       - name: Download openhospital-api
         uses: actions/download-artifact@v3
@@ -110,7 +110,7 @@ jobs:
 #        run: |
 #          echo "User's home directory: $HOME"
 #          echo "Contents of Maven Local Repository:"
-#          ls -R /root/.m2/repository || ls -R /root/.m2 || ls -R /root
+#          ls -R $RUNNER_WORKSPACE/.m2/repository || ls -R $RUNNER_WORKSPACE/.m2 || ls -R $RUNNER_WORKSPACE
 
       - name: Generate OpenAPI yaml
         run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,13 @@ jobs:
           sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
-          
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: target
+
   generate_openapi:
     needs: build
     runs-on: ubuntu-latest
@@ -58,10 +64,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Copy artifacts from build job
-        run: |
-          cp -r ${{ needs.build.outputs.artifacts }}/* .
-          
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: target
+
       - name: Run API
         run: |
           cd target


### PR DESCRIPTION
The aim is to have different checks for `build` (may success) and `openapi` generation (may fail)