### PR TITLE
Separate openapi check workflow from build one

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
 
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
@@ -25,47 +23,5 @@ jobs:
         with:
           java-version: 11
           
-      - name: Generate JWT Token
-        id: jwt
-        run: echo "token=7DlyD1SHR5pCa4HGgTLWSYm8YQ7oRL1wpPbxyjWyHU44vUrqrooRu3lHVFSXWChesc" >> $GITHUB_OUTPUT
-
-      - name: Store branch name
-        id: extract_branch
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
-          else
-            echo "branch=INVALID_EVENT_BRANCH_UNKNOWN" >> $GITHUB_OUTPUT
-          fi
-          
       - name: Build with Maven
-        run: |
-          cp rsc/application.properties.dist rsc/application.properties
-          cp rsc/database.properties.dist rsc/database.properties
-          cp rsc/log4j.properties.dist rsc/log4j.properties
-          cp rsc/settings.properties.dist rsc/settings.properties
-          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
-          mvn install -DskipTests=true
-          echo ${{ steps.extract_branch.outputs.branch }}
-          
-      - name: Run API
-        run: |
-          cd target
-          java -cp "openhospital-api-0.1.0.jar:rsc/:static/" org.springframework.boot.loader.JarLauncher &
-          sleep 60
-          
-      - name: Generate OpenAPI yaml
-        run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
-
-      - name: Running OpenAPI Spec breaking action
-        # run: |
-        #    tenant_id=`curl -d '{"tenant": "oh", "email": "community@open-hospital.org"}' https://register.oasdiff.com/tenants | jq -r .id`
-        #    curl -o output -X POST -F base=@openapi/oh.yaml -F revision=@openapi/oh_rev.yaml https://api.oasdiff.com/tenants/${tenant_id}/breaking-changes
-        #    cat output
-        uses: oasdiff/oasdiff-action/breaking@main
-        with:
-          base: openapi/oh.yaml
-          revision: openapi/oh_rev.yaml
-          fail-on-diff: true
+        run: mvn install -DskipTests=true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,9 @@ name: Java CI with Maven
 
 on: [push, pull_request]
 
+env:
+  MAVEN_ARGS: '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,14 +17,14 @@ jobs:
 
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
-
-      - name: Install core
-        run: cd openhospital-core && mvn install -DskipTests=true && cd ..
-
+        
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
+
+      - name: Install core
+        run: cd openhospital-core && mvn install -DskipTests=true && cd ..
           
       - name: Build with Maven
         run: mvn install -DskipTests=true

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: 'zulu'
+          java-version: 17
+          java-package: jdk
 
       - name: Install core
         run: cd openhospital-core && mvn install -DskipTests=true && cd ..

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,71 @@
+# This workflow will build and run the application for oasdiff/oasdiff-action/breaking@main
+# For more information see: https://github.com/oasdiff/oasdiff-action
+
+name: OpenAPI breaking changes check 
+
+on: [push, pull_request]
+
+jobs:
+  opeanpi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout core
+        run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
+
+      - name: Install core
+        run: cd openhospital-core && mvn -q install -DskipTests=true && cd ..
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          
+      - name: Generate JWT Token
+        id: jwt
+        run: echo "token=7DlyD1SHR5pCa4HGgTLWSYm8YQ7oRL1wpPbxyjWyHU44vUrqrooRu3lHVFSXWChesc" >> $GITHUB_OUTPUT
+
+      - name: Store branch name
+        id: extract_branch
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
+          else
+            echo "branch=INVALID_EVENT_BRANCH_UNKNOWN" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Build with Maven
+        run: |
+          cp rsc/application.properties.dist rsc/application.properties
+          cp rsc/database.properties.dist rsc/database.properties
+          cp rsc/log4j.properties.dist rsc/log4j.properties
+          cp rsc/settings.properties.dist rsc/settings.properties
+          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
+          mvn -q install -DskipTests=true
+          echo ${{ steps.extract_branch.outputs.branch }}
+          
+      - name: Run API
+        run: |
+          cd target
+          java -cp "openhospital-api-0.1.0.jar:rsc/:static/" org.springframework.boot.loader.JarLauncher &
+          sleep 60
+          
+      - name: Generate OpenAPI yaml
+        run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
+
+      - name: Running OpenAPI Spec breaking action
+        # run: |
+        #    tenant_id=`curl -d '{"tenant": "oh", "email": "community@open-hospital.org"}' https://register.oasdiff.com/tenants | jq -r .id`
+        #    curl -o output -X POST -F base=@openapi/oh.yaml -F revision=@openapi/oh_rev.yaml https://api.oasdiff.com/tenants/${tenant_id}/breaking-changes
+        #    cat output
+        uses: oasdiff/oasdiff-action/breaking@main
+        with:
+          base: openapi/oh.yaml
+          revision: openapi/oh_rev.yaml
+          fail-on-diff: true

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -5,6 +5,9 @@ name: OpenAPI breaking changes check
 
 on: [push, pull_request]
 
+env:
+  MAVEN_ARGS: '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+
 jobs:
   opeanpi:
     runs-on: ubuntu-latest
@@ -17,14 +20,14 @@ jobs:
       - name: Checkout core
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
 
-      - name: Install core
-        run: cd openhospital-core && mvn -q install -DskipTests=true && cd ..
-
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
-          
+
+      - name: Install core
+        run: cd openhospital-core && mvn install -DskipTests=true && cd ..
+
       - name: Generate JWT Token
         id: jwt
         run: echo "token=7DlyD1SHR5pCa4HGgTLWSYm8YQ7oRL1wpPbxyjWyHU44vUrqrooRu3lHVFSXWChesc" >> $GITHUB_OUTPUT
@@ -47,7 +50,7 @@ jobs:
           cp rsc/log4j.properties.dist rsc/log4j.properties
           cp rsc/settings.properties.dist rsc/settings.properties
           sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
-          mvn -q install -DskipTests=true
+          mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
           
       - name: Run API


### PR DESCRIPTION
This is an alternative solution to #421 in order to separate the `build` (may success) and `openapi` generation (may fail).