### PR TITLE
workflow: improve openapi with diff over formatted and sorted json

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -47,7 +47,6 @@ jobs:
           
       - name: Build with Maven
         run: |
-          cp rsc/application.properties.dist rsc/application.properties
           cp rsc/database.properties.dist rsc/database.properties
           cp rsc/log4j2-spring.properties.dist rsc/log4j2-spring.properties
           cp rsc/settings.properties.dist rsc/settings.properties

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -64,17 +64,43 @@ jobs:
       - name: Generate OpenAPI yaml
         run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
 
-      - name: Running OpenAPI Spec breaking action
+      # Step 1: Check if oh_rev.yaml differs from the committed version
+      - name: Install yq
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Convert to JSON and sort
+        run: |
+          yq eval -o=json openapi/oh_rev.yaml > oh_rev.json
+          yq eval -o=json openapi/oh.yaml > oh.json
+          jq --sort-keys . oh_rev.json > sorted_oh_rev.json
+          jq --sort-keys . oh.json > sorted_oh.json
+
+      - name: Compare JSON files
+        run: |
+          if diff -q sorted_oh_rev.yaml sorted_oh.yaml; then
+            echo "No changes in OpenAPI spec. Everything is up to date."
+          else
+            echo "The OpenAPI spec has changed. Please update the committed version."
+            exit 1
+          fi 
+
+      # Step 2: Check for breaking changes between committed oh.yaml and oh_rev.yaml
+      - name: Run OpenAPI Spec breaking action
         id: oasdiff
-        # run: |
-        #    tenant_id=`curl -d '{"tenant": "oh", "email": "community@open-hospital.org"}' https://register.oasdiff.com/tenants | jq -r .id`
-        #    curl -o output -X POST -F base=@openapi/oh.yaml -F revision=@openapi/oh_rev.yaml https://api.oasdiff.com/tenants/${tenant_id}/breaking-changes
-        #    cat output
         uses: oasdiff/oasdiff-action/breaking@main
         with:
-          base: openapi/oh.yaml
-          revision: openapi/oh_rev.yaml
-          #fail-on-diff: false
-      
-      #- name: show output
-      #  run: echo ${{ steps.oasdiff.outputs.breaking }}
+          base: openapi/oh.yaml # Committed version in the repository
+          revision: openapi/oh_rev.yaml # Generated version
+          # fail-on-diff: false
+
+      - name: Show breaking changes output
+        run: |
+          echo "Breaking changes output: ${{ steps.oasdiff.outputs.breaking }}"
+          if [[ "${{ steps.oasdiff.outputs.breaking }}" != "" ]]; then
+            echo "Warning: Breaking changes detected."
+          fi

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -50,9 +50,7 @@ jobs:
           cp rsc/database.properties.dist rsc/database.properties
           cp rsc/log4j2-spring.properties.dist rsc/log4j2-spring.properties
           cp rsc/settings.properties.dist rsc/settings.properties
-          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" \
-              -e "s/API_HOST/localhost/g" \ 
-              -e "s/API_PORT/8080/g" rsc/application.properties.dist > rsc/application.properties
+          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" -e "s/API_HOST/localhost/g" -e "s/API_PORT/8080/g" rsc/application.properties.dist > rsc/application.properties
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
           

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -52,6 +52,8 @@ jobs:
           cp rsc/log4j2-spring.properties.dist rsc/log4j2-spring.properties
           cp rsc/settings.properties.dist rsc/settings.properties
           sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
+          sed -i "s/API_HOST/localhost/g" $(OH_APPLICATION_PROPERTIES)
+          sed -i "s/API_PORT/8080/g" $(OH_APPLICATION_PROPERTIES)
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
           

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -80,6 +80,7 @@ jobs:
           jq --sort-keys . oh.json > sorted_oh.json
 
       - name: Compare JSON files
+        if: github.event_name == 'pull_request'
         run: |
           if diff sorted_oh_rev.json sorted_oh.json; then
             echo "No changes in OpenAPI spec. Everything is up to date."

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Compare JSON files
         run: |
-          if diff -q sorted_oh_rev.json sorted_oh.json; then
+          if diff sorted_oh_rev.json sorted_oh.json; then
             echo "No changes in OpenAPI spec. Everything is up to date."
           else
             echo "The OpenAPI spec has changed. Please update the committed version."

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Compare JSON files
         run: |
-          if diff -q sorted_oh_rev.yaml sorted_oh.yaml; then
+          if diff -q sorted_oh_rev.json sorted_oh.json; then
             echo "No changes in OpenAPI spec. Everything is up to date."
           else
             echo "The OpenAPI spec has changed. Please update the committed version."

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -51,9 +51,9 @@ jobs:
           cp rsc/database.properties.dist rsc/database.properties
           cp rsc/log4j2-spring.properties.dist rsc/log4j2-spring.properties
           cp rsc/settings.properties.dist rsc/settings.properties
-          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" rsc/application.properties.dist > rsc/application.properties
-          sed -i "s/API_HOST/localhost/g" $(OH_APPLICATION_PROPERTIES)
-          sed -i "s/API_PORT/8080/g" $(OH_APPLICATION_PROPERTIES)
+          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" \
+              -e "s/API_HOST/localhost/g" \ 
+              -e "s/API_PORT/8080/g" rsc/application.properties.dist > rsc/application.properties
           mvn install -DskipTests=true
           echo ${{ steps.extract_branch.outputs.branch }}
           


### PR DESCRIPTION
This PR introduces improvements to the GitHub Actions workflow by normalizing YAML file comparisons, ensuring consistent formatting across environments.

- use `yq` to format (normalize across OS) and convert the yml files to json
- use `jq` to sort (same way across OS) the json before diff
- use `diff` to spot changes and warn if `oh.yaml` needs to be update along with the code in the PR (step 1)
- check for breaking changes remains the same as before (step 2)

 