### PR TITLE
Chore: Hibernate renamed org.hibernate.type to org.hibernate.orm.jdbc.bind

### DIFF
--- a/rsc/log4j2-spring.properties.dist
+++ b/rsc/log4j2-spring.properties.dist
@@ -54,5 +54,5 @@ appender.jdbc.columnConfigs[2].isUnicode = false
 ##logger.hibernate-SQL.name=org.hibernate.SQL
 ##logger.hibernate-SQL.level=DEBUG
 ##
-##logger.hibernate-type.name=org.hibernate.type
+##logger.hibernate-type.name=org.hibernate.orm.jdbc.bind
 ##logger.hibernate-type.level=TRACE


### PR DESCRIPTION
Found this when trying to output sql parameters into the log