### PR TITLE
Chore: update maven.yml for JDK 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -18,13 +18,13 @@ jobs:
         run: git clone --depth=50 --branch=develop https://github.com/informatici/openhospital-core.git openhospital-core
 
       - name: Install core
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          java-package: jdk
         run: cd openhospital-core && mvn install -DskipTests=true && cd ..
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v1
-        with:
-          java-version: 17
-          
       - name: Generate JWT Token
         id: jwt
         run: echo "token=7DlyD1SHR5pCa4HGgTLWSYm8YQ7oRL1wpPbxyjWyHU44vUrqrooRu3lHVFSXWChesc" >> $GITHUB_OUTPUT
@@ -41,6 +41,11 @@ jobs:
           fi
           
       - name: Build with Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          java-package: jdk
         run: |
           cp rsc/application.properties.dist rsc/application.properties
           cp rsc/database.properties.dist rsc/database.properties


### PR DESCRIPTION
Note the failures of recent PRs; see https://github.com/informatici/openhospital-api/pull/426 for example complaining about JDK 17.