### PR TITLE
OH2-395 | Add endpoint to update user group permissions accepting list of permissions ids

### DIFF
--- a/.ide-settings/idea/OpenHospital-code-style-configuration.xml
+++ b/.ide-settings/idea/OpenHospital-code-style-configuration.xml
@@ -1,80 +1,80 @@
 <code_scheme name="Open Hospital profile" version="174">
-  <option name="RIGHT_MARGIN" value="160" />
-  <option name="FORMATTER_TAGS_ENABLED" value="false" />
-  <JavaCodeStyleSettings>
-    <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true" />
-    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-      <value />
-    </option>
-    <option name="IMPORT_LAYOUT_TABLE">
-      <value>
-        <package name="" withSubpackages="true" static="true" />
-        <emptyLine />
-        <package name="java" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="javax" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="jakarta" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="org" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="com" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="liquibase" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="" withSubpackages="true" static="false" />
-      </value>
-    </option>
-    <option name="ALIGN_MULTILINE_RECORDS" value="false" />
-    <option name="ALIGN_TYPES_IN_MULTI_CATCH" value="false" />
-    <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
-    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
-    <option name="JD_ADD_BLANK_AFTER_DESCRIPTION" value="false" />
-    <option name="JD_P_AT_EMPTY_LINES" value="false" />
-    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
-  </JavaCodeStyleSettings>
-  <editorconfig>
-    <option name="ENABLED" value="false" />
-  </editorconfig>
-  <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="160" />
-    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
-    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
-    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="BLANK_LINES_AFTER_ANONYMOUS_CLASS_HEADER" value="1" />
-    <option name="INDENT_CASE_FROM_SWITCH" value="false" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
-    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="RESOURCE_LIST_WRAP" value="5" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="5" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="ASSERT_STATEMENT_COLON_ON_NEXT_LINE" value="true" />
-    <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
-    <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="16" />
-      <option name="USE_TAB_CHARACTER" value="true" />
-    </indentOptions>
-  </codeStyleSettings>
+    <option name="RIGHT_MARGIN" value="160"/>
+    <option name="FORMATTER_TAGS_ENABLED" value="false"/>
+    <JavaCodeStyleSettings>
+        <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true"/>
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+        <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+            <value/>
+        </option>
+        <option name="IMPORT_LAYOUT_TABLE">
+            <value>
+                <package name="" withSubpackages="true" static="true"/>
+                <emptyLine/>
+                <package name="java" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="javax" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="jakarta" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="org" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="com" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="liquibase" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="" withSubpackages="true" static="false"/>
+            </value>
+        </option>
+        <option name="ALIGN_MULTILINE_RECORDS" value="false"/>
+        <option name="ALIGN_TYPES_IN_MULTI_CATCH" value="false"/>
+        <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+        <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+        <option name="JD_ADD_BLANK_AFTER_DESCRIPTION" value="false"/>
+        <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+        <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true"/>
+    </JavaCodeStyleSettings>
+    <editorconfig>
+        <option name="ENABLED" value="false"/>
+    </editorconfig>
+    <codeStyleSettings language="JAVA">
+        <option name="RIGHT_MARGIN" value="160"/>
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false"/>
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1"/>
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="BLANK_LINES_AROUND_METHOD" value="0"/>
+        <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0"/>
+        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+        <option name="BLANK_LINES_AFTER_ANONYMOUS_CLASS_HEADER" value="1"/>
+        <option name="INDENT_CASE_FROM_SWITCH" value="false"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true"/>
+        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="RESOURCE_LIST_WRAP" value="5"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="5"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="WRAP_COMMENTS" value="true"/>
+        <option name="ASSERT_STATEMENT_COLON_ON_NEXT_LINE" value="true"/>
+        <option name="VARIABLE_ANNOTATION_WRAP" value="2"/>
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="USE_TAB_CHARACTER" value="true"/>
+        </indentOptions>
+    </codeStyleSettings>
 </code_scheme>

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -398,6 +398,34 @@ paths:
           description: No Content
       security:
         - bearerAuth: [ ]
+  /usergroups/{group_code}/permissions:
+    put:
+      tags:
+        - User Groups
+      operationId: updateGroupPermissions
+      parameters:
+        - name: group_code
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupPermissionsDTO'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PermissionDTO'
+      security:
+        - bearerAuth: [ ]
   /suppliers:
     get:
       tags:
@@ -6146,9 +6174,9 @@ components:
           example: 0
         opd:
           type: boolean
-        female:
-          type: boolean
         male:
+          type: boolean
+        female:
           type: boolean
         pharmacy:
           type: boolean
@@ -6495,6 +6523,19 @@ components:
             type: string
         userGroup:
           $ref: '#/components/schemas/UserGroupDTO'
+    GroupPermissionsDTO:
+      type: object
+      properties:
+        permissions:
+          type: array
+          description: List of permissions' ids
+          example:
+            - 48
+            - 24
+          items:
+            type: integer
+            description: List of permissions' ids
+            format: int32
     SupplierDTO:
       required:
         - supId
@@ -6815,11 +6856,11 @@ components:
           type: string
           description: "Flag record deleted, values are 'Y' OR 'N' "
           example: "N"
+        fhu:
+          type: string
         yprog:
           type: integer
           format: int32
-        fhu:
-          type: string
       description: The admission
     AdmissionTypeDTO:
       required:
@@ -7830,9 +7871,9 @@ components:
           $ref: '#/components/schemas/PatientProfilePhoto'
         patientConsensus:
           $ref: '#/components/schemas/PatientConsensus'
-        searchString:
-          type: string
         informations:
+          type: string
+        searchString:
           type: string
     PatientConsensus:
       type: object
@@ -7929,6 +7970,8 @@ components:
                         type: object
                     family:
                       type: string
+                    plain:
+                      type: boolean
                     fontName:
                       type: string
                     transform:
@@ -7992,8 +8035,6 @@ components:
                       type: array
                       items:
                         type: object
-                    plain:
-                      type: boolean
                 fontMetrics:
                   type: object
                   properties:
@@ -8014,6 +8055,8 @@ components:
                             type: object
                         family:
                           type: string
+                        plain:
+                          type: boolean
                         fontName:
                           type: string
                         transform:
@@ -8077,8 +8120,9 @@ components:
                           type: array
                           items:
                             type: object
-                        plain:
-                          type: boolean
+                    height:
+                      type: integer
+                      format: int32
                     ascent:
                       type: integer
                       format: int32
@@ -8086,9 +8130,6 @@ components:
                       type: integer
                       format: int32
                     leading:
-                      type: integer
-                      format: int32
-                    height:
                       type: integer
                       format: int32
                     maxDescent:
@@ -8200,22 +8241,22 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        width:
+                          type: number
+                          format: double
                         minX:
                           type: number
                           format: double
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         height:
                           type: number
                           format: double
-                        x:
+                        "y":
                           type: number
                           format: double
-                        "y":
+                        x:
                           type: number
                           format: double
                         maxX:
@@ -8235,22 +8276,22 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        width:
+                          type: number
+                          format: double
                         minX:
                           type: number
                           format: double
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         height:
                           type: number
                           format: double
-                        x:
+                        "y":
                           type: number
                           format: double
-                        "y":
+                        x:
                           type: number
                           format: double
                         maxX:
@@ -8360,22 +8401,22 @@ components:
                           properties:
                             empty:
                               type: boolean
+                            width:
+                              type: number
+                              format: double
                             minX:
                               type: number
                               format: double
                             minY:
                               type: number
                               format: double
-                            width:
-                              type: number
-                              format: double
                             height:
                               type: number
                               format: double
-                            x:
+                            "y":
                               type: number
                               format: double
-                            "y":
+                            x:
                               type: number
                               format: double
                             maxX:
@@ -8395,22 +8436,22 @@ components:
                           properties:
                             empty:
                               type: boolean
+                            width:
+                              type: number
+                              format: double
                             minX:
                               type: number
                               format: double
                             minY:
                               type: number
                               format: double
-                            width:
-                              type: number
-                              format: double
                             height:
                               type: number
                               format: double
-                            x:
+                            "y":
                               type: number
                               format: double
-                            "y":
+                            x:
                               type: number
                               format: double
                             maxX:
@@ -8449,22 +8490,22 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        width:
+                          type: number
+                          format: double
                         minX:
                           type: number
                           format: double
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         height:
                           type: number
                           format: double
-                        x:
+                        "y":
                           type: number
                           format: double
-                        "y":
+                        x:
                           type: number
                           format: double
                         maxX:
@@ -8519,22 +8560,22 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        width:
+                          type: number
+                          format: double
                         minX:
                           type: number
                           format: double
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         height:
                           type: number
                           format: double
-                        x:
+                        "y":
                           type: number
                           format: double
-                        "y":
+                        x:
                           type: number
                           format: double
                         maxX:
@@ -8554,22 +8595,22 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        width:
+                          type: number
+                          format: double
                         minX:
                           type: number
                           format: double
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         height:
                           type: number
                           format: double
-                        x:
+                        "y":
                           type: number
                           format: double
-                        "y":
+                        x:
                           type: number
                           format: double
                         maxX:

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -6903,11 +6903,11 @@ components:
           type: string
           description: "Flag record deleted, values are 'Y' OR 'N' "
           example: "N"
+        fhu:
+          type: string
         yprog:
           type: integer
           format: int32
-        fhu:
-          type: string
       description: The admission
     AdmissionTypeDTO:
       required:
@@ -7918,9 +7918,9 @@ components:
           $ref: '#/components/schemas/PatientProfilePhoto'
         patientConsensus:
           $ref: '#/components/schemas/PatientConsensus'
-        searchString:
-          type: string
         informations:
+          type: string
+        searchString:
           type: string
     PatientConsensus:
       type: object
@@ -8017,8 +8017,6 @@ components:
                         type: object
                     family:
                       type: string
-                    plain:
-                      type: boolean
                     fontName:
                       type: string
                     transform:
@@ -8082,6 +8080,8 @@ components:
                       type: array
                       items:
                         type: object
+                    plain:
+                      type: boolean
                 fontMetrics:
                   type: object
                   properties:
@@ -8102,8 +8102,6 @@ components:
                             type: object
                         family:
                           type: string
-                        plain:
-                          type: boolean
                         fontName:
                           type: string
                         transform:
@@ -8167,9 +8165,8 @@ components:
                           type: array
                           items:
                             type: object
-                    height:
-                      type: integer
-                      format: int32
+                        plain:
+                          type: boolean
                     ascent:
                       type: integer
                       format: int32
@@ -8190,11 +8187,6 @@ components:
                     fontRenderContext:
                       type: object
                       properties:
-                        antiAliased:
-                          type: boolean
-                        transformType:
-                          type: integer
-                          format: int32
                         transform:
                           type: object
                           properties:
@@ -8238,6 +8230,11 @@ components:
                           type: object
                         transformed:
                           type: boolean
+                        antiAliased:
+                          type: boolean
+                        transformType:
+                          type: integer
+                          format: int32
                     maxAscent:
                       type: integer
                       format: int32
@@ -8246,6 +8243,9 @@ components:
                       format: int32
                       deprecated: true
                     maxAdvance:
+                      type: integer
+                      format: int32
+                    height:
                       type: integer
                       format: int32
                 clipBounds:
@@ -8288,24 +8288,6 @@ components:
                       properties:
                         empty:
                           type: boolean
-                        height:
-                          type: number
-                          format: double
-                        minX:
-                          type: number
-                          format: double
-                        minY:
-                          type: number
-                          format: double
-                        width:
-                          type: number
-                          format: double
-                        x:
-                          type: number
-                          format: double
-                        "y":
-                          type: number
-                          format: double
                         maxX:
                           type: number
                           format: double
@@ -8316,6 +8298,24 @@ components:
                           type: number
                           format: double
                         centerY:
+                          type: number
+                          format: double
+                        width:
+                          type: number
+                          format: double
+                        height:
+                          type: number
+                          format: double
+                        minX:
+                          type: number
+                          format: double
+                        minY:
+                          type: number
+                          format: double
+                        x:
+                          type: number
+                          format: double
+                        "y":
                           type: number
                           format: double
                     rect:
@@ -8323,24 +8323,6 @@ components:
                       properties:
                         empty:
                           type: boolean
-                        height:
-                          type: number
-                          format: double
-                        minX:
-                          type: number
-                          format: double
-                        minY:
-                          type: number
-                          format: double
-                        width:
-                          type: number
-                          format: double
-                        x:
-                          type: number
-                          format: double
-                        "y":
-                          type: number
-                          format: double
                         maxX:
                           type: number
                           format: double
@@ -8353,13 +8335,25 @@ components:
                         centerY:
                           type: number
                           format: double
+                        width:
+                          type: number
+                          format: double
+                        height:
+                          type: number
+                          format: double
+                        minX:
+                          type: number
+                          format: double
+                        minY:
+                          type: number
+                          format: double
+                        x:
+                          type: number
+                          format: double
+                        "y":
+                          type: number
+                          format: double
                       writeOnly: true
-                    minX:
-                      type: number
-                      format: double
-                    minY:
-                      type: number
-                      format: double
                     maxX:
                       type: number
                       format: double
@@ -8370,6 +8364,12 @@ components:
                       type: number
                       format: double
                     centerY:
+                      type: number
+                      format: double
+                    minX:
+                      type: number
+                      format: double
+                    minY:
                       type: number
                       format: double
                 xormode:
@@ -8448,24 +8448,6 @@ components:
                           properties:
                             empty:
                               type: boolean
-                            height:
-                              type: number
-                              format: double
-                            minX:
-                              type: number
-                              format: double
-                            minY:
-                              type: number
-                              format: double
-                            width:
-                              type: number
-                              format: double
-                            x:
-                              type: number
-                              format: double
-                            "y":
-                              type: number
-                              format: double
                             maxX:
                               type: number
                               format: double
@@ -8476,6 +8458,24 @@ components:
                               type: number
                               format: double
                             centerY:
+                              type: number
+                              format: double
+                            width:
+                              type: number
+                              format: double
+                            height:
+                              type: number
+                              format: double
+                            minX:
+                              type: number
+                              format: double
+                            minY:
+                              type: number
+                              format: double
+                            x:
+                              type: number
+                              format: double
+                            "y":
                               type: number
                               format: double
                         rect:
@@ -8483,24 +8483,6 @@ components:
                           properties:
                             empty:
                               type: boolean
-                            height:
-                              type: number
-                              format: double
-                            minX:
-                              type: number
-                              format: double
-                            minY:
-                              type: number
-                              format: double
-                            width:
-                              type: number
-                              format: double
-                            x:
-                              type: number
-                              format: double
-                            "y":
-                              type: number
-                              format: double
                             maxX:
                               type: number
                               format: double
@@ -8513,13 +8495,25 @@ components:
                             centerY:
                               type: number
                               format: double
+                            width:
+                              type: number
+                              format: double
+                            height:
+                              type: number
+                              format: double
+                            minX:
+                              type: number
+                              format: double
+                            minY:
+                              type: number
+                              format: double
+                            x:
+                              type: number
+                              format: double
+                            "y":
+                              type: number
+                              format: double
                           writeOnly: true
-                        minX:
-                          type: number
-                          format: double
-                        minY:
-                          type: number
-                          format: double
                         maxX:
                           type: number
                           format: double
@@ -8532,11 +8526,32 @@ components:
                         centerY:
                           type: number
                           format: double
+                        minX:
+                          type: number
+                          format: double
+                        minY:
+                          type: number
+                          format: double
                     bounds2D:
                       type: object
                       properties:
                         empty:
                           type: boolean
+                        maxX:
+                          type: number
+                          format: double
+                        maxY:
+                          type: number
+                          format: double
+                        centerX:
+                          type: number
+                          format: double
+                        centerY:
+                          type: number
+                          format: double
+                        width:
+                          type: number
+                          format: double
                         height:
                           type: number
                           format: double
@@ -8546,25 +8561,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        width:
-                          type: number
-                          format: double
                         x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        maxX:
-                          type: number
-                          format: double
-                        maxY:
-                          type: number
-                          format: double
-                        centerX:
-                          type: number
-                          format: double
-                        centerY:
                           type: number
                           format: double
                 clipRect:
@@ -8607,24 +8607,6 @@ components:
                       properties:
                         empty:
                           type: boolean
-                        height:
-                          type: number
-                          format: double
-                        minX:
-                          type: number
-                          format: double
-                        minY:
-                          type: number
-                          format: double
-                        width:
-                          type: number
-                          format: double
-                        x:
-                          type: number
-                          format: double
-                        "y":
-                          type: number
-                          format: double
                         maxX:
                           type: number
                           format: double
@@ -8635,6 +8617,24 @@ components:
                           type: number
                           format: double
                         centerY:
+                          type: number
+                          format: double
+                        width:
+                          type: number
+                          format: double
+                        height:
+                          type: number
+                          format: double
+                        minX:
+                          type: number
+                          format: double
+                        minY:
+                          type: number
+                          format: double
+                        x:
+                          type: number
+                          format: double
+                        "y":
                           type: number
                           format: double
                     rect:
@@ -8642,24 +8642,6 @@ components:
                       properties:
                         empty:
                           type: boolean
-                        height:
-                          type: number
-                          format: double
-                        minX:
-                          type: number
-                          format: double
-                        minY:
-                          type: number
-                          format: double
-                        width:
-                          type: number
-                          format: double
-                        x:
-                          type: number
-                          format: double
-                        "y":
-                          type: number
-                          format: double
                         maxX:
                           type: number
                           format: double
@@ -8672,13 +8654,25 @@ components:
                         centerY:
                           type: number
                           format: double
+                        width:
+                          type: number
+                          format: double
+                        height:
+                          type: number
+                          format: double
+                        minX:
+                          type: number
+                          format: double
+                        minY:
+                          type: number
+                          format: double
+                        x:
+                          type: number
+                          format: double
+                        "y":
+                          type: number
+                          format: double
                       writeOnly: true
-                    minX:
-                      type: number
-                      format: double
-                    minY:
-                      type: number
-                      format: double
                     maxX:
                       type: number
                       format: double
@@ -8689,6 +8683,12 @@ components:
                       type: number
                       format: double
                     centerY:
+                      type: number
+                      format: double
+                    minX:
+                      type: number
+                      format: double
+                    minY:
                       type: number
                       format: double
                   deprecated: true
@@ -8756,9 +8756,9 @@ components:
         medical:
           type: integer
           format: int32
-        notify:
-          type: boolean
         sms:
+          type: boolean
+        notify:
           type: boolean
     TherapyDTO:
       type: object

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -426,6 +426,33 @@ paths:
                   $ref: '#/components/schemas/PermissionDTO'
       security:
         - bearerAuth: [ ]
+    patch:
+      tags:
+        - User Groups
+      operationId: replaceGroupPermissions
+      parameters:
+        - name: group_code
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupPermissionsDTO'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PermissionDTO'
+      security:
+        - bearerAuth: [ ]
   /suppliers:
     get:
       tags:
@@ -6174,9 +6201,9 @@ components:
           example: 0
         opd:
           type: boolean
-        male:
-          type: boolean
         female:
+          type: boolean
+        male:
           type: boolean
         pharmacy:
           type: boolean
@@ -6856,11 +6883,11 @@ components:
           type: string
           description: "Flag record deleted, values are 'Y' OR 'N' "
           example: "N"
-        fhu:
-          type: string
         yprog:
           type: integer
           format: int32
+        fhu:
+          type: string
       description: The admission
     AdmissionTypeDTO:
       required:
@@ -7871,9 +7898,9 @@ components:
           $ref: '#/components/schemas/PatientProfilePhoto'
         patientConsensus:
           $ref: '#/components/schemas/PatientConsensus'
-        informations:
-          type: string
         searchString:
+          type: string
+        informations:
           type: string
     PatientConsensus:
       type: object
@@ -8143,6 +8170,11 @@ components:
                     fontRenderContext:
                       type: object
                       properties:
+                        antiAliased:
+                          type: boolean
+                        transformType:
+                          type: integer
+                          format: int32
                         transform:
                           type: object
                           properties:
@@ -8186,11 +8218,6 @@ components:
                           type: object
                         transformed:
                           type: boolean
-                        antiAliased:
-                          type: boolean
-                        transformType:
-                          type: integer
-                          format: int32
                     maxAscent:
                       type: integer
                       format: int32
@@ -8241,6 +8268,9 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        height:
+                          type: number
+                          format: double
                         width:
                           type: number
                           format: double
@@ -8250,13 +8280,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        height:
+                        x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        x:
                           type: number
                           format: double
                         maxX:
@@ -8276,6 +8303,9 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        height:
+                          type: number
+                          format: double
                         width:
                           type: number
                           format: double
@@ -8285,13 +8315,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        height:
+                        x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        x:
                           type: number
                           format: double
                         maxX:
@@ -8401,6 +8428,9 @@ components:
                           properties:
                             empty:
                               type: boolean
+                            height:
+                              type: number
+                              format: double
                             width:
                               type: number
                               format: double
@@ -8410,13 +8440,10 @@ components:
                             minY:
                               type: number
                               format: double
-                            height:
+                            x:
                               type: number
                               format: double
                             "y":
-                              type: number
-                              format: double
-                            x:
                               type: number
                               format: double
                             maxX:
@@ -8436,6 +8463,9 @@ components:
                           properties:
                             empty:
                               type: boolean
+                            height:
+                              type: number
+                              format: double
                             width:
                               type: number
                               format: double
@@ -8445,13 +8475,10 @@ components:
                             minY:
                               type: number
                               format: double
-                            height:
+                            x:
                               type: number
                               format: double
                             "y":
-                              type: number
-                              format: double
-                            x:
                               type: number
                               format: double
                             maxX:
@@ -8490,6 +8517,9 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        height:
+                          type: number
+                          format: double
                         width:
                           type: number
                           format: double
@@ -8499,13 +8529,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        height:
+                        x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        x:
                           type: number
                           format: double
                         maxX:
@@ -8560,6 +8587,9 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        height:
+                          type: number
+                          format: double
                         width:
                           type: number
                           format: double
@@ -8569,13 +8599,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        height:
+                        x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        x:
                           type: number
                           format: double
                         maxX:
@@ -8595,6 +8622,9 @@ components:
                       properties:
                         empty:
                           type: boolean
+                        height:
+                          type: number
+                          format: double
                         width:
                           type: number
                           format: double
@@ -8604,13 +8634,10 @@ components:
                         minY:
                           type: number
                           format: double
-                        height:
+                        x:
                           type: number
                           format: double
                         "y":
-                          type: number
-                          format: double
-                        x:
                           type: number
                           format: double
                         maxX:
@@ -8709,9 +8736,9 @@ components:
         medical:
           type: integer
           format: int32
-        notify:
-          type: boolean
         sms:
+          type: boolean
+        notify:
           type: boolean
     TherapyDTO:
       type: object

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -252,7 +252,7 @@ public class SecurityConfig {
 			// grouppermission
 			.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
 			.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
-			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.update")
+			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**").access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
 			.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
 			// usergroups
 			.requestMatchers(HttpMethod.POST, "/usergroups/**").hasAuthority("usergroups.create")

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -21,8 +21,6 @@
  */
 package org.isf.config;
 
-import java.util.List;
-
 import org.isf.permissions.manager.PermissionManager;
 import org.isf.security.ApiAuditorAwareImpl;
 import org.isf.security.CustomLogoutHandler;
@@ -54,6 +52,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -108,234 +108,234 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-						.and().cors()
-						.and().csrf().disable().authorizeRequests()
-						// .expressionHandler(webExpressionHandler())
-						.and().exceptionHandling()
-						// .accessDeniedHandler(accessDeniedHandler)
-						.authenticationEntryPoint(restAuthenticationEntryPoint)
-						.and().authorizeRequests().requestMatchers("/auth/**").permitAll()
+			.and().cors()
+			.and().csrf().disable().authorizeRequests()
+			// .expressionHandler(webExpressionHandler())
+			.and().exceptionHandling()
+			// .accessDeniedHandler(accessDeniedHandler)
+			.authenticationEntryPoint(restAuthenticationEntryPoint)
+			.and().authorizeRequests().requestMatchers("/auth/**").permitAll()
 
-						// admissions
-						.requestMatchers(HttpMethod.POST, "/admissions/**").hasAuthority("admissions.create")
-						.requestMatchers(HttpMethod.GET, "/admissions/**").hasAnyAuthority("admissions.read")
-						.requestMatchers(HttpMethod.PUT, "/admissions/**").hasAuthority("admissions.update")
-						.requestMatchers(HttpMethod.DELETE, "/admissions/**").hasAuthority("admissions.delete")
-						// admissiontypes
-						.requestMatchers(HttpMethod.POST, "/admissiontypes/**").hasAuthority("admissiontypes.create")
-						.requestMatchers(HttpMethod.GET, "/admissiontypes/**").hasAnyAuthority("admissiontypes.read")
-						.requestMatchers(HttpMethod.PUT, "/admissiontypes/**").hasAuthority("admissiontypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/admissiontypes/**").hasAuthority("admissiontypes.delete")
-						// age types
-						.requestMatchers(HttpMethod.GET, "/agetypes/**").hasAnyAuthority("agetypes.read")
-						.requestMatchers(HttpMethod.PUT, "/agetypes/**").hasAuthority("agetypes.update")
-						// dischargetypes
-						.requestMatchers(HttpMethod.POST, "/dischargetypes/**").hasAuthority("dischargetypes.create")
-						.requestMatchers(HttpMethod.GET, "/dischargetypes/**").hasAnyAuthority("dischargetypes.read")
-						.requestMatchers(HttpMethod.PUT, "/dischargetypes/**").hasAuthority("dischargetypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/dischargetypes/**").hasAuthority("dischargetypes.delete")
-						// diseases
-						.requestMatchers(HttpMethod.POST, "/diseases/**").hasAuthority("diseases.create")
-						.requestMatchers(HttpMethod.GET, "/diseases/**").hasAnyAuthority("diseases.read")
-						.requestMatchers(HttpMethod.PUT, "/diseases/**").hasAuthority("diseases.update")
-						.requestMatchers(HttpMethod.DELETE, "/diseases/**").hasAuthority("diseases.delete")
-						// diseasetypes
-						.requestMatchers(HttpMethod.POST, "/diseasetypes/**").hasAuthority("diseasetypes.create")
-						.requestMatchers(HttpMethod.GET, "/diseasetypes/**").hasAnyAuthority("diseasetypes.read")
-						.requestMatchers(HttpMethod.PUT, "/diseasetypes/**").hasAuthority("diseasetypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/diseasetypes/**").hasAuthority("diseasetypes.delete")
-						// deliveryresulttype
-						.requestMatchers(HttpMethod.POST, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.create")
-						.requestMatchers(HttpMethod.GET, "/deliveryresulttypes/**").hasAnyAuthority("deliveryresulttypes.read")
-						.requestMatchers(HttpMethod.PUT, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.delete")
-						// deliverytypes
-						.requestMatchers(HttpMethod.POST, "/deliverytypes/**").hasAuthority("deliverytypes.create")
-						.requestMatchers(HttpMethod.GET, "/deliverytypes/**").hasAnyAuthority("deliverytypes.read")
-						.requestMatchers(HttpMethod.PUT, "/deliverytypes/**").hasAuthority("deliverytypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/deliverytypes/**").hasAuthority("deliverytypes.delete")
-						// exams
-						.requestMatchers(HttpMethod.POST, "/exams/**").hasAuthority("exams.create")
-						.requestMatchers(HttpMethod.GET, "/exams/**").hasAnyAuthority("exams.read")
-						.requestMatchers(HttpMethod.PUT, "/exams/**").hasAuthority("exams.update")
-						.requestMatchers(HttpMethod.DELETE, "/exams/**").hasAuthority("exams.delete")
-						// examrows
-						.requestMatchers(HttpMethod.POST, "/examrows/**").hasAuthority("examrows.create")
-						.requestMatchers(HttpMethod.GET, "/examrows/**").hasAnyAuthority("examrows.read")
-						.requestMatchers(HttpMethod.PUT, "/examrows/**").hasAuthority("examrows.update")
-						.requestMatchers(HttpMethod.DELETE, "/examrows/**").hasAuthority("examrows.delete")
-						// examinations
-						.requestMatchers(HttpMethod.POST, "/examinations/**").hasAuthority("examinations.create")
-						.requestMatchers(HttpMethod.GET, "/examinations/**").hasAnyAuthority("examinations.read")
-						.requestMatchers(HttpMethod.PUT, "/examinations/**").hasAuthority("examinations.update")
-						.requestMatchers(HttpMethod.DELETE, "/examinations/**").hasAuthority("examinations.delete")
-						// examtypes
-						.requestMatchers(HttpMethod.POST, "/examtypes/**").hasAuthority("examtypes.create")
-						.requestMatchers(HttpMethod.GET, "/examtypes/**").hasAnyAuthority("examtypes.read")
-						.requestMatchers(HttpMethod.PUT, "/examtypes/**").hasAuthority("examtypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/examtypes/**").hasAuthority("examtypes.delete")
-						// hospitals
-						.requestMatchers(HttpMethod.POST, "/hospitals/**").hasAuthority("hospitals.create")
-						// .requestMatchers(HttpMethod.GET, "/hospitals/**").hasAnyAuthority("hospital.read") to anyone
-						.requestMatchers(HttpMethod.PUT, "/hospitals/**").hasAuthority("hospitals.update")
-						.requestMatchers(HttpMethod.DELETE, "/hospitals/**").hasAuthority("hospitals.delete")
-						// laboratories
-						.requestMatchers(HttpMethod.POST, "/laboratories/**").hasAuthority("laboratories.create")
-						.requestMatchers(HttpMethod.GET, "/laboratories/**").hasAnyAuthority("laboratories.read")
-						.requestMatchers(HttpMethod.PUT, "/laboratories/**").hasAuthority("laboratories.update")
-						.requestMatchers(HttpMethod.DELETE, "/laboratories/**").hasAuthority("laboratories.delete")
-						// malnutrition
-						.requestMatchers(HttpMethod.POST, "/malnutritions/**").hasAuthority("malnutritions.create")
-						.requestMatchers(HttpMethod.GET, "/malnutritions/**").hasAuthority("malnutritions.read")
-						.requestMatchers(HttpMethod.PUT, "/malnutritions/**").hasAuthority("malnutritions.update")
-						.requestMatchers(HttpMethod.DELETE, "/malnutritions/**").hasAuthority("malnutritions.delete")
-						// medicals
-						.requestMatchers(HttpMethod.POST, "/medicals/**").hasAuthority("medicals.create")
-						.requestMatchers(HttpMethod.GET, "/medicals/**").hasAuthority("medicals.read")
-						.requestMatchers(HttpMethod.PUT, "/medicals/**").hasAuthority("medicals.update")
-						.requestMatchers(HttpMethod.DELETE, "/medicals/**").hasAuthority("medicals.delete")
-						// medicalstock
-						.requestMatchers(HttpMethod.POST, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.create")
-						.requestMatchers(HttpMethod.GET, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.read")
-						.requestMatchers(HttpMethod.PUT, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.update")
-						.requestMatchers(HttpMethod.DELETE, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.delete")
-						// medicalstockward
-						.requestMatchers(HttpMethod.POST, "/medicalstockward/**").hasAuthority("medicalstockward.create")
-						.requestMatchers(HttpMethod.GET, "/medicalstockward/**").hasAuthority("medicalstockward.read")
-						.requestMatchers(HttpMethod.PUT, "/medicalstockward/**").hasAuthority("medicalstockward.update")
-						.requestMatchers(HttpMethod.DELETE, "/medicalstockward/**").hasAuthority("medicalstockward.delete")
-						// medicalstockmovtype
-						.requestMatchers(HttpMethod.POST, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.create")
-						.requestMatchers(HttpMethod.GET, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.read")
-						.requestMatchers(HttpMethod.PUT, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.delete")
-						// medicaltype
-						.requestMatchers(HttpMethod.POST, "/medicaltypes/**").hasAuthority("medicaltypes.create")
-						.requestMatchers(HttpMethod.GET, "/medicaltypes/**").hasAuthority("medicaltypes.read")
-						.requestMatchers(HttpMethod.PUT, "/medicaltypes/**").hasAuthority("medicaltypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/medicaltypes/**").hasAuthority("medicaltypes.delete")
-						// opd
-						.requestMatchers(HttpMethod.POST, "/opds/**").hasAuthority("opds.create")
-						.requestMatchers(HttpMethod.GET, "/opds/**").hasAnyAuthority("opds.read")
-						.requestMatchers(HttpMethod.PUT, "/opds/**").hasAuthority("opds.update")
-						.requestMatchers(HttpMethod.DELETE, "/opds/**").hasAuthority("opds.delete")
-						// operations
-						.requestMatchers(HttpMethod.POST, "/operations/**").hasAuthority("operations.create")
-						.requestMatchers(HttpMethod.GET, "/operations/**").hasAnyAuthority("operations.read")
-						.requestMatchers(HttpMethod.PUT, "/operations/**").hasAuthority("operations.update")
-						.requestMatchers(HttpMethod.DELETE, "/operations/**").hasAuthority("operations.delete")
-						// operation types
-						.requestMatchers(HttpMethod.POST, "/operationtypes/**").hasAuthority("operationtypes.create")
-						.requestMatchers(HttpMethod.GET, "/operationtypes/**").hasAnyAuthority("operationtypes.read")
-						.requestMatchers(HttpMethod.PUT, "/operationtypes/**").hasAuthority("operationtypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/operationtypes/**").hasAuthority("operationtypes.delete")
-						// patientconsensus
-						.requestMatchers(HttpMethod.POST, "/patientconsensus/**").hasAuthority("patientconsensus.create")
-						.requestMatchers(HttpMethod.GET, "/patientconsensus/**").hasAuthority("patientconsensus.read")
-						.requestMatchers(HttpMethod.PUT, "/patientconsensus/**").hasAuthority("patientconsensus.update")
-						.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
-						// patients
-						.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
-						.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
-						.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")
-						.requestMatchers(HttpMethod.DELETE, "/patients/**").hasAuthority("patients.delete")
-						// patientvaccines
-						.requestMatchers(HttpMethod.POST, "/patientvaccines/**").hasAuthority("patientvaccines.create")
-						.requestMatchers(HttpMethod.GET, "/patientvaccines/**").hasAnyAuthority("patientvaccines.read")
-						.requestMatchers(HttpMethod.PUT, "/patientvaccines/**").hasAuthority("patientvaccines.update")
-						.requestMatchers(HttpMethod.DELETE, "/patientvaccines/**").hasAuthority("patientvaccines.delete")
-						// permission
-						.requestMatchers(HttpMethod.POST, "/permissions/**").hasAuthority("permissions.create")
-						.requestMatchers(HttpMethod.GET, "/permissions/**").hasAuthority("permissions.read")
-						.requestMatchers(HttpMethod.PUT, "/permissions/**").hasAuthority("permissions.update")
-						.requestMatchers(HttpMethod.DELETE, "/permissions/**").hasAuthority("permissions.delete")
-						// grouppermission
-						.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
-						.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
-						.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**")
-						.access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
-						.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
-						// usergroups
-						.requestMatchers(HttpMethod.POST, "/usergroups/**").hasAuthority("usergroups.create")
-						.requestMatchers(HttpMethod.GET, "/usergroups/**").hasAuthority("usergroups.read")
-						.requestMatchers(HttpMethod.PUT, "/usergroups/**").hasAuthority("usergroups.update")
-						.requestMatchers(HttpMethod.DELETE, "/usergroups/**").hasAuthority("usergroups.delete")
-						// user
-						.requestMatchers("/users/me").authenticated()
-						.requestMatchers(HttpMethod.POST, "/users").hasAuthority("users.create")
-						.requestMatchers(HttpMethod.GET, "/users/**").hasAuthority("users.read")
-						.requestMatchers(HttpMethod.PUT, "/users/{username}").hasAuthority("users.update")
-						.requestMatchers(HttpMethod.DELETE, "/users/**").hasAuthority("users.delete")
-						// user setting
-						.requestMatchers("/usersettings/**").authenticated()
-						// pregnanttreatmenttypes
-						.requestMatchers(HttpMethod.POST, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.create")
-						.requestMatchers(HttpMethod.GET, "/pregnanttreatmenttypes/**").hasAnyAuthority("pregnanttreatmenttypes.read")
-						.requestMatchers(HttpMethod.PUT, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.delete")
-						// pricelists
-						.requestMatchers(HttpMethod.POST, "/pricelists/**").hasAuthority("pricelists.create")
-						.requestMatchers(HttpMethod.GET, "/pricelists/**").hasAnyAuthority("pricelists.read")
-						.requestMatchers(HttpMethod.PUT, "/pricelists/**").hasAuthority("pricelists.update")
-						.requestMatchers(HttpMethod.DELETE, "/pricelists/**").hasAuthority("pricelists.delete")
-						// pricesothers
-						.requestMatchers(HttpMethod.POST, "/pricesothers/**").hasAuthority("pricesothers.create")
-						.requestMatchers(HttpMethod.GET, "/pricesothers/**").hasAnyAuthority("pricesothers.read")
-						.requestMatchers(HttpMethod.PUT, "/pricesothers/**").hasAuthority("pricesothers.update")
-						.requestMatchers(HttpMethod.DELETE, "/pricesothers/**").hasAuthority("pricesothers.delete")
-						// reports
-						.requestMatchers(HttpMethod.POST, "/reports/**").hasAuthority("reports.create")
-						.requestMatchers(HttpMethod.GET, "/reports/**").hasAnyAuthority("reports.read")
-						.requestMatchers(HttpMethod.PUT, "/reports/**").hasAuthority("reports.update")
-						.requestMatchers(HttpMethod.DELETE, "/reports/**").hasAuthority("reports.delete")
-						// sms
-						.requestMatchers(HttpMethod.POST, "/sms/**").hasAuthority("sms.create")
-						.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
-						.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
-						.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
-						// suppliers
-						.requestMatchers(HttpMethod.POST, "/suppliers/**").hasAuthority("suppliers.create")
-						.requestMatchers(HttpMethod.GET, "/suppliers/**").hasAnyAuthority("suppliers.read")
-						.requestMatchers(HttpMethod.PUT, "/suppliers/**").hasAuthority("suppliers.update")
-						.requestMatchers(HttpMethod.DELETE, "/suppliers/**").hasAuthority("suppliers.delete")
-						// therapy
-						.requestMatchers(HttpMethod.POST, "/therapies/**").hasAuthority("therapies.create")
-						.requestMatchers(HttpMethod.GET, "/therapies/**").hasAnyAuthority("therapies.read")
-						.requestMatchers(HttpMethod.PUT, "/therapies/**").hasAuthority("therapies.update")
-						.requestMatchers(HttpMethod.DELETE, "/therapies/**").hasAuthority("therapies.delete")
-						// vaccines
-						.requestMatchers(HttpMethod.POST, "/vaccines/**").hasAuthority("vaccines.create")
-						.requestMatchers(HttpMethod.GET, "/vaccines/**").hasAnyAuthority("vaccines.read")
-						.requestMatchers(HttpMethod.PUT, "/vaccines/**").hasAuthority("vaccines.update")
-						.requestMatchers(HttpMethod.DELETE, "/vaccines/**").hasAuthority("vaccines.delete")
-						// vaccineType
-						.requestMatchers(HttpMethod.POST, "/vaccinetypes/**").hasAuthority("vaccinetypes.create")
-						.requestMatchers(HttpMethod.GET, "/vaccinetypes/**").hasAnyAuthority("vaccinetypes.read")
-						.requestMatchers(HttpMethod.PUT, "/vaccinetypes/**").hasAuthority("vaccinetypes.update")
-						.requestMatchers(HttpMethod.DELETE, "/vaccinetypes/**").hasAuthority("vaccinetypes.delete")
-						// visit
-						.requestMatchers(HttpMethod.POST, "/visits/**").hasAuthority("visits.create")
-						.requestMatchers(HttpMethod.GET, "/visits/**").hasAnyAuthority("visits.read")
-						.requestMatchers(HttpMethod.PUT, "/visits/**").hasAuthority("visits.update")
-						.requestMatchers(HttpMethod.DELETE, "/visits/**").hasAuthority("visits.delete")
-						// wards
-						.requestMatchers(HttpMethod.POST, "/wards/**").hasAuthority("wards.create")
-						.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
-						.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
-						.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
+			// admissions
+			.requestMatchers(HttpMethod.POST, "/admissions/**").hasAuthority("admissions.create")
+			.requestMatchers(HttpMethod.GET, "/admissions/**").hasAnyAuthority("admissions.read")
+			.requestMatchers(HttpMethod.PUT, "/admissions/**").hasAuthority("admissions.update")
+			.requestMatchers(HttpMethod.DELETE, "/admissions/**").hasAuthority("admissions.delete")
+			// admissiontypes
+			.requestMatchers(HttpMethod.POST, "/admissiontypes/**").hasAuthority("admissiontypes.create")
+			.requestMatchers(HttpMethod.GET, "/admissiontypes/**").hasAnyAuthority("admissiontypes.read")
+			.requestMatchers(HttpMethod.PUT, "/admissiontypes/**").hasAuthority("admissiontypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/admissiontypes/**").hasAuthority("admissiontypes.delete")
+			// age types
+			.requestMatchers(HttpMethod.GET, "/agetypes/**").hasAnyAuthority("agetypes.read")
+			.requestMatchers(HttpMethod.PUT, "/agetypes/**").hasAuthority("agetypes.update")
+			// dischargetypes
+			.requestMatchers(HttpMethod.POST, "/dischargetypes/**").hasAuthority("dischargetypes.create")
+			.requestMatchers(HttpMethod.GET, "/dischargetypes/**").hasAnyAuthority("dischargetypes.read")
+			.requestMatchers(HttpMethod.PUT, "/dischargetypes/**").hasAuthority("dischargetypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/dischargetypes/**").hasAuthority("dischargetypes.delete")
+			// diseases
+			.requestMatchers(HttpMethod.POST, "/diseases/**").hasAuthority("diseases.create")
+			.requestMatchers(HttpMethod.GET, "/diseases/**").hasAnyAuthority("diseases.read")
+			.requestMatchers(HttpMethod.PUT, "/diseases/**").hasAuthority("diseases.update")
+			.requestMatchers(HttpMethod.DELETE, "/diseases/**").hasAuthority("diseases.delete")
+			// diseasetypes
+			.requestMatchers(HttpMethod.POST, "/diseasetypes/**").hasAuthority("diseasetypes.create")
+			.requestMatchers(HttpMethod.GET, "/diseasetypes/**").hasAnyAuthority("diseasetypes.read")
+			.requestMatchers(HttpMethod.PUT, "/diseasetypes/**").hasAuthority("diseasetypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/diseasetypes/**").hasAuthority("diseasetypes.delete")
+			// deliveryresulttype
+			.requestMatchers(HttpMethod.POST, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.create")
+			.requestMatchers(HttpMethod.GET, "/deliveryresulttypes/**").hasAnyAuthority("deliveryresulttypes.read")
+			.requestMatchers(HttpMethod.PUT, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.delete")
+			// deliverytypes
+			.requestMatchers(HttpMethod.POST, "/deliverytypes/**").hasAuthority("deliverytypes.create")
+			.requestMatchers(HttpMethod.GET, "/deliverytypes/**").hasAnyAuthority("deliverytypes.read")
+			.requestMatchers(HttpMethod.PUT, "/deliverytypes/**").hasAuthority("deliverytypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/deliverytypes/**").hasAuthority("deliverytypes.delete")
+			// exams
+			.requestMatchers(HttpMethod.POST, "/exams/**").hasAuthority("exams.create")
+			.requestMatchers(HttpMethod.GET, "/exams/**").hasAnyAuthority("exams.read")
+			.requestMatchers(HttpMethod.PUT, "/exams/**").hasAuthority("exams.update")
+			.requestMatchers(HttpMethod.DELETE, "/exams/**").hasAuthority("exams.delete")
+			// examrows
+			.requestMatchers(HttpMethod.POST, "/examrows/**").hasAuthority("examrows.create")
+			.requestMatchers(HttpMethod.GET, "/examrows/**").hasAnyAuthority("examrows.read")
+			.requestMatchers(HttpMethod.PUT, "/examrows/**").hasAuthority("examrows.update")
+			.requestMatchers(HttpMethod.DELETE, "/examrows/**").hasAuthority("examrows.delete")
+			// examinations
+			.requestMatchers(HttpMethod.POST, "/examinations/**").hasAuthority("examinations.create")
+			.requestMatchers(HttpMethod.GET, "/examinations/**").hasAnyAuthority("examinations.read")
+			.requestMatchers(HttpMethod.PUT, "/examinations/**").hasAuthority("examinations.update")
+			.requestMatchers(HttpMethod.DELETE, "/examinations/**").hasAuthority("examinations.delete")
+			// examtypes
+			.requestMatchers(HttpMethod.POST, "/examtypes/**").hasAuthority("examtypes.create")
+			.requestMatchers(HttpMethod.GET, "/examtypes/**").hasAnyAuthority("examtypes.read")
+			.requestMatchers(HttpMethod.PUT, "/examtypes/**").hasAuthority("examtypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/examtypes/**").hasAuthority("examtypes.delete")
+			// hospitals
+			.requestMatchers(HttpMethod.POST, "/hospitals/**").hasAuthority("hospitals.create")
+			// .requestMatchers(HttpMethod.GET, "/hospitals/**").hasAnyAuthority("hospital.read") to anyone
+			.requestMatchers(HttpMethod.PUT, "/hospitals/**").hasAuthority("hospitals.update")
+			.requestMatchers(HttpMethod.DELETE, "/hospitals/**").hasAuthority("hospitals.delete")
+			// laboratories
+			.requestMatchers(HttpMethod.POST, "/laboratories/**").hasAuthority("laboratories.create")
+			.requestMatchers(HttpMethod.GET, "/laboratories/**").hasAnyAuthority("laboratories.read")
+			.requestMatchers(HttpMethod.PUT, "/laboratories/**").hasAuthority("laboratories.update")
+			.requestMatchers(HttpMethod.DELETE, "/laboratories/**").hasAuthority("laboratories.delete")
+			// malnutrition
+			.requestMatchers(HttpMethod.POST, "/malnutritions/**").hasAuthority("malnutritions.create")
+			.requestMatchers(HttpMethod.GET, "/malnutritions/**").hasAuthority("malnutritions.read")
+			.requestMatchers(HttpMethod.PUT, "/malnutritions/**").hasAuthority("malnutritions.update")
+			.requestMatchers(HttpMethod.DELETE, "/malnutritions/**").hasAuthority("malnutritions.delete")
+			// medicals
+			.requestMatchers(HttpMethod.POST, "/medicals/**").hasAuthority("medicals.create")
+			.requestMatchers(HttpMethod.GET, "/medicals/**").hasAuthority("medicals.read")
+			.requestMatchers(HttpMethod.PUT, "/medicals/**").hasAuthority("medicals.update")
+			.requestMatchers(HttpMethod.DELETE, "/medicals/**").hasAuthority("medicals.delete")
+			// medicalstock
+			.requestMatchers(HttpMethod.POST, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.create")
+			.requestMatchers(HttpMethod.GET, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.read")
+			.requestMatchers(HttpMethod.PUT, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.update")
+			.requestMatchers(HttpMethod.DELETE, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.delete")
+			// medicalstockward
+			.requestMatchers(HttpMethod.POST, "/medicalstockward/**").hasAuthority("medicalstockward.create")
+			.requestMatchers(HttpMethod.GET, "/medicalstockward/**").hasAuthority("medicalstockward.read")
+			.requestMatchers(HttpMethod.PUT, "/medicalstockward/**").hasAuthority("medicalstockward.update")
+			.requestMatchers(HttpMethod.DELETE, "/medicalstockward/**").hasAuthority("medicalstockward.delete")
+			// medicalstockmovtype
+			.requestMatchers(HttpMethod.POST, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.create")
+			.requestMatchers(HttpMethod.GET, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.read")
+			.requestMatchers(HttpMethod.PUT, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.delete")
+			// medicaltype
+			.requestMatchers(HttpMethod.POST, "/medicaltypes/**").hasAuthority("medicaltypes.create")
+			.requestMatchers(HttpMethod.GET, "/medicaltypes/**").hasAuthority("medicaltypes.read")
+			.requestMatchers(HttpMethod.PUT, "/medicaltypes/**").hasAuthority("medicaltypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/medicaltypes/**").hasAuthority("medicaltypes.delete")
+			// opd
+			.requestMatchers(HttpMethod.POST, "/opds/**").hasAuthority("opds.create")
+			.requestMatchers(HttpMethod.GET, "/opds/**").hasAnyAuthority("opds.read")
+			.requestMatchers(HttpMethod.PUT, "/opds/**").hasAuthority("opds.update")
+			.requestMatchers(HttpMethod.DELETE, "/opds/**").hasAuthority("opds.delete")
+			// operations
+			.requestMatchers(HttpMethod.POST, "/operations/**").hasAuthority("operations.create")
+			.requestMatchers(HttpMethod.GET, "/operations/**").hasAnyAuthority("operations.read")
+			.requestMatchers(HttpMethod.PUT, "/operations/**").hasAuthority("operations.update")
+			.requestMatchers(HttpMethod.DELETE, "/operations/**").hasAuthority("operations.delete")
+			// operation types
+			.requestMatchers(HttpMethod.POST, "/operationtypes/**").hasAuthority("operationtypes.create")
+			.requestMatchers(HttpMethod.GET, "/operationtypes/**").hasAnyAuthority("operationtypes.read")
+			.requestMatchers(HttpMethod.PUT, "/operationtypes/**").hasAuthority("operationtypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/operationtypes/**").hasAuthority("operationtypes.delete")
+			// patientconsensus
+			.requestMatchers(HttpMethod.POST, "/patientconsensus/**").hasAuthority("patientconsensus.create")
+			.requestMatchers(HttpMethod.GET, "/patientconsensus/**").hasAuthority("patientconsensus.read")
+			.requestMatchers(HttpMethod.PUT, "/patientconsensus/**").hasAuthority("patientconsensus.update")
+			.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
+			// patients
+			.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
+			.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
+			.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")
+			.requestMatchers(HttpMethod.DELETE, "/patients/**").hasAuthority("patients.delete")
+			// patientvaccines
+			.requestMatchers(HttpMethod.POST, "/patientvaccines/**").hasAuthority("patientvaccines.create")
+			.requestMatchers(HttpMethod.GET, "/patientvaccines/**").hasAnyAuthority("patientvaccines.read")
+			.requestMatchers(HttpMethod.PUT, "/patientvaccines/**").hasAuthority("patientvaccines.update")
+			.requestMatchers(HttpMethod.DELETE, "/patientvaccines/**").hasAuthority("patientvaccines.delete")
+			// permission
+			.requestMatchers(HttpMethod.POST, "/permissions/**").hasAuthority("permissions.create")
+			.requestMatchers(HttpMethod.GET, "/permissions/**").hasAuthority("permissions.read")
+			.requestMatchers(HttpMethod.PUT, "/permissions/**").hasAuthority("permissions.update")
+			.requestMatchers(HttpMethod.DELETE, "/permissions/**").hasAuthority("permissions.delete")
+			// grouppermission
+			.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
+			.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
+			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**")
+			.access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
+			.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
+			// usergroups
+			.requestMatchers(HttpMethod.POST, "/usergroups/**").hasAuthority("usergroups.create")
+			.requestMatchers(HttpMethod.GET, "/usergroups/**").hasAuthority("usergroups.read")
+			.requestMatchers(HttpMethod.PUT, "/usergroups/**").hasAuthority("usergroups.update")
+			.requestMatchers(HttpMethod.DELETE, "/usergroups/**").hasAuthority("usergroups.delete")
+			// user
+			.requestMatchers("/users/me").authenticated()
+			.requestMatchers(HttpMethod.POST, "/users").hasAuthority("users.create")
+			.requestMatchers(HttpMethod.GET, "/users/**").hasAuthority("users.read")
+			.requestMatchers(HttpMethod.PUT, "/users/{username}").hasAuthority("users.update")
+			.requestMatchers(HttpMethod.DELETE, "/users/**").hasAuthority("users.delete")
+			// user setting
+			.requestMatchers("/usersettings/**").authenticated()
+			// pregnanttreatmenttypes
+			.requestMatchers(HttpMethod.POST, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.create")
+			.requestMatchers(HttpMethod.GET, "/pregnanttreatmenttypes/**").hasAnyAuthority("pregnanttreatmenttypes.read")
+			.requestMatchers(HttpMethod.PUT, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.delete")
+			// pricelists
+			.requestMatchers(HttpMethod.POST, "/pricelists/**").hasAuthority("pricelists.create")
+			.requestMatchers(HttpMethod.GET, "/pricelists/**").hasAnyAuthority("pricelists.read")
+			.requestMatchers(HttpMethod.PUT, "/pricelists/**").hasAuthority("pricelists.update")
+			.requestMatchers(HttpMethod.DELETE, "/pricelists/**").hasAuthority("pricelists.delete")
+			// pricesothers
+			.requestMatchers(HttpMethod.POST, "/pricesothers/**").hasAuthority("pricesothers.create")
+			.requestMatchers(HttpMethod.GET, "/pricesothers/**").hasAnyAuthority("pricesothers.read")
+			.requestMatchers(HttpMethod.PUT, "/pricesothers/**").hasAuthority("pricesothers.update")
+			.requestMatchers(HttpMethod.DELETE, "/pricesothers/**").hasAuthority("pricesothers.delete")
+			// reports
+			.requestMatchers(HttpMethod.POST, "/reports/**").hasAuthority("reports.create")
+			.requestMatchers(HttpMethod.GET, "/reports/**").hasAnyAuthority("reports.read")
+			.requestMatchers(HttpMethod.PUT, "/reports/**").hasAuthority("reports.update")
+			.requestMatchers(HttpMethod.DELETE, "/reports/**").hasAuthority("reports.delete")
+			// sms
+			.requestMatchers(HttpMethod.POST, "/sms/**").hasAuthority("sms.create")
+			.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
+			.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
+			.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
+			// suppliers
+			.requestMatchers(HttpMethod.POST, "/suppliers/**").hasAuthority("suppliers.create")
+			.requestMatchers(HttpMethod.GET, "/suppliers/**").hasAnyAuthority("suppliers.read")
+			.requestMatchers(HttpMethod.PUT, "/suppliers/**").hasAuthority("suppliers.update")
+			.requestMatchers(HttpMethod.DELETE, "/suppliers/**").hasAuthority("suppliers.delete")
+			// therapy
+			.requestMatchers(HttpMethod.POST, "/therapies/**").hasAuthority("therapies.create")
+			.requestMatchers(HttpMethod.GET, "/therapies/**").hasAnyAuthority("therapies.read")
+			.requestMatchers(HttpMethod.PUT, "/therapies/**").hasAuthority("therapies.update")
+			.requestMatchers(HttpMethod.DELETE, "/therapies/**").hasAuthority("therapies.delete")
+			// vaccines
+			.requestMatchers(HttpMethod.POST, "/vaccines/**").hasAuthority("vaccines.create")
+			.requestMatchers(HttpMethod.GET, "/vaccines/**").hasAnyAuthority("vaccines.read")
+			.requestMatchers(HttpMethod.PUT, "/vaccines/**").hasAuthority("vaccines.update")
+			.requestMatchers(HttpMethod.DELETE, "/vaccines/**").hasAuthority("vaccines.delete")
+			// vaccineType
+			.requestMatchers(HttpMethod.POST, "/vaccinetypes/**").hasAuthority("vaccinetypes.create")
+			.requestMatchers(HttpMethod.GET, "/vaccinetypes/**").hasAnyAuthority("vaccinetypes.read")
+			.requestMatchers(HttpMethod.PUT, "/vaccinetypes/**").hasAuthority("vaccinetypes.update")
+			.requestMatchers(HttpMethod.DELETE, "/vaccinetypes/**").hasAuthority("vaccinetypes.delete")
+			// visit
+			.requestMatchers(HttpMethod.POST, "/visits/**").hasAuthority("visits.create")
+			.requestMatchers(HttpMethod.GET, "/visits/**").hasAnyAuthority("visits.read")
+			.requestMatchers(HttpMethod.PUT, "/visits/**").hasAuthority("visits.update")
+			.requestMatchers(HttpMethod.DELETE, "/visits/**").hasAuthority("visits.delete")
+			// wards
+			.requestMatchers(HttpMethod.POST, "/wards/**").hasAuthority("wards.create")
+			.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
+			.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
+			.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
 
-						// .requestMatchers("/auth-needed/**").authenticated()
-						// .requestMatchers("/noauth-public/**").permitAll()
-						// .requestMatchers("/admin/**").hasAuthority("admin")
+			// .requestMatchers("/auth-needed/**").authenticated()
+			// .requestMatchers("/noauth-public/**").permitAll()
+			// .requestMatchers("/admin/**").hasAuthority("admin")
 
-						//			.and()
-						//			.formLogin()
-						//				 .loginPage("/auth/login")
-						//				 .successHandler(successHandler())
-						//				 .failureHandler(failureHandler())
-						.and().apply(securityConfigurerAdapter())
-						.and().httpBasic()
-						.and().logout().logoutUrl("/auth/logout").addLogoutHandler(customLogoutHandler).permitAll();
+			//			.and()
+			//			.formLogin()
+			//				 .loginPage("/auth/login")
+			//				 .successHandler(successHandler())
+			//				 .failureHandler(failureHandler())
+			.and().apply(securityConfigurerAdapter())
+			.and().httpBasic()
+			.and().logout().logoutUrl("/auth/logout").addLogoutHandler(customLogoutHandler).permitAll();
 		return http.build();
 	}
 

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -21,6 +21,8 @@
  */
 package org.isf.config;
 
+import java.util.List;
+
 import org.isf.permissions.manager.PermissionManager;
 import org.isf.security.ApiAuditorAwareImpl;
 import org.isf.security.CustomLogoutHandler;
@@ -52,8 +54,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -108,233 +108,234 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-			.and().cors()
-			.and().csrf().disable().authorizeRequests()
-			// .expressionHandler(webExpressionHandler())
-			.and().exceptionHandling()
-			// .accessDeniedHandler(accessDeniedHandler)
-			.authenticationEntryPoint(restAuthenticationEntryPoint)
-			.and().authorizeRequests().requestMatchers("/auth/**").permitAll()
+						.and().cors()
+						.and().csrf().disable().authorizeRequests()
+						// .expressionHandler(webExpressionHandler())
+						.and().exceptionHandling()
+						// .accessDeniedHandler(accessDeniedHandler)
+						.authenticationEntryPoint(restAuthenticationEntryPoint)
+						.and().authorizeRequests().requestMatchers("/auth/**").permitAll()
 
-			// admissions
-			.requestMatchers(HttpMethod.POST, "/admissions/**").hasAuthority("admissions.create")
-			.requestMatchers(HttpMethod.GET, "/admissions/**").hasAnyAuthority("admissions.read")
-			.requestMatchers(HttpMethod.PUT, "/admissions/**").hasAuthority("admissions.update")
-			.requestMatchers(HttpMethod.DELETE, "/admissions/**").hasAuthority("admissions.delete")
-			// admissiontypes
-			.requestMatchers(HttpMethod.POST, "/admissiontypes/**").hasAuthority("admissiontypes.create")
-			.requestMatchers(HttpMethod.GET, "/admissiontypes/**").hasAnyAuthority("admissiontypes.read")
-			.requestMatchers(HttpMethod.PUT, "/admissiontypes/**").hasAuthority("admissiontypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/admissiontypes/**").hasAuthority("admissiontypes.delete")
-			// age types
-			.requestMatchers(HttpMethod.GET, "/agetypes/**").hasAnyAuthority("agetypes.read")
-			.requestMatchers(HttpMethod.PUT, "/agetypes/**").hasAuthority("agetypes.update")
-			// dischargetypes
-			.requestMatchers(HttpMethod.POST, "/dischargetypes/**").hasAuthority("dischargetypes.create")
-			.requestMatchers(HttpMethod.GET, "/dischargetypes/**").hasAnyAuthority("dischargetypes.read")
-			.requestMatchers(HttpMethod.PUT, "/dischargetypes/**").hasAuthority("dischargetypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/dischargetypes/**").hasAuthority("dischargetypes.delete")
-			// diseases
-			.requestMatchers(HttpMethod.POST, "/diseases/**").hasAuthority("diseases.create")
-			.requestMatchers(HttpMethod.GET, "/diseases/**").hasAnyAuthority("diseases.read")
-			.requestMatchers(HttpMethod.PUT, "/diseases/**").hasAuthority("diseases.update")
-			.requestMatchers(HttpMethod.DELETE, "/diseases/**").hasAuthority("diseases.delete")
-			// diseasetypes
-			.requestMatchers(HttpMethod.POST, "/diseasetypes/**").hasAuthority("diseasetypes.create")
-			.requestMatchers(HttpMethod.GET, "/diseasetypes/**").hasAnyAuthority("diseasetypes.read")
-			.requestMatchers(HttpMethod.PUT, "/diseasetypes/**").hasAuthority("diseasetypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/diseasetypes/**").hasAuthority("diseasetypes.delete")
-			// deliveryresulttype
-			.requestMatchers(HttpMethod.POST, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.create")
-			.requestMatchers(HttpMethod.GET, "/deliveryresulttypes/**").hasAnyAuthority("deliveryresulttypes.read")
-			.requestMatchers(HttpMethod.PUT, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.delete")
-			// deliverytypes
-			.requestMatchers(HttpMethod.POST, "/deliverytypes/**").hasAuthority("deliverytypes.create")
-			.requestMatchers(HttpMethod.GET, "/deliverytypes/**").hasAnyAuthority("deliverytypes.read")
-			.requestMatchers(HttpMethod.PUT, "/deliverytypes/**").hasAuthority("deliverytypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/deliverytypes/**").hasAuthority("deliverytypes.delete")
-			// exams
-			.requestMatchers(HttpMethod.POST, "/exams/**").hasAuthority("exams.create")
-			.requestMatchers(HttpMethod.GET, "/exams/**").hasAnyAuthority("exams.read")
-			.requestMatchers(HttpMethod.PUT, "/exams/**").hasAuthority("exams.update")
-			.requestMatchers(HttpMethod.DELETE, "/exams/**").hasAuthority("exams.delete")
-			// examrows
-			.requestMatchers(HttpMethod.POST, "/examrows/**").hasAuthority("examrows.create")
-			.requestMatchers(HttpMethod.GET, "/examrows/**").hasAnyAuthority("examrows.read")
-			.requestMatchers(HttpMethod.PUT, "/examrows/**").hasAuthority("examrows.update")
-			.requestMatchers(HttpMethod.DELETE, "/examrows/**").hasAuthority("examrows.delete")
-			// examinations
-			.requestMatchers(HttpMethod.POST, "/examinations/**").hasAuthority("examinations.create")
-			.requestMatchers(HttpMethod.GET, "/examinations/**").hasAnyAuthority("examinations.read")
-			.requestMatchers(HttpMethod.PUT, "/examinations/**").hasAuthority("examinations.update")
-			.requestMatchers(HttpMethod.DELETE, "/examinations/**").hasAuthority("examinations.delete")
-			// examtypes
-			.requestMatchers(HttpMethod.POST, "/examtypes/**").hasAuthority("examtypes.create")
-			.requestMatchers(HttpMethod.GET, "/examtypes/**").hasAnyAuthority("examtypes.read")
-			.requestMatchers(HttpMethod.PUT, "/examtypes/**").hasAuthority("examtypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/examtypes/**").hasAuthority("examtypes.delete")
-			// hospitals
-			.requestMatchers(HttpMethod.POST, "/hospitals/**").hasAuthority("hospitals.create")
-			// .requestMatchers(HttpMethod.GET, "/hospitals/**").hasAnyAuthority("hospital.read") to anyone
-			.requestMatchers(HttpMethod.PUT, "/hospitals/**").hasAuthority("hospitals.update")
-			.requestMatchers(HttpMethod.DELETE, "/hospitals/**").hasAuthority("hospitals.delete")
-			// laboratories
-			.requestMatchers(HttpMethod.POST, "/laboratories/**").hasAuthority("laboratories.create")
-			.requestMatchers(HttpMethod.GET, "/laboratories/**").hasAnyAuthority("laboratories.read")
-			.requestMatchers(HttpMethod.PUT, "/laboratories/**").hasAuthority("laboratories.update")
-			.requestMatchers(HttpMethod.DELETE, "/laboratories/**").hasAuthority("laboratories.delete")
-			// malnutrition
-			.requestMatchers(HttpMethod.POST, "/malnutritions/**").hasAuthority("malnutritions.create")
-			.requestMatchers(HttpMethod.GET, "/malnutritions/**").hasAuthority("malnutritions.read")
-			.requestMatchers(HttpMethod.PUT, "/malnutritions/**").hasAuthority("malnutritions.update")
-			.requestMatchers(HttpMethod.DELETE, "/malnutritions/**").hasAuthority("malnutritions.delete")
-			// medicals
-			.requestMatchers(HttpMethod.POST, "/medicals/**").hasAuthority("medicals.create")
-			.requestMatchers(HttpMethod.GET, "/medicals/**").hasAuthority("medicals.read")
-			.requestMatchers(HttpMethod.PUT, "/medicals/**").hasAuthority("medicals.update")
-			.requestMatchers(HttpMethod.DELETE, "/medicals/**").hasAuthority("medicals.delete")
-			// medicalstock
-			.requestMatchers(HttpMethod.POST, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.create")
-			.requestMatchers(HttpMethod.GET, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.read")
-			.requestMatchers(HttpMethod.PUT, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.update")
-			.requestMatchers(HttpMethod.DELETE, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.delete")
-			// medicalstockward
-			.requestMatchers(HttpMethod.POST, "/medicalstockward/**").hasAuthority("medicalstockward.create")
-			.requestMatchers(HttpMethod.GET, "/medicalstockward/**").hasAuthority("medicalstockward.read")
-			.requestMatchers(HttpMethod.PUT, "/medicalstockward/**").hasAuthority("medicalstockward.update")
-			.requestMatchers(HttpMethod.DELETE, "/medicalstockward/**").hasAuthority("medicalstockward.delete")
-			// medicalstockmovtype
-			.requestMatchers(HttpMethod.POST, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.create")
-			.requestMatchers(HttpMethod.GET, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.read")
-			.requestMatchers(HttpMethod.PUT, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.delete")
-			// medicaltype
-			.requestMatchers(HttpMethod.POST, "/medicaltypes/**").hasAuthority("medicaltypes.create")
-			.requestMatchers(HttpMethod.GET, "/medicaltypes/**").hasAuthority("medicaltypes.read")
-			.requestMatchers(HttpMethod.PUT, "/medicaltypes/**").hasAuthority("medicaltypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/medicaltypes/**").hasAuthority("medicaltypes.delete")
-			// opd
-			.requestMatchers(HttpMethod.POST, "/opds/**").hasAuthority("opds.create")
-			.requestMatchers(HttpMethod.GET, "/opds/**").hasAnyAuthority("opds.read")
-			.requestMatchers(HttpMethod.PUT, "/opds/**").hasAuthority("opds.update")
-			.requestMatchers(HttpMethod.DELETE, "/opds/**").hasAuthority("opds.delete")
-			// operations
-			.requestMatchers(HttpMethod.POST, "/operations/**").hasAuthority("operations.create")
-			.requestMatchers(HttpMethod.GET, "/operations/**").hasAnyAuthority("operations.read")
-			.requestMatchers(HttpMethod.PUT, "/operations/**").hasAuthority("operations.update")
-			.requestMatchers(HttpMethod.DELETE, "/operations/**").hasAuthority("operations.delete")
-			// operation types
-			.requestMatchers(HttpMethod.POST, "/operationtypes/**").hasAuthority("operationtypes.create")
-			.requestMatchers(HttpMethod.GET, "/operationtypes/**").hasAnyAuthority("operationtypes.read")
-			.requestMatchers(HttpMethod.PUT, "/operationtypes/**").hasAuthority("operationtypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/operationtypes/**").hasAuthority("operationtypes.delete")
-			// patientconsensus
-			.requestMatchers(HttpMethod.POST, "/patientconsensus/**").hasAuthority("patientconsensus.create")
-			.requestMatchers(HttpMethod.GET, "/patientconsensus/**").hasAuthority("patientconsensus.read")
-			.requestMatchers(HttpMethod.PUT, "/patientconsensus/**").hasAuthority("patientconsensus.update")
-			.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
-			// patients
-			.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
-			.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
-			.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")
-			.requestMatchers(HttpMethod.DELETE, "/patients/**").hasAuthority("patients.delete")
-			// patientvaccines
-			.requestMatchers(HttpMethod.POST, "/patientvaccines/**").hasAuthority("patientvaccines.create")
-			.requestMatchers(HttpMethod.GET, "/patientvaccines/**").hasAnyAuthority("patientvaccines.read")
-			.requestMatchers(HttpMethod.PUT, "/patientvaccines/**").hasAuthority("patientvaccines.update")
-			.requestMatchers(HttpMethod.DELETE, "/patientvaccines/**").hasAuthority("patientvaccines.delete")
-			// permission
-			.requestMatchers(HttpMethod.POST, "/permissions/**").hasAuthority("permissions.create")
-			.requestMatchers(HttpMethod.GET, "/permissions/**").hasAuthority("permissions.read")
-			.requestMatchers(HttpMethod.PUT, "/permissions/**").hasAuthority("permissions.update")
-			.requestMatchers(HttpMethod.DELETE, "/permissions/**").hasAuthority("permissions.delete")
-			// grouppermission
-			.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
-			.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
-			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**").access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
-			.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
-			// usergroups
-			.requestMatchers(HttpMethod.POST, "/usergroups/**").hasAuthority("usergroups.create")
-			.requestMatchers(HttpMethod.GET, "/usergroups/**").hasAuthority("usergroups.read")
-			.requestMatchers(HttpMethod.PUT, "/usergroups/**").hasAuthority("usergroups.update")
-			.requestMatchers(HttpMethod.DELETE, "/usergroups/**").hasAuthority("usergroups.delete")
-			// user
-			.requestMatchers("/users/me").authenticated()
-			.requestMatchers(HttpMethod.POST, "/users").hasAuthority("users.create")
-			.requestMatchers(HttpMethod.GET, "/users/**").hasAuthority("users.read")
-			.requestMatchers(HttpMethod.PUT, "/users/{username}").hasAuthority("users.update")
-			.requestMatchers(HttpMethod.DELETE, "/users/**").hasAuthority("users.delete")
-			// user setting
-			.requestMatchers("/usersettings/**").authenticated()
-			// pregnanttreatmenttypes
-			.requestMatchers(HttpMethod.POST, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.create")
-			.requestMatchers(HttpMethod.GET, "/pregnanttreatmenttypes/**").hasAnyAuthority("pregnanttreatmenttypes.read")
-			.requestMatchers(HttpMethod.PUT, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.delete")
-			// pricelists
-			.requestMatchers(HttpMethod.POST, "/pricelists/**").hasAuthority("pricelists.create")
-			.requestMatchers(HttpMethod.GET, "/pricelists/**").hasAnyAuthority("pricelists.read")
-			.requestMatchers(HttpMethod.PUT, "/pricelists/**").hasAuthority("pricelists.update")
-			.requestMatchers(HttpMethod.DELETE, "/pricelists/**").hasAuthority("pricelists.delete")
-			// pricesothers
-			.requestMatchers(HttpMethod.POST, "/pricesothers/**").hasAuthority("pricesothers.create")
-			.requestMatchers(HttpMethod.GET, "/pricesothers/**").hasAnyAuthority("pricesothers.read")
-			.requestMatchers(HttpMethod.PUT, "/pricesothers/**").hasAuthority("pricesothers.update")
-			.requestMatchers(HttpMethod.DELETE, "/pricesothers/**").hasAuthority("pricesothers.delete")
-			// reports
-			.requestMatchers(HttpMethod.POST, "/reports/**").hasAuthority("reports.create")
-			.requestMatchers(HttpMethod.GET, "/reports/**").hasAnyAuthority("reports.read")
-			.requestMatchers(HttpMethod.PUT, "/reports/**").hasAuthority("reports.update")
-			.requestMatchers(HttpMethod.DELETE, "/reports/**").hasAuthority("reports.delete")
-			// sms
-			.requestMatchers(HttpMethod.POST, "/sms/**").hasAuthority("sms.create")
-			.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
-			.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
-			.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
-			// suppliers
-			.requestMatchers(HttpMethod.POST, "/suppliers/**").hasAuthority("suppliers.create")
-			.requestMatchers(HttpMethod.GET, "/suppliers/**").hasAnyAuthority("suppliers.read")
-			.requestMatchers(HttpMethod.PUT, "/suppliers/**").hasAuthority("suppliers.update")
-			.requestMatchers(HttpMethod.DELETE, "/suppliers/**").hasAuthority("suppliers.delete")
-			// therapy
-			.requestMatchers(HttpMethod.POST, "/therapies/**").hasAuthority("therapies.create")
-			.requestMatchers(HttpMethod.GET, "/therapies/**").hasAnyAuthority("therapies.read")
-			.requestMatchers(HttpMethod.PUT, "/therapies/**").hasAuthority("therapies.update")
-			.requestMatchers(HttpMethod.DELETE, "/therapies/**").hasAuthority("therapies.delete")
-			// vaccines
-			.requestMatchers(HttpMethod.POST, "/vaccines/**").hasAuthority("vaccines.create")
-			.requestMatchers(HttpMethod.GET, "/vaccines/**").hasAnyAuthority("vaccines.read")
-			.requestMatchers(HttpMethod.PUT, "/vaccines/**").hasAuthority("vaccines.update")
-			.requestMatchers(HttpMethod.DELETE, "/vaccines/**").hasAuthority("vaccines.delete")
-			// vaccineType
-			.requestMatchers(HttpMethod.POST, "/vaccinetypes/**").hasAuthority("vaccinetypes.create")
-			.requestMatchers(HttpMethod.GET, "/vaccinetypes/**").hasAnyAuthority("vaccinetypes.read")
-			.requestMatchers(HttpMethod.PUT, "/vaccinetypes/**").hasAuthority("vaccinetypes.update")
-			.requestMatchers(HttpMethod.DELETE, "/vaccinetypes/**").hasAuthority("vaccinetypes.delete")
-			// visit
-			.requestMatchers(HttpMethod.POST, "/visits/**").hasAuthority("visits.create")
-			.requestMatchers(HttpMethod.GET, "/visits/**").hasAnyAuthority("visits.read")
-			.requestMatchers(HttpMethod.PUT, "/visits/**").hasAuthority("visits.update")
-			.requestMatchers(HttpMethod.DELETE, "/visits/**").hasAuthority("visits.delete")
-			// wards
-			.requestMatchers(HttpMethod.POST, "/wards/**").hasAuthority("wards.create")
-			.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
-			.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
-			.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
+						// admissions
+						.requestMatchers(HttpMethod.POST, "/admissions/**").hasAuthority("admissions.create")
+						.requestMatchers(HttpMethod.GET, "/admissions/**").hasAnyAuthority("admissions.read")
+						.requestMatchers(HttpMethod.PUT, "/admissions/**").hasAuthority("admissions.update")
+						.requestMatchers(HttpMethod.DELETE, "/admissions/**").hasAuthority("admissions.delete")
+						// admissiontypes
+						.requestMatchers(HttpMethod.POST, "/admissiontypes/**").hasAuthority("admissiontypes.create")
+						.requestMatchers(HttpMethod.GET, "/admissiontypes/**").hasAnyAuthority("admissiontypes.read")
+						.requestMatchers(HttpMethod.PUT, "/admissiontypes/**").hasAuthority("admissiontypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/admissiontypes/**").hasAuthority("admissiontypes.delete")
+						// age types
+						.requestMatchers(HttpMethod.GET, "/agetypes/**").hasAnyAuthority("agetypes.read")
+						.requestMatchers(HttpMethod.PUT, "/agetypes/**").hasAuthority("agetypes.update")
+						// dischargetypes
+						.requestMatchers(HttpMethod.POST, "/dischargetypes/**").hasAuthority("dischargetypes.create")
+						.requestMatchers(HttpMethod.GET, "/dischargetypes/**").hasAnyAuthority("dischargetypes.read")
+						.requestMatchers(HttpMethod.PUT, "/dischargetypes/**").hasAuthority("dischargetypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/dischargetypes/**").hasAuthority("dischargetypes.delete")
+						// diseases
+						.requestMatchers(HttpMethod.POST, "/diseases/**").hasAuthority("diseases.create")
+						.requestMatchers(HttpMethod.GET, "/diseases/**").hasAnyAuthority("diseases.read")
+						.requestMatchers(HttpMethod.PUT, "/diseases/**").hasAuthority("diseases.update")
+						.requestMatchers(HttpMethod.DELETE, "/diseases/**").hasAuthority("diseases.delete")
+						// diseasetypes
+						.requestMatchers(HttpMethod.POST, "/diseasetypes/**").hasAuthority("diseasetypes.create")
+						.requestMatchers(HttpMethod.GET, "/diseasetypes/**").hasAnyAuthority("diseasetypes.read")
+						.requestMatchers(HttpMethod.PUT, "/diseasetypes/**").hasAuthority("diseasetypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/diseasetypes/**").hasAuthority("diseasetypes.delete")
+						// deliveryresulttype
+						.requestMatchers(HttpMethod.POST, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.create")
+						.requestMatchers(HttpMethod.GET, "/deliveryresulttypes/**").hasAnyAuthority("deliveryresulttypes.read")
+						.requestMatchers(HttpMethod.PUT, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/deliveryresulttypes/**").hasAuthority("deliveryresulttypes.delete")
+						// deliverytypes
+						.requestMatchers(HttpMethod.POST, "/deliverytypes/**").hasAuthority("deliverytypes.create")
+						.requestMatchers(HttpMethod.GET, "/deliverytypes/**").hasAnyAuthority("deliverytypes.read")
+						.requestMatchers(HttpMethod.PUT, "/deliverytypes/**").hasAuthority("deliverytypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/deliverytypes/**").hasAuthority("deliverytypes.delete")
+						// exams
+						.requestMatchers(HttpMethod.POST, "/exams/**").hasAuthority("exams.create")
+						.requestMatchers(HttpMethod.GET, "/exams/**").hasAnyAuthority("exams.read")
+						.requestMatchers(HttpMethod.PUT, "/exams/**").hasAuthority("exams.update")
+						.requestMatchers(HttpMethod.DELETE, "/exams/**").hasAuthority("exams.delete")
+						// examrows
+						.requestMatchers(HttpMethod.POST, "/examrows/**").hasAuthority("examrows.create")
+						.requestMatchers(HttpMethod.GET, "/examrows/**").hasAnyAuthority("examrows.read")
+						.requestMatchers(HttpMethod.PUT, "/examrows/**").hasAuthority("examrows.update")
+						.requestMatchers(HttpMethod.DELETE, "/examrows/**").hasAuthority("examrows.delete")
+						// examinations
+						.requestMatchers(HttpMethod.POST, "/examinations/**").hasAuthority("examinations.create")
+						.requestMatchers(HttpMethod.GET, "/examinations/**").hasAnyAuthority("examinations.read")
+						.requestMatchers(HttpMethod.PUT, "/examinations/**").hasAuthority("examinations.update")
+						.requestMatchers(HttpMethod.DELETE, "/examinations/**").hasAuthority("examinations.delete")
+						// examtypes
+						.requestMatchers(HttpMethod.POST, "/examtypes/**").hasAuthority("examtypes.create")
+						.requestMatchers(HttpMethod.GET, "/examtypes/**").hasAnyAuthority("examtypes.read")
+						.requestMatchers(HttpMethod.PUT, "/examtypes/**").hasAuthority("examtypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/examtypes/**").hasAuthority("examtypes.delete")
+						// hospitals
+						.requestMatchers(HttpMethod.POST, "/hospitals/**").hasAuthority("hospitals.create")
+						// .requestMatchers(HttpMethod.GET, "/hospitals/**").hasAnyAuthority("hospital.read") to anyone
+						.requestMatchers(HttpMethod.PUT, "/hospitals/**").hasAuthority("hospitals.update")
+						.requestMatchers(HttpMethod.DELETE, "/hospitals/**").hasAuthority("hospitals.delete")
+						// laboratories
+						.requestMatchers(HttpMethod.POST, "/laboratories/**").hasAuthority("laboratories.create")
+						.requestMatchers(HttpMethod.GET, "/laboratories/**").hasAnyAuthority("laboratories.read")
+						.requestMatchers(HttpMethod.PUT, "/laboratories/**").hasAuthority("laboratories.update")
+						.requestMatchers(HttpMethod.DELETE, "/laboratories/**").hasAuthority("laboratories.delete")
+						// malnutrition
+						.requestMatchers(HttpMethod.POST, "/malnutritions/**").hasAuthority("malnutritions.create")
+						.requestMatchers(HttpMethod.GET, "/malnutritions/**").hasAuthority("malnutritions.read")
+						.requestMatchers(HttpMethod.PUT, "/malnutritions/**").hasAuthority("malnutritions.update")
+						.requestMatchers(HttpMethod.DELETE, "/malnutritions/**").hasAuthority("malnutritions.delete")
+						// medicals
+						.requestMatchers(HttpMethod.POST, "/medicals/**").hasAuthority("medicals.create")
+						.requestMatchers(HttpMethod.GET, "/medicals/**").hasAuthority("medicals.read")
+						.requestMatchers(HttpMethod.PUT, "/medicals/**").hasAuthority("medicals.update")
+						.requestMatchers(HttpMethod.DELETE, "/medicals/**").hasAuthority("medicals.delete")
+						// medicalstock
+						.requestMatchers(HttpMethod.POST, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.create")
+						.requestMatchers(HttpMethod.GET, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.read")
+						.requestMatchers(HttpMethod.PUT, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.update")
+						.requestMatchers(HttpMethod.DELETE, "/medicalstockmovements/**").hasAuthority("medicalstockmovements.delete")
+						// medicalstockward
+						.requestMatchers(HttpMethod.POST, "/medicalstockward/**").hasAuthority("medicalstockward.create")
+						.requestMatchers(HttpMethod.GET, "/medicalstockward/**").hasAuthority("medicalstockward.read")
+						.requestMatchers(HttpMethod.PUT, "/medicalstockward/**").hasAuthority("medicalstockward.update")
+						.requestMatchers(HttpMethod.DELETE, "/medicalstockward/**").hasAuthority("medicalstockward.delete")
+						// medicalstockmovtype
+						.requestMatchers(HttpMethod.POST, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.create")
+						.requestMatchers(HttpMethod.GET, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.read")
+						.requestMatchers(HttpMethod.PUT, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/medstockmovementtypes/**").hasAuthority("medstockmovementtypes.delete")
+						// medicaltype
+						.requestMatchers(HttpMethod.POST, "/medicaltypes/**").hasAuthority("medicaltypes.create")
+						.requestMatchers(HttpMethod.GET, "/medicaltypes/**").hasAuthority("medicaltypes.read")
+						.requestMatchers(HttpMethod.PUT, "/medicaltypes/**").hasAuthority("medicaltypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/medicaltypes/**").hasAuthority("medicaltypes.delete")
+						// opd
+						.requestMatchers(HttpMethod.POST, "/opds/**").hasAuthority("opds.create")
+						.requestMatchers(HttpMethod.GET, "/opds/**").hasAnyAuthority("opds.read")
+						.requestMatchers(HttpMethod.PUT, "/opds/**").hasAuthority("opds.update")
+						.requestMatchers(HttpMethod.DELETE, "/opds/**").hasAuthority("opds.delete")
+						// operations
+						.requestMatchers(HttpMethod.POST, "/operations/**").hasAuthority("operations.create")
+						.requestMatchers(HttpMethod.GET, "/operations/**").hasAnyAuthority("operations.read")
+						.requestMatchers(HttpMethod.PUT, "/operations/**").hasAuthority("operations.update")
+						.requestMatchers(HttpMethod.DELETE, "/operations/**").hasAuthority("operations.delete")
+						// operation types
+						.requestMatchers(HttpMethod.POST, "/operationtypes/**").hasAuthority("operationtypes.create")
+						.requestMatchers(HttpMethod.GET, "/operationtypes/**").hasAnyAuthority("operationtypes.read")
+						.requestMatchers(HttpMethod.PUT, "/operationtypes/**").hasAuthority("operationtypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/operationtypes/**").hasAuthority("operationtypes.delete")
+						// patientconsensus
+						.requestMatchers(HttpMethod.POST, "/patientconsensus/**").hasAuthority("patientconsensus.create")
+						.requestMatchers(HttpMethod.GET, "/patientconsensus/**").hasAuthority("patientconsensus.read")
+						.requestMatchers(HttpMethod.PUT, "/patientconsensus/**").hasAuthority("patientconsensus.update")
+						.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
+						// patients
+						.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
+						.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
+						.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")
+						.requestMatchers(HttpMethod.DELETE, "/patients/**").hasAuthority("patients.delete")
+						// patientvaccines
+						.requestMatchers(HttpMethod.POST, "/patientvaccines/**").hasAuthority("patientvaccines.create")
+						.requestMatchers(HttpMethod.GET, "/patientvaccines/**").hasAnyAuthority("patientvaccines.read")
+						.requestMatchers(HttpMethod.PUT, "/patientvaccines/**").hasAuthority("patientvaccines.update")
+						.requestMatchers(HttpMethod.DELETE, "/patientvaccines/**").hasAuthority("patientvaccines.delete")
+						// permission
+						.requestMatchers(HttpMethod.POST, "/permissions/**").hasAuthority("permissions.create")
+						.requestMatchers(HttpMethod.GET, "/permissions/**").hasAuthority("permissions.read")
+						.requestMatchers(HttpMethod.PUT, "/permissions/**").hasAuthority("permissions.update")
+						.requestMatchers(HttpMethod.DELETE, "/permissions/**").hasAuthority("permissions.delete")
+						// grouppermission
+						.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
+						.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
+						.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**")
+						.access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
+						.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
+						// usergroups
+						.requestMatchers(HttpMethod.POST, "/usergroups/**").hasAuthority("usergroups.create")
+						.requestMatchers(HttpMethod.GET, "/usergroups/**").hasAuthority("usergroups.read")
+						.requestMatchers(HttpMethod.PUT, "/usergroups/**").hasAuthority("usergroups.update")
+						.requestMatchers(HttpMethod.DELETE, "/usergroups/**").hasAuthority("usergroups.delete")
+						// user
+						.requestMatchers("/users/me").authenticated()
+						.requestMatchers(HttpMethod.POST, "/users").hasAuthority("users.create")
+						.requestMatchers(HttpMethod.GET, "/users/**").hasAuthority("users.read")
+						.requestMatchers(HttpMethod.PUT, "/users/{username}").hasAuthority("users.update")
+						.requestMatchers(HttpMethod.DELETE, "/users/**").hasAuthority("users.delete")
+						// user setting
+						.requestMatchers("/usersettings/**").authenticated()
+						// pregnanttreatmenttypes
+						.requestMatchers(HttpMethod.POST, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.create")
+						.requestMatchers(HttpMethod.GET, "/pregnanttreatmenttypes/**").hasAnyAuthority("pregnanttreatmenttypes.read")
+						.requestMatchers(HttpMethod.PUT, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.delete")
+						// pricelists
+						.requestMatchers(HttpMethod.POST, "/pricelists/**").hasAuthority("pricelists.create")
+						.requestMatchers(HttpMethod.GET, "/pricelists/**").hasAnyAuthority("pricelists.read")
+						.requestMatchers(HttpMethod.PUT, "/pricelists/**").hasAuthority("pricelists.update")
+						.requestMatchers(HttpMethod.DELETE, "/pricelists/**").hasAuthority("pricelists.delete")
+						// pricesothers
+						.requestMatchers(HttpMethod.POST, "/pricesothers/**").hasAuthority("pricesothers.create")
+						.requestMatchers(HttpMethod.GET, "/pricesothers/**").hasAnyAuthority("pricesothers.read")
+						.requestMatchers(HttpMethod.PUT, "/pricesothers/**").hasAuthority("pricesothers.update")
+						.requestMatchers(HttpMethod.DELETE, "/pricesothers/**").hasAuthority("pricesothers.delete")
+						// reports
+						.requestMatchers(HttpMethod.POST, "/reports/**").hasAuthority("reports.create")
+						.requestMatchers(HttpMethod.GET, "/reports/**").hasAnyAuthority("reports.read")
+						.requestMatchers(HttpMethod.PUT, "/reports/**").hasAuthority("reports.update")
+						.requestMatchers(HttpMethod.DELETE, "/reports/**").hasAuthority("reports.delete")
+						// sms
+						.requestMatchers(HttpMethod.POST, "/sms/**").hasAuthority("sms.create")
+						.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
+						.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
+						.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
+						// suppliers
+						.requestMatchers(HttpMethod.POST, "/suppliers/**").hasAuthority("suppliers.create")
+						.requestMatchers(HttpMethod.GET, "/suppliers/**").hasAnyAuthority("suppliers.read")
+						.requestMatchers(HttpMethod.PUT, "/suppliers/**").hasAuthority("suppliers.update")
+						.requestMatchers(HttpMethod.DELETE, "/suppliers/**").hasAuthority("suppliers.delete")
+						// therapy
+						.requestMatchers(HttpMethod.POST, "/therapies/**").hasAuthority("therapies.create")
+						.requestMatchers(HttpMethod.GET, "/therapies/**").hasAnyAuthority("therapies.read")
+						.requestMatchers(HttpMethod.PUT, "/therapies/**").hasAuthority("therapies.update")
+						.requestMatchers(HttpMethod.DELETE, "/therapies/**").hasAuthority("therapies.delete")
+						// vaccines
+						.requestMatchers(HttpMethod.POST, "/vaccines/**").hasAuthority("vaccines.create")
+						.requestMatchers(HttpMethod.GET, "/vaccines/**").hasAnyAuthority("vaccines.read")
+						.requestMatchers(HttpMethod.PUT, "/vaccines/**").hasAuthority("vaccines.update")
+						.requestMatchers(HttpMethod.DELETE, "/vaccines/**").hasAuthority("vaccines.delete")
+						// vaccineType
+						.requestMatchers(HttpMethod.POST, "/vaccinetypes/**").hasAuthority("vaccinetypes.create")
+						.requestMatchers(HttpMethod.GET, "/vaccinetypes/**").hasAnyAuthority("vaccinetypes.read")
+						.requestMatchers(HttpMethod.PUT, "/vaccinetypes/**").hasAuthority("vaccinetypes.update")
+						.requestMatchers(HttpMethod.DELETE, "/vaccinetypes/**").hasAuthority("vaccinetypes.delete")
+						// visit
+						.requestMatchers(HttpMethod.POST, "/visits/**").hasAuthority("visits.create")
+						.requestMatchers(HttpMethod.GET, "/visits/**").hasAnyAuthority("visits.read")
+						.requestMatchers(HttpMethod.PUT, "/visits/**").hasAuthority("visits.update")
+						.requestMatchers(HttpMethod.DELETE, "/visits/**").hasAuthority("visits.delete")
+						// wards
+						.requestMatchers(HttpMethod.POST, "/wards/**").hasAuthority("wards.create")
+						.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
+						.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
+						.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
 
-			// .requestMatchers("/auth-needed/**").authenticated()
-			// .requestMatchers("/noauth-public/**").permitAll()
-			// .requestMatchers("/admin/**").hasAuthority("admin")
+						// .requestMatchers("/auth-needed/**").authenticated()
+						// .requestMatchers("/noauth-public/**").permitAll()
+						// .requestMatchers("/admin/**").hasAuthority("admin")
 
-			//			.and()
-			//			.formLogin()
-			//				 .loginPage("/auth/login")
-			//				 .successHandler(successHandler())
-			//				 .failureHandler(failureHandler())
-			.and().apply(securityConfigurerAdapter())
-			.and().httpBasic()
-			.and().logout().logoutUrl("/auth/logout").addLogoutHandler(customLogoutHandler).permitAll();
+						//			.and()
+						//			.formLogin()
+						//				 .loginPage("/auth/login")
+						//				 .successHandler(successHandler())
+						//				 .failureHandler(failureHandler())
+						.and().apply(securityConfigurerAdapter())
+						.and().httpBasic()
+						.and().logout().logoutUrl("/auth/logout").addLogoutHandler(customLogoutHandler).permitAll();
 		return http.build();
 	}
 

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -21,6 +21,8 @@
  */
 package org.isf.config;
 
+import java.util.List;
+
 import org.isf.permissions.manager.PermissionManager;
 import org.isf.security.ApiAuditorAwareImpl;
 import org.isf.security.CustomLogoutHandler;
@@ -52,8 +54,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -252,7 +252,8 @@ public class SecurityConfig {
 			// grouppermission
 			.requestMatchers(HttpMethod.POST, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
 			.requestMatchers(HttpMethod.GET, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.read")
-			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**")
+			.requestMatchers(HttpMethod.PUT, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.create")
+			.requestMatchers(HttpMethod.PATCH, "/usergroups/{group_code}/permissions/**")
 			.access("hasAuthority('grouppermission.create') and hasAuthority('grouppermission.delete')")
 			.requestMatchers(HttpMethod.DELETE, "/usergroups/{group_code}/permissions/**").hasAuthority("grouppermission.delete")
 			// usergroups

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -1,3 +1,24 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.isf.usergroups.dto;
 
 import java.util.List;

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -26,6 +26,6 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GroupPermissionsDTO(
-	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
+	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissionIds) {
 
 }

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -1,9 +1,10 @@
 package org.isf.usergroups.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record GroupPermissionsDTO(
-	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
+				@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
+
 }

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -1,8 +1,8 @@
 package org.isf.usergroups.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GroupPermissionsDTO(
 	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -1,10 +1,10 @@
 package org.isf.usergroups.dto;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 public record GroupPermissionsDTO(
-				@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
+	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
 
 }

--- a/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
+++ b/src/main/java/org/isf/usergroups/dto/GroupPermissionsDTO.java
@@ -1,0 +1,9 @@
+package org.isf.usergroups.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record GroupPermissionsDTO(
+	@Schema(name = "permissions", example = "[48, 24]", description = "List of permissions' ids") List<Integer> permissions) {
+}

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -33,6 +33,7 @@ import org.isf.permissions.mapper.PermissionMapper;
 import org.isf.permissions.model.GroupPermission;
 import org.isf.permissions.model.Permission;
 import org.isf.shared.exceptions.OHAPIException;
+import org.isf.usergroups.dto.GroupPermissionsDTO;
 import org.isf.usergroups.dto.UserGroupDTO;
 import org.isf.usergroups.mapper.UserGroupMapper;
 import org.isf.utils.exception.OHDataValidationException;
@@ -55,201 +56,218 @@ import java.util.stream.Collectors;
 @SecurityRequirement(name = "bearerAuth")
 public class UserGroupController {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(UserGroupController.class);
-	@Autowired
-	protected PermissionManager permissionManager;
-	@Autowired
-	protected GroupPermissionManager groupPermissionManager;
-	@Autowired
-	private UserGroupMapper userGroupMapper;
-	@Autowired
-	private PermissionMapper permissionMapper;
-	@Autowired
-	private UserBrowsingManager userManager;
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserGroupController.class);
+    @Autowired
+    protected PermissionManager permissionManager;
+    @Autowired
+    protected GroupPermissionManager groupPermissionManager;
+    @Autowired
+    private UserGroupMapper userGroupMapper;
+    @Autowired
+    private PermissionMapper permissionMapper;
+    @Autowired
+    private UserBrowsingManager userManager;
 
-	/**
-	 * Returns the list of {@link UserGroup}s.
-	 *
-	 * @return the list of {@link UserGroup}s
-	 */
-	@GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
-	public List<UserGroupDTO> getUserGroups() throws OHServiceException {
-		LOGGER.info("Attempting to fetch the list of user groups.");
-		List<UserGroup> groups = userManager.getUserGroup();
-		List<UserGroupDTO> mappedGroups = userGroupMapper.map2DTOList(groups);
-		LOGGER.info("Found {} group(s).", mappedGroups.size());
-		return mappedGroups;
-	}
+    /**
+     * Returns the list of {@link UserGroup}s.
+     *
+     * @return the list of {@link UserGroup}s
+     */
+    @GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<UserGroupDTO> getUserGroups() throws OHServiceException {
+        LOGGER.info("Attempting to fetch the list of user groups.");
+        List<UserGroup> groups = userManager.getUserGroup();
+        List<UserGroupDTO> mappedGroups = userGroupMapper.map2DTOList(groups);
+        LOGGER.info("Found {} group(s).", mappedGroups.size());
+        return mappedGroups;
+    }
 
-	/**
-	 * Deletes a {@link UserGroup}.
-	 *
-	 * @param code - the code of the {@link UserGroup} to delete
-	 */
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@DeleteMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public void deleteGroup(@PathVariable("group_code") String code) throws OHServiceException {
-		try {
-			UserGroup group = loadUserGroup(code);
-			userManager.deleteGroup(group);
-		} catch (OHServiceException serviceException) {
-			throw new OHAPIException(new OHExceptionMessage("User group not deleted."));
-		}
-	}
+    /**
+     * Deletes a {@link UserGroup}.
+     *
+     * @param code - the code of the {@link UserGroup} to delete
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public void deleteGroup(@PathVariable("group_code") String code) throws OHServiceException {
+        try {
+            UserGroup group = loadUserGroup(code);
+            userManager.deleteGroup(group);
+        } catch (OHServiceException serviceException) {
+            throw new OHAPIException(new OHExceptionMessage("User group not deleted."));
+        }
+    }
 
-	/**
-	 * Creates a new {@link UserGroup} with a minimum set of rights.
-	 *
-	 * @param userGroupDTO - the {@link UserGroup} to insert
-	 * @return the {@link UserGroupDTO} of new user group.
-	 * @throws OHServiceException When failed to create the user group
-	 */
-	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
-	public UserGroupDTO newUserGroup(@Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
-		UserGroup userGroup = userGroupMapper.map2Model(userGroupDTO);
-		List<Permission> permissions = new ArrayList<>();
+    /**
+     * Creates a new {@link UserGroup} with a minimum set of rights.
+     *
+     * @param userGroupDTO - the {@link UserGroup} to insert
+     * @return the {@link UserGroupDTO} of new user group.
+     * @throws OHServiceException When failed to create the user group
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
+    public UserGroupDTO newUserGroup(@Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
+        UserGroup userGroup = userGroupMapper.map2Model(userGroupDTO);
+        List<Permission> permissions = new ArrayList<>();
 
-		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
-			permissions = userGroupDTO.getPermissions()
-				.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-				.toList();
-		}
+        if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
+            permissions = userGroupDTO.getPermissions()
+                    .stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+                    .toList();
+        }
 
-		try {
-			var group = userManager.newUserGroup(userGroup, permissions);
-			return getUserGroup(group.getCode());
-		} catch (OHServiceException serviceException) {
-			throw new OHAPIException(new OHExceptionMessage("User group not created."));
-		}
-	}
+        try {
+            var group = userManager.newUserGroup(userGroup, permissions);
+            return getUserGroup(group.getCode());
+        } catch (OHServiceException serviceException) {
+            throw new OHAPIException(new OHExceptionMessage("User group not created."));
+        }
+    }
 
-	/**
-	 * Updates an existing {@link UserGroup}.
-	 *
-	 * @param userGroupDTO - the {@link UserGroup} to update
-	 * @return {@link  UserGroupDTO} for the updated group.
-	 * @throws OHServiceException When failed to update the user group
-	 */
-	@PutMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public UserGroupDTO updateUserGroup(@PathVariable("group_code") String code, @Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
-		if (!Objects.equals(userGroupDTO.getCode(), code)) {
-			throw new OHAPIException(new OHExceptionMessage("Invalid request payload"));
-		}
-		UserGroup group = userGroupMapper.map2Model(userGroupDTO);
+    /**
+     * Updates an existing {@link UserGroup}.
+     *
+     * @param userGroupDTO - the {@link UserGroup} to update
+     * @return {@link  UserGroupDTO} for the updated group.
+     * @throws OHServiceException When failed to update the user group
+     */
+    @PutMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public UserGroupDTO updateUserGroup(@PathVariable("group_code") String code, @Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
+        if (!Objects.equals(userGroupDTO.getCode(), code)) {
+            throw new OHAPIException(new OHExceptionMessage("Invalid request payload"));
+        }
+        UserGroup group = userGroupMapper.map2Model(userGroupDTO);
 
-		if (!userManager.findUserGroupByCode(userGroupDTO.getCode()).getCode().equals(group.getCode())) {
-			throw new OHAPIException(new OHExceptionMessage("User group not found."));
-		}
+        if (!userManager.findUserGroupByCode(userGroupDTO.getCode()).getCode().equals(group.getCode())) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+        }
 
-		List<Permission> permissions = new ArrayList<>();
-		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
-			permissions = userGroupDTO.getPermissions()
-				.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-				.toList();
-		}
+        List<Permission> permissions = new ArrayList<>();
+        if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
+            permissions = userGroupDTO.getPermissions()
+                    .stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+                    .toList();
+        }
 
-		boolean isUpdated = userManager.updateUserGroup(group, permissions);
-		if (isUpdated) {
-			return getUserGroup(group.getCode());
-		} else {
-			throw new OHAPIException(new OHExceptionMessage("User group not updated."));
-		}
-	}
+        boolean isUpdated = userManager.updateUserGroup(group, permissions);
+        if (isUpdated) {
+            return getUserGroup(group.getCode());
+        } else {
+            throw new OHAPIException(new OHExceptionMessage("User group not updated."));
+        }
+    }
 
-	/**
-	 * Retrieve a {@link UserGroup} using its code
-	 *
-	 * @param code UserGroup code
-	 * @return Returns the {@link UserGroup} found using the given code
-	 * @throws OHServiceException When failed to retrieve the user group
-	 */
-	@GetMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public UserGroupDTO getUserGroup(@PathVariable("group_code") String code) throws OHServiceException {
-		UserGroup userGroup = userManager.findUserGroupByCode(code);
-		if (userGroup == null) {
-			throw new OHAPIException(new OHExceptionMessage("User group not found."));
-		}
+    /**
+     * Retrieve a {@link UserGroup} using its code
+     *
+     * @param code UserGroup code
+     * @return Returns the {@link UserGroup} found using the given code
+     * @throws OHServiceException When failed to retrieve the user group
+     */
+    @GetMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public UserGroupDTO getUserGroup(@PathVariable("group_code") String code) throws OHServiceException {
+        UserGroup userGroup = userManager.findUserGroupByCode(code);
+        if (userGroup == null) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+        }
 
-		List<GroupPermission> groupPermissions = groupPermissionManager.findUserGroupPermissions(userGroup.getCode());
-		List<PermissionDTO> permissions = groupPermissions.stream()
-			.map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
-			.toList();
+        List<GroupPermission> groupPermissions = groupPermissionManager.findUserGroupPermissions(userGroup.getCode());
+        List<PermissionDTO> permissions = groupPermissions.stream()
+                .map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
+                .toList();
 
-		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-		userGroupDTO.setPermissions(permissions);
+        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        userGroupDTO.setPermissions(permissions);
 
-		return userGroupDTO;
-	}
+        return userGroupDTO;
+    }
 
-	/**
-	 * Assign a {@link Permission} to a {@link UserGroup}
-	 *
-	 * @param userGroupCode - the {@link UserGroup}'s code
-	 * @param permissionId  - the {@link Permission}'s id
-	 * @return the id of the new group permission.
-	 * @throws OHServiceException When failed to assign the permission to the user group
-	 */
-	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public int assignPermission(
-		@PathVariable("group_code") String userGroupCode,
-		@PathVariable("id") int permissionId
-	) throws OHServiceException {
-		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
-		if (userGroup == null) {
-			throw new OHAPIException(new OHExceptionMessage("User group not found."));
-		}
+    /**
+     * Assign a {@link Permission} to a {@link UserGroup}
+     *
+     * @param userGroupCode - the {@link UserGroup}'s code
+     * @param permissionId  - the {@link Permission}'s id
+     * @return the id of the new group permission.
+     * @throws OHServiceException When failed to assign the permission to the user group
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public int assignPermission(
+            @PathVariable("group_code") String userGroupCode,
+            @PathVariable("id") int permissionId
+    ) throws OHServiceException {
+        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+        if (userGroup == null) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+        }
 
-		Permission permission = permissionManager.retrievePermissionById(permissionId);
+        Permission permission = permissionManager.retrievePermissionById(permissionId);
 
-		if (permission == null || permission.getName() == null) {
-			throw new OHAPIException(new OHExceptionMessage("Permission not found."));
-		}
+        if (permission == null || permission.getName() == null) {
+            throw new OHAPIException(new OHExceptionMessage("Permission not found."));
+        }
 
-		try {
-			return groupPermissionManager.create(userGroup, permission).getId();
-		} catch (OHDataValidationException e) {
-			throw new OHAPIException(new OHExceptionMessage("Failed to assign permission"));
-		}
-	}
+        try {
+            return groupPermissionManager.create(userGroup, permission).getId();
+        } catch (OHDataValidationException e) {
+            throw new OHAPIException(new OHExceptionMessage("Failed to assign permission"));
+        }
+    }
 
-	/**
-	 * Revoke a {@link Permission} from a {@link UserGroup}
-	 *
-	 * @param userGroupCode - the {@link UserGroup}'s code
-	 * @param permissionId  - the {@link Permission}'s id
-	 * @throws OHServiceException When failed to revoke the permission to the user group
-	 */
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@DeleteMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public void revokePermission(
-		@PathVariable("group_code") String userGroupCode,
-		@PathVariable("id") int permissionId
-	) throws OHServiceException {
-		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
-		if (userGroup == null) {
-			throw new OHAPIException(new OHExceptionMessage("User group not found."));
-		}
+    @PutMapping(value = "/usergroups/{group_code}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<PermissionDTO> updateGroupPermissions(
+            @PathVariable("group_code") String userGroupCode,
+            @RequestBody GroupPermissionsDTO payload
+    ) throws OHServiceException {
+        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+        if (userGroup == null) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+        }
 
-		Permission permission = permissionManager.retrievePermissionById(permissionId);
+        try {
+            return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissions()));
+        } catch (OHDataValidationException e) {
+            throw new OHAPIException(new OHExceptionMessage("Failed to update permissions"));
+        }
+    }
 
-		if (permission == null || permission.getName() == null) {
-			throw new OHAPIException(new OHExceptionMessage("Permission not found."));
-		}
+    /**
+     * Revoke a {@link Permission} from a {@link UserGroup}
+     *
+     * @param userGroupCode - the {@link UserGroup}'s code
+     * @param permissionId  - the {@link Permission}'s id
+     * @throws OHServiceException When failed to revoke the permission to the user group
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public void revokePermission(
+            @PathVariable("group_code") String userGroupCode,
+            @PathVariable("id") int permissionId
+    ) throws OHServiceException {
+        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+        if (userGroup == null) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+        }
 
-		try {
-			groupPermissionManager.delete(userGroup, permission);
-		} catch (OHDataValidationException e) {
-			throw new OHAPIException(new OHExceptionMessage("Failed to revoke permission"));
-		}
-	}
+        Permission permission = permissionManager.retrievePermissionById(permissionId);
 
-	private UserGroup loadUserGroup(String code) throws OHServiceException {
-		List<UserGroup> group = userManager.getUserGroup().stream().filter(g -> g.getCode().equals(code)).collect(Collectors.toList());
-		if (group.isEmpty()) {
-			throw new OHAPIException(new OHExceptionMessage("User group not found."));
-		}
-		return group.get(0);
-	}
+        if (permission == null || permission.getName() == null) {
+            throw new OHAPIException(new OHExceptionMessage("Permission not found."));
+        }
+
+        try {
+            groupPermissionManager.delete(userGroup, permission);
+        } catch (OHDataValidationException e) {
+            throw new OHAPIException(new OHExceptionMessage("Failed to revoke permission"));
+        }
+    }
+
+    private UserGroup loadUserGroup(String code) throws OHServiceException {
+        List<UserGroup> group = userManager.getUserGroup().stream().filter(g -> g.getCode().equals(code)).collect(Collectors.toList());
+        if (group.isEmpty()) {
+            throw new OHAPIException(new OHExceptionMessage("User group not found."));
+        }
+        return group.get(0);
+    }
 }

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -21,9 +21,13 @@
  */
 package org.isf.usergroups.rest;
 
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import jakarta.validation.Valid;
+
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.permissions.dto.PermissionDTO;
@@ -44,247 +48,244 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController(value = "/usergroups")
 @Tag(name = "User Groups")
 @SecurityRequirement(name = "bearerAuth")
 public class UserGroupController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserGroupController.class);
-    @Autowired
-    protected PermissionManager permissionManager;
-    @Autowired
-    protected GroupPermissionManager groupPermissionManager;
-    @Autowired
-    private UserGroupMapper userGroupMapper;
-    @Autowired
-    private PermissionMapper permissionMapper;
-    @Autowired
-    private UserBrowsingManager userManager;
+	private static final Logger LOGGER = LoggerFactory.getLogger(UserGroupController.class);
+	@Autowired
+	protected PermissionManager permissionManager;
+	@Autowired
+	protected GroupPermissionManager groupPermissionManager;
+	@Autowired
+	private UserGroupMapper userGroupMapper;
+	@Autowired
+	private PermissionMapper permissionMapper;
+	@Autowired
+	private UserBrowsingManager userManager;
 
-    /**
-     * Returns the list of {@link UserGroup}s.
-     *
-     * @return the list of {@link UserGroup}s
-     */
-    @GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<UserGroupDTO> getUserGroups() throws OHServiceException {
-        LOGGER.info("Attempting to fetch the list of user groups.");
-        List<UserGroup> groups = userManager.getUserGroup();
-        List<UserGroupDTO> mappedGroups = userGroupMapper.map2DTOList(groups);
-        LOGGER.info("Found {} group(s).", mappedGroups.size());
-        return mappedGroups;
-    }
+	/**
+	 * Returns the list of {@link UserGroup}s.
+	 * @return the list of {@link UserGroup}s
+	 */
+	@GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
+	public List<UserGroupDTO> getUserGroups() throws OHServiceException {
+		LOGGER.info("Attempting to fetch the list of user groups.");
+		List<UserGroup> groups = userManager.getUserGroup();
+		List<UserGroupDTO> mappedGroups = userGroupMapper.map2DTOList(groups);
+		LOGGER.info("Found {} group(s).", mappedGroups.size());
+		return mappedGroups;
+	}
 
-    /**
-     * Deletes a {@link UserGroup}.
-     *
-     * @param code - the code of the {@link UserGroup} to delete
-     */
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void deleteGroup(@PathVariable("group_code") String code) throws OHServiceException {
-        try {
-            UserGroup group = loadUserGroup(code);
-            userManager.deleteGroup(group);
-        } catch (OHServiceException serviceException) {
-            throw new OHAPIException(new OHExceptionMessage("User group not deleted."));
-        }
-    }
+	/**
+	 * Deletes a {@link UserGroup}.
+	 * @param code - the code of the {@link UserGroup} to delete
+	 */
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public void deleteGroup(@PathVariable("group_code") String code) throws OHServiceException {
+		try {
+			UserGroup group = loadUserGroup(code);
+			userManager.deleteGroup(group);
+		} catch (OHServiceException serviceException) {
+			throw new OHAPIException(new OHExceptionMessage("User group not deleted."));
+		}
+	}
 
-    /**
-     * Creates a new {@link UserGroup} with a minimum set of rights.
-     *
-     * @param userGroupDTO - the {@link UserGroup} to insert
-     * @return the {@link UserGroupDTO} of new user group.
-     * @throws OHServiceException When failed to create the user group
-     */
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
-    public UserGroupDTO newUserGroup(@Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
-        UserGroup userGroup = userGroupMapper.map2Model(userGroupDTO);
-        List<Permission> permissions = new ArrayList<>();
+	/**
+	 * Creates a new {@link UserGroup} with a minimum set of rights.
+	 * @param userGroupDTO - the {@link UserGroup} to insert
+	 * @return the {@link UserGroupDTO} of new user group.
+	 * @throws OHServiceException When failed to create the user group
+	 */
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
+	public UserGroupDTO newUserGroup(@Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
+		UserGroup userGroup = userGroupMapper.map2Model(userGroupDTO);
+		List<Permission> permissions = new ArrayList<>();
 
-        if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
-            permissions = userGroupDTO.getPermissions()
-                    .stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-                    .toList();
-        }
+		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
+			permissions = userGroupDTO.getPermissions()
+							.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+							.toList();
+		}
 
-        try {
-            var group = userManager.newUserGroup(userGroup, permissions);
-            return getUserGroup(group.getCode());
-        } catch (OHServiceException serviceException) {
-            throw new OHAPIException(new OHExceptionMessage("User group not created."));
-        }
-    }
+		try {
+			var group = userManager.newUserGroup(userGroup, permissions);
+			return getUserGroup(group.getCode());
+		} catch (OHServiceException serviceException) {
+			throw new OHAPIException(new OHExceptionMessage("User group not created."));
+		}
+	}
 
-    /**
-     * Updates an existing {@link UserGroup}.
-     *
-     * @param userGroupDTO - the {@link UserGroup} to update
-     * @return {@link  UserGroupDTO} for the updated group.
-     * @throws OHServiceException When failed to update the user group
-     */
-    @PutMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public UserGroupDTO updateUserGroup(@PathVariable("group_code") String code, @Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
-        if (!Objects.equals(userGroupDTO.getCode(), code)) {
-            throw new OHAPIException(new OHExceptionMessage("Invalid request payload"));
-        }
-        UserGroup group = userGroupMapper.map2Model(userGroupDTO);
+	/**
+	 * Updates an existing {@link UserGroup}.
+	 * @param userGroupDTO - the {@link UserGroup} to update
+	 * @return {@link  UserGroupDTO} for the updated group.
+	 * @throws OHServiceException When failed to update the user group
+	 */
+	@PutMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public UserGroupDTO updateUserGroup(@PathVariable("group_code") String code, @Valid @RequestBody UserGroupDTO userGroupDTO) throws OHServiceException {
+		if (!Objects.equals(userGroupDTO.getCode(), code)) {
+			throw new OHAPIException(new OHExceptionMessage("Invalid request payload"));
+		}
+		UserGroup group = userGroupMapper.map2Model(userGroupDTO);
 
-        if (!userManager.findUserGroupByCode(userGroupDTO.getCode()).getCode().equals(group.getCode())) {
-            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
-        }
+		if (!userManager.findUserGroupByCode(userGroupDTO.getCode()).getCode().equals(group.getCode())) {
+			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+		}
 
-        List<Permission> permissions = new ArrayList<>();
-        if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
-            permissions = userGroupDTO.getPermissions()
-                    .stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-                    .toList();
-        }
+		List<Permission> permissions = new ArrayList<>();
+		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
+			permissions = userGroupDTO.getPermissions()
+							.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+							.toList();
+		}
 
-        boolean isUpdated = userManager.updateUserGroup(group, permissions);
-        if (isUpdated) {
-            return getUserGroup(group.getCode());
-        } else {
-            throw new OHAPIException(new OHExceptionMessage("User group not updated."));
-        }
-    }
+		boolean isUpdated = userManager.updateUserGroup(group, permissions);
+		if (isUpdated) {
+			return getUserGroup(group.getCode());
+		} else {
+			throw new OHAPIException(new OHExceptionMessage("User group not updated."));
+		}
+	}
 
-    /**
-     * Retrieve a {@link UserGroup} using its code
-     *
-     * @param code UserGroup code
-     * @return Returns the {@link UserGroup} found using the given code
-     * @throws OHServiceException When failed to retrieve the user group
-     */
-    @GetMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public UserGroupDTO getUserGroup(@PathVariable("group_code") String code) throws OHServiceException {
-        UserGroup userGroup = userManager.findUserGroupByCode(code);
-        if (userGroup == null) {
-            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
-        }
+	/**
+	 * Retrieve a {@link UserGroup} using its code
+	 * @param code UserGroup code
+	 * @return Returns the {@link UserGroup} found using the given code
+	 * @throws OHServiceException When failed to retrieve the user group
+	 */
+	@GetMapping(value = "/usergroups/{group_code}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public UserGroupDTO getUserGroup(@PathVariable("group_code") String code) throws OHServiceException {
+		UserGroup userGroup = userManager.findUserGroupByCode(code);
+		if (userGroup == null) {
+			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+		}
 
-        List<GroupPermission> groupPermissions = groupPermissionManager.findUserGroupPermissions(userGroup.getCode());
-        List<PermissionDTO> permissions = groupPermissions.stream()
-                .map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
-                .toList();
+		List<GroupPermission> groupPermissions = groupPermissionManager.findUserGroupPermissions(userGroup.getCode());
+		List<PermissionDTO> permissions = groupPermissions.stream()
+						.map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
+						.toList();
 
-        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-        userGroupDTO.setPermissions(permissions);
+		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+		userGroupDTO.setPermissions(permissions);
 
-        return userGroupDTO;
-    }
+		return userGroupDTO;
+	}
 
-    /**
-     * Assign a {@link Permission} to a {@link UserGroup}
-     *
-     * @param userGroupCode - the {@link UserGroup}'s code
-     * @param permissionId  - the {@link Permission}'s id
-     * @return the id of the new group permission.
-     * @throws OHServiceException When failed to assign the permission to the user group
-     */
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public int assignPermission(
-            @PathVariable("group_code") String userGroupCode,
-            @PathVariable("id") int permissionId
-    ) throws OHServiceException {
-        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
-        if (userGroup == null) {
-            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
-        }
+	/**
+	 * Assign a {@link Permission} to a {@link UserGroup}
+	 * @param userGroupCode - the {@link UserGroup}'s code
+	 * @param permissionId - the {@link Permission}'s id
+	 * @return the id of the new group permission.
+	 * @throws OHServiceException When failed to assign the permission to the user group
+	 */
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public int assignPermission(
+					@PathVariable("group_code") String userGroupCode,
+					@PathVariable("id") int permissionId
+	) throws OHServiceException {
+		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+		if (userGroup == null) {
+			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+		}
 
-        Permission permission = permissionManager.retrievePermissionById(permissionId);
+		Permission permission = permissionManager.retrievePermissionById(permissionId);
 
-        if (permission == null || permission.getName() == null) {
-            throw new OHAPIException(new OHExceptionMessage("Permission not found."));
-        }
+		if (permission == null || permission.getName() == null) {
+			throw new OHAPIException(new OHExceptionMessage("Permission not found."));
+		}
 
-        try {
-            return groupPermissionManager.create(userGroup, permission).getId();
-        } catch (OHDataValidationException e) {
-            throw new OHAPIException(new OHExceptionMessage("Failed to assign permission"));
-        }
-    }
+		try {
+			return groupPermissionManager.create(userGroup, permission).getId();
+		} catch (OHDataValidationException e) {
+			throw new OHAPIException(new OHExceptionMessage("Failed to assign permission"));
+		}
+	}
 
-    /**
-     * Assign or revoke permissions for the target user group.
-     * <ul>
-     *     <li>Ids corresponding to permissions already assigned to the group will be skipped.</li>
-     *     <li>User group permissions that don't have their id in the permission ids payload will be removed</li>
-     *     <li>ids that corresponding permission are not yet assigned to the groups will be assigned.</li>
-     *     <li>Permissions ids that don't exist are ignored</li>
-     * </ul>
-     *
-     * @param userGroupCode Code of the group to update
-     * @param payload       New group permissions
-     * @return List of {@link PermissionDTO} corresponding to the list of permissions assigned to the group
-     * @throws OHServiceException If the update operation fails
-     */
-    @PutMapping(value = "/usergroups/{group_code}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<PermissionDTO> updateGroupPermissions(
-            @PathVariable("group_code") String userGroupCode,
-            @RequestBody GroupPermissionsDTO payload
-    ) throws OHServiceException {
-        LOGGER.info("Attempting to update user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
-        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
-        if (userGroup == null) {
-            LOGGER.info("Could not find user corresponding to the group code {}", userGroupCode);
-            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
-        }
+	/**
+	 * Assign or revoke permissions for the target user group.
+	 * <ul>
+	 *     <li>Ids corresponding to permissions already assigned to the group will be skipped.</li>
+	 *     <li>User group permissions that don't have their id in the permission ids payload will be removed</li>
+	 *     <li>ids that corresponding permission are not yet assigned to the groups will be assigned.</li>
+	 *     <li>Permissions ids that don't exist are ignored</li>
+	 * </ul>
+	 * @param userGroupCode Code of the group to update
+	 * @param payload New group permissions
+	 * @return List of {@link PermissionDTO} corresponding to the list of permissions assigned to the group
+	 * @throws OHServiceException If the update operation fails
+	 */
+	@PutMapping(value = "/usergroups/{group_code}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
+	public List<PermissionDTO> updateGroupPermissions(
+					@PathVariable("group_code") String userGroupCode,
+					@RequestBody GroupPermissionsDTO payload
+	) throws OHServiceException {
+		LOGGER.info("Attempting to update user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
+		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+		if (userGroup == null) {
+			LOGGER.info("Could not find user corresponding to the group code {}", userGroupCode);
+			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+		}
 
-        try {
-            return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissions()));
-        } catch (OHDataValidationException e) {
-            LOGGER.info("Fail to update user groups permissions, reason: {}", e.getMessage());
-            throw new OHAPIException(new OHExceptionMessage("Failed to update permissions"));
-        }
-    }
+		try {
+			return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissions()));
+		} catch (OHDataValidationException e) {
+			LOGGER.info("Fail to update user groups permissions, reason: {}", e.getMessage());
+			throw new OHAPIException(new OHExceptionMessage("Failed to update permissions"));
+		}
+	}
 
-    /**
-     * Revoke a {@link Permission} from a {@link UserGroup}
-     *
-     * @param userGroupCode - the {@link UserGroup}'s code
-     * @param permissionId  - the {@link Permission}'s id
-     * @throws OHServiceException When failed to revoke the permission to the user group
-     */
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void revokePermission(
-            @PathVariable("group_code") String userGroupCode,
-            @PathVariable("id") int permissionId
-    ) throws OHServiceException {
-        UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
-        if (userGroup == null) {
-            throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
-        }
+	/**
+	 * Revoke a {@link Permission} from a {@link UserGroup}
+	 * @param userGroupCode - the {@link UserGroup}'s code
+	 * @param permissionId - the {@link Permission}'s id
+	 * @throws OHServiceException When failed to revoke the permission to the user group
+	 */
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public void revokePermission(
+					@PathVariable("group_code") String userGroupCode,
+					@PathVariable("id") int permissionId
+	) throws OHServiceException {
+		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
+		if (userGroup == null) {
+			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
+		}
 
-        Permission permission = permissionManager.retrievePermissionById(permissionId);
+		Permission permission = permissionManager.retrievePermissionById(permissionId);
 
-        if (permission == null || permission.getName() == null) {
-            throw new OHAPIException(new OHExceptionMessage("Permission not found."));
-        }
+		if (permission == null || permission.getName() == null) {
+			throw new OHAPIException(new OHExceptionMessage("Permission not found."));
+		}
 
-        try {
-            groupPermissionManager.delete(userGroup, permission);
-        } catch (OHDataValidationException e) {
-            throw new OHAPIException(new OHExceptionMessage("Failed to revoke permission"));
-        }
-    }
+		try {
+			groupPermissionManager.delete(userGroup, permission);
+		} catch (OHDataValidationException e) {
+			throw new OHAPIException(new OHExceptionMessage("Failed to revoke permission"));
+		}
+	}
 
-    private UserGroup loadUserGroup(String code) throws OHServiceException {
-        List<UserGroup> group = userManager.getUserGroup().stream().filter(g -> g.getCode().equals(code)).collect(Collectors.toList());
-        if (group.isEmpty()) {
-            throw new OHAPIException(new OHExceptionMessage("User group not found."));
-        }
-        return group.get(0);
-    }
+	private UserGroup loadUserGroup(String code) throws OHServiceException {
+		List<UserGroup> group = userManager.getUserGroup().stream().filter(g -> g.getCode().equals(code)).collect(Collectors.toList());
+		if (group.isEmpty()) {
+			throw new OHAPIException(new OHExceptionMessage("User group not found."));
+		}
+		return group.get(0);
+	}
 }

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -268,7 +268,7 @@ public class UserGroupController {
 		LOGGER.info("Attempting to replace user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
 		if (userGroup == null) {
-			LOGGER.info("Could not find user corresponding to the group code {}", userGroupCode);
+			LOGGER.info("Could not find user group corresponding to the group code {}", userGroupCode);
 			throw new OHAPIException(new OHExceptionMessage("User group not found."), HttpStatus.NOT_FOUND);
 		}
 

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -21,13 +21,9 @@
  */
 package org.isf.usergroups.rest;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.permissions.dto.PermissionDTO;
@@ -48,17 +44,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @RestController(value = "/usergroups")
 @Tag(name = "User Groups")
@@ -79,6 +70,7 @@ public class UserGroupController {
 
 	/**
 	 * Returns the list of {@link UserGroup}s.
+	 *
 	 * @return the list of {@link UserGroup}s
 	 */
 	@GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -92,6 +84,7 @@ public class UserGroupController {
 
 	/**
 	 * Deletes a {@link UserGroup}.
+	 *
 	 * @param code - the code of the {@link UserGroup} to delete
 	 */
 	@ResponseStatus(HttpStatus.NO_CONTENT)
@@ -107,6 +100,7 @@ public class UserGroupController {
 
 	/**
 	 * Creates a new {@link UserGroup} with a minimum set of rights.
+	 *
 	 * @param userGroupDTO - the {@link UserGroup} to insert
 	 * @return the {@link UserGroupDTO} of new user group.
 	 * @throws OHServiceException When failed to create the user group
@@ -133,6 +127,7 @@ public class UserGroupController {
 
 	/**
 	 * Updates an existing {@link UserGroup}.
+	 *
 	 * @param userGroupDTO - the {@link UserGroup} to update
 	 * @return {@link  UserGroupDTO} for the updated group.
 	 * @throws OHServiceException When failed to update the user group
@@ -165,6 +160,7 @@ public class UserGroupController {
 
 	/**
 	 * Retrieve a {@link UserGroup} using its code
+	 *
 	 * @param code UserGroup code
 	 * @return Returns the {@link UserGroup} found using the given code
 	 * @throws OHServiceException When failed to retrieve the user group
@@ -189,6 +185,7 @@ public class UserGroupController {
 
 	/**
 	 * Assign a {@link Permission} to a {@link UserGroup}
+	 *
 	 * @param userGroupCode - the {@link UserGroup}'s code
 	 * @param permissionId - the {@link Permission}'s id
 	 * @return the id of the new group permission.
@@ -226,6 +223,7 @@ public class UserGroupController {
 	 *     <li>ids that corresponding permission are not yet assigned to the groups will be assigned.</li>
 	 *     <li>Permissions ids that don't exist are ignored</li>
 	 * </ul>
+	 *
 	 * @param userGroupCode Code of the group to update
 	 * @param payload New group permissions
 	 * @return List of {@link PermissionDTO} corresponding to the list of permissions assigned to the group
@@ -253,6 +251,7 @@ public class UserGroupController {
 
 	/**
 	 * Revoke a {@link Permission} from a {@link UserGroup}
+	 *
 	 * @param userGroupCode - the {@link UserGroup}'s code
 	 * @param permissionId - the {@link Permission}'s id
 	 * @throws OHServiceException When failed to revoke the permission to the user group

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -21,9 +21,13 @@
  */
 package org.isf.usergroups.rest;
 
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import jakarta.validation.Valid;
+
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.UserGroup;
 import org.isf.permissions.dto.PermissionDTO;
@@ -44,12 +48,17 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController(value = "/usergroups")
 @Tag(name = "User Groups")
@@ -70,7 +79,6 @@ public class UserGroupController {
 
 	/**
 	 * Returns the list of {@link UserGroup}s.
-	 *
 	 * @return the list of {@link UserGroup}s
 	 */
 	@GetMapping(value = "/usergroups", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -84,7 +92,6 @@ public class UserGroupController {
 
 	/**
 	 * Deletes a {@link UserGroup}.
-	 *
 	 * @param code - the code of the {@link UserGroup} to delete
 	 */
 	@ResponseStatus(HttpStatus.NO_CONTENT)
@@ -100,7 +107,6 @@ public class UserGroupController {
 
 	/**
 	 * Creates a new {@link UserGroup} with a minimum set of rights.
-	 *
 	 * @param userGroupDTO - the {@link UserGroup} to insert
 	 * @return the {@link UserGroupDTO} of new user group.
 	 * @throws OHServiceException When failed to create the user group
@@ -113,8 +119,8 @@ public class UserGroupController {
 
 		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
 			permissions = userGroupDTO.getPermissions()
-							.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-							.toList();
+				.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+				.toList();
 		}
 
 		try {
@@ -127,7 +133,6 @@ public class UserGroupController {
 
 	/**
 	 * Updates an existing {@link UserGroup}.
-	 *
 	 * @param userGroupDTO - the {@link UserGroup} to update
 	 * @return {@link  UserGroupDTO} for the updated group.
 	 * @throws OHServiceException When failed to update the user group
@@ -146,8 +151,8 @@ public class UserGroupController {
 		List<Permission> permissions = new ArrayList<>();
 		if (userGroupDTO.getPermissions() != null && !userGroupDTO.getPermissions().isEmpty()) {
 			permissions = userGroupDTO.getPermissions()
-							.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
-							.toList();
+				.stream().map(permissionDTO -> permissionMapper.map2Model(permissionDTO))
+				.toList();
 		}
 
 		boolean isUpdated = userManager.updateUserGroup(group, permissions);
@@ -160,7 +165,6 @@ public class UserGroupController {
 
 	/**
 	 * Retrieve a {@link UserGroup} using its code
-	 *
 	 * @param code UserGroup code
 	 * @return Returns the {@link UserGroup} found using the given code
 	 * @throws OHServiceException When failed to retrieve the user group
@@ -174,8 +178,8 @@ public class UserGroupController {
 
 		List<GroupPermission> groupPermissions = groupPermissionManager.findUserGroupPermissions(userGroup.getCode());
 		List<PermissionDTO> permissions = groupPermissions.stream()
-						.map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
-						.toList();
+			.map(groupPermission -> permissionMapper.map2DTO(groupPermission.getPermission()))
+			.toList();
 
 		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 		userGroupDTO.setPermissions(permissions);
@@ -185,7 +189,6 @@ public class UserGroupController {
 
 	/**
 	 * Assign a {@link Permission} to a {@link UserGroup}
-	 *
 	 * @param userGroupCode - the {@link UserGroup}'s code
 	 * @param permissionId - the {@link Permission}'s id
 	 * @return the id of the new group permission.
@@ -194,8 +197,8 @@ public class UserGroupController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public int assignPermission(
-					@PathVariable("group_code") String userGroupCode,
-					@PathVariable("id") int permissionId
+		@PathVariable("group_code") String userGroupCode,
+		@PathVariable("id") int permissionId
 	) throws OHServiceException {
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
 		if (userGroup == null) {
@@ -223,7 +226,6 @@ public class UserGroupController {
 	 *     <li>ids that corresponding permission are not yet assigned to the groups will be assigned.</li>
 	 *     <li>Permissions ids that don't exist are ignored</li>
 	 * </ul>
-	 *
 	 * @param userGroupCode Code of the group to update
 	 * @param payload New group permissions
 	 * @return List of {@link PermissionDTO} corresponding to the list of permissions assigned to the group
@@ -231,8 +233,8 @@ public class UserGroupController {
 	 */
 	@PutMapping(value = "/usergroups/{group_code}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
 	public List<PermissionDTO> updateGroupPermissions(
-					@PathVariable("group_code") String userGroupCode,
-					@RequestBody GroupPermissionsDTO payload
+		@PathVariable("group_code") String userGroupCode,
+		@RequestBody GroupPermissionsDTO payload
 	) throws OHServiceException {
 		LOGGER.info("Attempting to update user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
@@ -251,7 +253,6 @@ public class UserGroupController {
 
 	/**
 	 * Revoke a {@link Permission} from a {@link UserGroup}
-	 *
 	 * @param userGroupCode - the {@link UserGroup}'s code
 	 * @param permissionId - the {@link Permission}'s id
 	 * @throws OHServiceException When failed to revoke the permission to the user group
@@ -259,8 +260,8 @@ public class UserGroupController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@DeleteMapping(value = "/usergroups/{group_code}/permissions/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public void revokePermission(
-					@PathVariable("group_code") String userGroupCode,
-					@PathVariable("id") int permissionId
+		@PathVariable("group_code") String userGroupCode,
+		@PathVariable("id") int permissionId
 	) throws OHServiceException {
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
 		if (userGroup == null) {

--- a/src/main/java/org/isf/usergroups/rest/UserGroupController.java
+++ b/src/main/java/org/isf/usergroups/rest/UserGroupController.java
@@ -55,7 +55,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -232,7 +231,7 @@ public class UserGroupController {
 		@PathVariable("group_code") String userGroupCode,
 		@RequestBody GroupPermissionsDTO payload
 	) throws OHServiceException {
-		LOGGER.info("Attempting to update user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
+		LOGGER.info("Attempting to update user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissionIds());
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
 		if (userGroup == null) {
 			LOGGER.info("Could not find user corresponding to the group code {}", userGroupCode);
@@ -240,7 +239,7 @@ public class UserGroupController {
 		}
 
 		try {
-			return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissions(), false));
+			return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissionIds(), false));
 		} catch (OHDataValidationException e) {
 			LOGGER.info("Fail to update user groups permissions, reason: {}", e.getMessage());
 			throw new OHAPIException(new OHExceptionMessage("Failed to update permissions"));
@@ -265,7 +264,7 @@ public class UserGroupController {
 		@PathVariable("group_code") String userGroupCode,
 		@RequestBody GroupPermissionsDTO payload
 	) throws OHServiceException {
-		LOGGER.info("Attempting to replace user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissions());
+		LOGGER.info("Attempting to replace user group({}) permissions, with permissions ids, {}", userGroupCode, payload.permissionIds());
 		UserGroup userGroup = userManager.findUserGroupByCode(userGroupCode);
 		if (userGroup == null) {
 			LOGGER.info("Could not find user group corresponding to the group code {}", userGroupCode);
@@ -273,7 +272,7 @@ public class UserGroupController {
 		}
 
 		try {
-			return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissions(), true));
+			return permissionMapper.map2DTOList(groupPermissionManager.update(userGroup, payload.permissionIds(), true));
 		} catch (OHDataValidationException e) {
 			LOGGER.info("Fail to replace user groups permissions, reason: {}", e.getMessage());
 			throw new OHAPIException(new OHExceptionMessage("Failed to update permissions"));

--- a/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
+++ b/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
@@ -34,6 +34,7 @@ import org.isf.permissions.mapper.PermissionMapper;
 import org.isf.permissions.model.GroupPermission;
 import org.isf.permissions.model.Permission;
 import org.isf.usergroups.data.UserGroupHelper;
+import org.isf.usergroups.dto.GroupPermissionsDTO;
 import org.isf.usergroups.dto.UserGroupDTO;
 import org.isf.usergroups.mapper.UserGroupMapper;
 import org.isf.utils.exception.OHDataValidationException;
@@ -60,322 +61,361 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = OpenHospitalApiApplication.class)
 @AutoConfigureMockMvc
 public class UserGroupControllerTest {
 
-	private final Logger LOGGER = LoggerFactory.getLogger(UserGroupControllerTest.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(UserGroupControllerTest.class);
 
-	@Autowired
-	private MockMvc mvc;
+    @Autowired
+    private MockMvc mvc;
 
-	@Autowired
-	private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-	@Autowired
-	private UserGroupMapper userGroupMapper;
+    @Autowired
+    private UserGroupMapper userGroupMapper;
 
-	@Autowired
-	private PermissionMapper permissionMapper;
+    @Autowired
+    private PermissionMapper permissionMapper;
 
-	@MockBean
-	private UserBrowsingManager userManager;
+    @MockBean
+    private UserBrowsingManager userManager;
 
-	@MockBean
-	private PermissionManager permissionManager;
+    @MockBean
+    private PermissionManager permissionManager;
 
-	@MockBean
-	private GroupPermissionManager groupPermissionManager;
+    @MockBean
+    private GroupPermissionManager groupPermissionManager;
 
-	@Test
-	@WithMockUser(username = "admin", authorities = {"usergroups.read"})
-	@DisplayName("Get all user groups")
-	void getAllUserGroups() throws Exception {
-		List<UserGroup> userGroups = List.of(UserGroupHelper.generateUserGroup());
-		List<UserGroupDTO> userGroupDTOS = userGroups.stream().map(userGroup -> userGroupMapper.map2DTO(userGroup)).toList();
+    @Test
+    @WithMockUser(username = "admin", authorities = {"usergroups.read"})
+    @DisplayName("Get all user groups")
+    void getAllUserGroups() throws Exception {
+        List<UserGroup> userGroups = List.of(UserGroupHelper.generateUserGroup());
+        List<UserGroupDTO> userGroupDTOS = userGroups.stream().map(userGroup -> userGroupMapper.map2DTO(userGroup)).toList();
 
-		when(userManager.getUserGroup()).thenReturn(userGroups);
+        when(userManager.getUserGroup()).thenReturn(userGroups);
 
-		var result = mvc.perform(
-				get("/usergroups").contentType(MediaType.APPLICATION_JSON))
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
-			.andReturn();
+        var result = mvc.perform(
+                        get("/usergroups").contentType(MediaType.APPLICATION_JSON))
+                .andDo(log())
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
+                .andReturn();
 
-		LOGGER.debug("result: {}", result);
-	}
+        LOGGER.debug("result: {}", result);
+    }
 
-	@Test
-	@WithMockUser(username = "admin", authorities = {"usergroups.create"})
-	@DisplayName("Create user group")
-	void createUserGroup() throws Exception {
-		List<Permission> permissions = TestPermission.generatePermissions(4);
-		UserGroup userGroup = UserGroupHelper.generateUserGroup();
+    @Test
+    @WithMockUser(username = "admin", authorities = {"usergroups.create"})
+    @DisplayName("Create user group")
+    void createUserGroup() throws Exception {
+        List<Permission> permissions = TestPermission.generatePermissions(4);
+        UserGroup userGroup = UserGroupHelper.generateUserGroup();
 
-		List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-		userGroupDTO.setPermissions(permissionDTOS);
+        List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        userGroupDTO.setPermissions(permissionDTOS);
 
-		when(userManager.newUserGroup(any(), any())).thenReturn(userGroup);
-		when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+        when(userManager.newUserGroup(any(), any())).thenReturn(userGroup);
+        when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
 
-		var result = mvc.perform(
-				post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
-			.andDo(log())
-			.andExpect(status().isCreated())
-			.andReturn();
+        var result = mvc.perform(
+                        post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
+                .andDo(log())
+                .andExpect(status().isCreated())
+                .andReturn();
 
-		LOGGER.debug("result: {}", result);
-	}
+        LOGGER.debug("result: {}", result);
+    }
 
-	@Nested
-	@DisplayName("Update user group")
-	class UpdateUserGroup {
-		@Test
-		@WithMockUser(username = "admin", authorities = {"usergroups.update"})
-		@DisplayName("Should update user group")
-		void shouldUpdateUserGroup() throws Exception {
-			List<Permission> permissions = TestPermission.generatePermissions(4);
-			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+    @Test
+    @WithMockUser(username = "admin", authorities = {"usergroups.read"})
+    @DisplayName("Get user group")
+    void getUserGroup() throws Exception {
+        List<Permission> permissions = TestPermission.generatePermissions(4);
+        UserGroup userGroup = UserGroupHelper.generateUserGroup();
 
-			List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-			userGroupDTO.setPermissions(permissionDTOS);
+        List<GroupPermission> groupPermissions = permissions.stream().map(permission -> {
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-			when(userManager.updateUserGroup(any(), any())).thenReturn(true);
+            return groupPermission;
+        }).toList();
 
-			var result = mvc.perform(
-					put("/usergroups/{group_code}", userGroupDTO.getCode())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(userGroupDTO))
-				)
-				.andDo(log())
-				.andExpect(status().isOk())
-				.andReturn();
+        List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        userGroupDTO.setPermissions(permissionDTOS);
 
-			LOGGER.debug("result: {}", result);
-		}
+        when(userManager.findUserGroupByCode(userGroup.getCode())).thenReturn(userGroup);
+        when(groupPermissionManager.findUserGroupPermissions(any())).thenReturn(groupPermissions);
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"usergroups.update"})
-		@DisplayName("Should fail to update user group when invalid payload")
-		void shouldFailUpdateUserGroupWhenInvalidPayload() throws Exception {
-			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+        var result = mvc.perform(
+                        get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+                .andDo(log())
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
+                .andReturn();
 
-			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        LOGGER.debug("result: {}", result);
+    }
 
-			var result = mvc.perform(
-					put("/usergroups/{group_code}", "DD")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(userGroupDTO))
-				)
-				.andDo(log())
-				.andExpect(status().isBadRequest())
-				.andReturn();
+    @Test
+    @WithMockUser(username = "admin", authorities = {"usergroups.delete"})
+    @DisplayName("Delete user groups")
+    void deleteUserGroup() throws Exception {
+        UserGroup userGroup = UserGroupHelper.generateUserGroup();
+        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 
-			LOGGER.debug("result: {}", result);
-		}
+        when(userManager.getUserGroup()).thenReturn(List.of(userGroup));
+        doNothing().when(userManager).deleteGroup(any());
 
-		@Test
-		@WithMockUser(username = "admin")
-		@DisplayName("Should throw forbidden error when updating user group")
-		void shouldThrowForbiddenErrorWhenUpdatingUserGroup() throws Exception {
-			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+        var result = mvc.perform(
+                        delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+                .andDo(log())
+                .andExpect(status().isNoContent())
+                .andReturn();
 
-			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        LOGGER.debug("result: {}", result);
+    }
 
-			var result = mvc.perform(
-					put("/usergroups/{group_code}", userGroupDTO.getCode())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(userGroupDTO))
-				)
-				.andDo(log())
-				.andExpect(status().isForbidden())
-				.andReturn();
+    @Nested
+    @DisplayName("Update user group")
+    class UpdateUserGroup {
+        @Test
+        @WithMockUser(username = "admin", authorities = {"usergroups.update"})
+        @DisplayName("Should update user group")
+        void shouldUpdateUserGroup() throws Exception {
+            List<Permission> permissions = TestPermission.generatePermissions(4);
+            UserGroup userGroup = UserGroupHelper.generateUserGroup();
 
-			LOGGER.debug("result: {}", result);
-		}
-	}
+            List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+            userGroupDTO.setPermissions(permissionDTOS);
 
-	@Test
-	@WithMockUser(username = "admin", authorities = {"usergroups.read"})
-	@DisplayName("Get user group")
-	void getUserGroup() throws Exception {
-		List<Permission> permissions = TestPermission.generatePermissions(4);
-		UserGroup userGroup = UserGroupHelper.generateUserGroup();
+            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+            when(userManager.updateUserGroup(any(), any())).thenReturn(true);
 
-		List<GroupPermission> groupPermissions = permissions.stream().map(permission -> {
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+            var result = mvc.perform(
+                            put("/usergroups/{group_code}", userGroupDTO.getCode())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(userGroupDTO))
+                    )
+                    .andDo(log())
+                    .andExpect(status().isOk())
+                    .andReturn();
 
-			return groupPermission;
-		}).toList();
+            LOGGER.debug("result: {}", result);
+        }
 
-		List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-		userGroupDTO.setPermissions(permissionDTOS);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"usergroups.update"})
+        @DisplayName("Should fail to update user group when invalid payload")
+        void shouldFailUpdateUserGroupWhenInvalidPayload() throws Exception {
+            UserGroup userGroup = UserGroupHelper.generateUserGroup();
 
-		when(userManager.findUserGroupByCode(userGroup.getCode())).thenReturn(userGroup);
-		when(groupPermissionManager.findUserGroupPermissions(any())).thenReturn(groupPermissions);
+            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 
-		var result = mvc.perform(
-				get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-			.andDo(log())
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
-			.andReturn();
+            var result = mvc.perform(
+                            put("/usergroups/{group_code}", "DD")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(userGroupDTO))
+                    )
+                    .andDo(log())
+                    .andExpect(status().isBadRequest())
+                    .andReturn();
 
-		LOGGER.debug("result: {}", result);
-	}
+            LOGGER.debug("result: {}", result);
+        }
 
-	@Test
-	@WithMockUser(username = "admin", authorities = {"usergroups.delete"})
-	@DisplayName("Delete user groups")
-	void deleteUserGroup() throws Exception {
-		UserGroup userGroup = UserGroupHelper.generateUserGroup();
-		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+        @Test
+        @WithMockUser(username = "admin")
+        @DisplayName("Should throw forbidden error when updating user group")
+        void shouldThrowForbiddenErrorWhenUpdatingUserGroup() throws Exception {
+            UserGroup userGroup = UserGroupHelper.generateUserGroup();
 
-		when(userManager.getUserGroup()).thenReturn(List.of(userGroup));
-		doNothing().when(userManager).deleteGroup(any());
+            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 
-		var result = mvc.perform(
-				delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-			.andDo(log())
-			.andExpect(status().isNoContent())
-			.andReturn();
+            var result = mvc.perform(
+                            put("/usergroups/{group_code}", userGroupDTO.getCode())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(userGroupDTO))
+                    )
+                    .andDo(log())
+                    .andExpect(status().isForbidden())
+                    .andReturn();
 
-		LOGGER.debug("result: {}", result);
-	}
+            LOGGER.debug("result: {}", result);
+        }
+    }
 
-	@Nested
-	@DisplayName("Assign / revoke permission")
-	class UserGroupPermissions {
+    @Nested
+    @DisplayName("Assign / revoke permission")
+    class UserGroupPermissions {
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-		@DisplayName("Assign a permission to a user group")
-		void assignPermissionToUserGroup() throws Exception {
-			UserGroup userGroup = new TestUserGroup().setup(false);
-			Permission permission = TestPermission.generatePermission();
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
+        @DisplayName("Assign a permission to a user group")
+        void assignPermissionToUserGroup() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
-			var result = mvc.perform(
-					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-						.contentType(MediaType.APPLICATION_JSON)
-				)
-				.andDo(log())
-				.andExpect(status().isCreated())
-				.andReturn();
+            var result = mvc.perform(
+                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().isCreated())
+                    .andReturn();
 
-			LOGGER.debug("result: {}", result);
-		}
+            LOGGER.debug("result: {}", result);
+        }
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-		@DisplayName("Assign already assigned permission to a user group")
-		void assignAlreadyAssignedPermissionToUserGroup() throws Exception {
-			UserGroup userGroup = new TestUserGroup().setup(false);
-			Permission permission = TestPermission.generatePermission();
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
+        @DisplayName("Assign already assigned permission to a user group")
+        void assignAlreadyAssignedPermissionToUserGroup() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-			when(groupPermissionManager.create(any(), any())).thenThrow(
-				new OHDataValidationException(new OHExceptionMessage(""))
-			);
+            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+            when(groupPermissionManager.create(any(), any())).thenThrow(
+                    new OHDataValidationException(new OHExceptionMessage(""))
+            );
 
-			mvc.perform(
-					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-						.contentType(MediaType.APPLICATION_JSON)
-				)
-				.andDo(log())
-				.andExpect(status().is4xxClientError())
-				.andExpect(content().string(containsString("Failed")));
-		}
+            mvc.perform(
+                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().string(containsString("Failed")));
+        }
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-		@DisplayName("Assign non existing permission to a user group")
-		void assignNonExistingPermissionToUserGroup() throws Exception {
-			UserGroup userGroup = new TestUserGroup().setup(false);
-			Permission permission = TestPermission.generatePermission();
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
+        @DisplayName("Assign non existing permission to a user group")
+        void assignNonExistingPermissionToUserGroup() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(null);
-			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
-			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+            when(userManager.findUserGroupByCode(any())).thenReturn(null);
+            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
+            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
-			mvc.perform(
-					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-						.contentType(MediaType.APPLICATION_JSON)
-				)
-				.andDo(log())
-				.andExpect(status().is4xxClientError())
-				.andExpect(content().string(containsString("not found")));
-		}
+            mvc.perform(
+                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().string(containsString("not found")));
+        }
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"grouppermission.delete"})
-		@DisplayName("Revoke a permission from a user group")
-		void revokePermissionFromUserGroup() throws Exception {
-			UserGroup userGroup = new TestUserGroup().setup(false);
-			Permission permission = TestPermission.generatePermission();
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"grouppermission.delete"})
+        @DisplayName("Revoke a permission from a user group")
+        void revokePermissionFromUserGroup() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-			doNothing().when(groupPermissionManager).delete(any(), any());
+            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+            doNothing().when(groupPermissionManager).delete(any(), any());
 
-			var result = mvc.perform(
-					delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-						.contentType(MediaType.APPLICATION_JSON)
-				)
-				.andDo(log())
-				.andExpect(status().isNoContent())
-				.andReturn();
+            var result = mvc.perform(
+                            delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().isNoContent())
+                    .andReturn();
 
-			LOGGER.debug("result: {}", result);
-		}
+            LOGGER.debug("result: {}", result);
+        }
 
-		@Test
-		@WithMockUser(username = "admin", authorities = {"grouppermission.create"})
-		@DisplayName("Revoke not assigned permission to a user group")
-		void revokeNotAssignedPermissionToUserGroup() throws Exception {
-			UserGroup userGroup = new TestUserGroup().setup(false);
-			Permission permission = TestPermission.generatePermission();
-			GroupPermission groupPermission = new GroupPermission();
-			groupPermission.setUserGroup(userGroup);
-			groupPermission.setPermission(permission);
+        @Test
+        @WithMockUser(username = "admin", authorities = {"grouppermission.create"})
+        @DisplayName("Revoke not assigned permission to a user group")
+        void revokeNotAssignedPermissionToUserGroup() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+            GroupPermission groupPermission = new GroupPermission();
+            groupPermission.setUserGroup(userGroup);
+            groupPermission.setPermission(permission);
 
-			when(userManager.findUserGroupByCode(any())).thenReturn(null);
-			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
-			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+            when(userManager.findUserGroupByCode(any())).thenReturn(null);
+            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
+            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
-			mvc.perform(
-					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-						.contentType(MediaType.APPLICATION_JSON)
-				)
-				.andDo(log())
-				.andExpect(status().is4xxClientError())
-				.andExpect(content().string(containsString("not found")));
-		}
-	}
+            mvc.perform(
+                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().string(containsString("not found")));
+        }
+
+        @Test
+        @WithMockUser(username = "admin", authorities = {"grouppermission.create", "grouppermission.delete"})
+        @DisplayName("Should update user group permissions")
+        void shouldUpdateUserGroupPermissions() throws Exception {
+            UserGroup userGroup = new TestUserGroup().setup(false);
+            Permission permission = TestPermission.generatePermission();
+
+            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+            when(groupPermissionManager.update(any(), any())).thenReturn(List.of(permission));
+
+            var result = mvc.perform(
+                            put("/usergroups/{group_code}/permissions", userGroup.getCode())
+                                    .content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(permission.getId()))))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.[0].id").value(permission.getId()))
+                    .andReturn();
+
+            LOGGER.debug("result: {}", result);
+        }
+
+        @Test
+        @WithMockUser(username = "admin", authorities = {"grouppermission.delete"})
+        @DisplayName("Should fail to update user group permissions when insufficient permissions")
+        void shouldFailToUpdateUserGroupPermissionsWhenInsufficientPermissions() throws Exception {
+
+            var result = mvc.perform(
+                            put("/usergroups/{group_code}/permissions", "12")
+                                    .content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(44))))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(log())
+                    .andExpect(status().isForbidden())
+                    .andReturn();
+
+            LOGGER.debug("result: {}", result);
+        }
+    }
 }

--- a/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
+++ b/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
@@ -21,22 +21,7 @@
  */
 package org.isf.usergroups.rest;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.isf.OpenHospitalApiApplication;
 import org.isf.menu.TestPermission;
 import org.isf.menu.TestUserGroup;
@@ -67,7 +52,16 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = OpenHospitalApiApplication.class)
 @AutoConfigureMockMvc

--- a/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
+++ b/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
@@ -21,7 +21,22 @@
  */
 package org.isf.usergroups.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
 import org.isf.OpenHospitalApiApplication;
 import org.isf.menu.TestPermission;
 import org.isf.menu.TestUserGroup;
@@ -52,16 +67,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = OpenHospitalApiApplication.class)
 @AutoConfigureMockMvc
@@ -100,11 +106,11 @@ public class UserGroupControllerTest {
 		when(userManager.getUserGroup()).thenReturn(userGroups);
 
 		var result = mvc.perform(
-										get("/usergroups").contentType(MediaType.APPLICATION_JSON))
-						.andDo(log())
-						.andExpect(status().isOk())
-						.andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
-						.andReturn();
+				get("/usergroups").contentType(MediaType.APPLICATION_JSON))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
+			.andReturn();
 
 		LOGGER.debug("result: {}", result);
 	}
@@ -124,10 +130,10 @@ public class UserGroupControllerTest {
 		when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
 
 		var result = mvc.perform(
-										post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
-						.andDo(log())
-						.andExpect(status().isCreated())
-						.andReturn();
+				post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
+			.andDo(log())
+			.andExpect(status().isCreated())
+			.andReturn();
 
 		LOGGER.debug("result: {}", result);
 	}
@@ -155,11 +161,11 @@ public class UserGroupControllerTest {
 		when(groupPermissionManager.findUserGroupPermissions(any())).thenReturn(groupPermissions);
 
 		var result = mvc.perform(
-										get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-						.andDo(log())
-						.andExpect(status().isOk())
-						.andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
-						.andReturn();
+				get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
+			.andReturn();
 
 		LOGGER.debug("result: {}", result);
 	}
@@ -175,10 +181,10 @@ public class UserGroupControllerTest {
 		doNothing().when(userManager).deleteGroup(any());
 
 		var result = mvc.perform(
-										delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-						.andDo(log())
-						.andExpect(status().isNoContent())
-						.andReturn();
+				delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+			.andDo(log())
+			.andExpect(status().isNoContent())
+			.andReturn();
 
 		LOGGER.debug("result: {}", result);
 	}
@@ -202,13 +208,13 @@ public class UserGroupControllerTest {
 			when(userManager.updateUserGroup(any(), any())).thenReturn(true);
 
 			var result = mvc.perform(
-											put("/usergroups/{group_code}", userGroupDTO.getCode())
-															.contentType(MediaType.APPLICATION_JSON)
-															.content(objectMapper.writeValueAsString(userGroupDTO))
-							)
-							.andDo(log())
-							.andExpect(status().isOk())
-							.andReturn();
+					put("/usergroups/{group_code}", userGroupDTO.getCode())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(userGroupDTO))
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -222,13 +228,13 @@ public class UserGroupControllerTest {
 			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 
 			var result = mvc.perform(
-											put("/usergroups/{group_code}", "DD")
-															.contentType(MediaType.APPLICATION_JSON)
-															.content(objectMapper.writeValueAsString(userGroupDTO))
-							)
-							.andDo(log())
-							.andExpect(status().isBadRequest())
-							.andReturn();
+					put("/usergroups/{group_code}", "DD")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(userGroupDTO))
+				)
+				.andDo(log())
+				.andExpect(status().isBadRequest())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -242,13 +248,13 @@ public class UserGroupControllerTest {
 			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
 
 			var result = mvc.perform(
-											put("/usergroups/{group_code}", userGroupDTO.getCode())
-															.contentType(MediaType.APPLICATION_JSON)
-															.content(objectMapper.writeValueAsString(userGroupDTO))
-							)
-							.andDo(log())
-							.andExpect(status().isForbidden())
-							.andReturn();
+					put("/usergroups/{group_code}", userGroupDTO.getCode())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(userGroupDTO))
+				)
+				.andDo(log())
+				.andExpect(status().isForbidden())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -273,12 +279,12 @@ public class UserGroupControllerTest {
 			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
 			var result = mvc.perform(
-											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().isCreated())
-							.andReturn();
+					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isCreated())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -296,16 +302,16 @@ public class UserGroupControllerTest {
 			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
 			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
 			when(groupPermissionManager.create(any(), any())).thenThrow(
-							new OHDataValidationException(new OHExceptionMessage(""))
+				new OHDataValidationException(new OHExceptionMessage(""))
 			);
 
 			mvc.perform(
-											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().is4xxClientError())
-							.andExpect(content().string(containsString("Failed")));
+					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(content().string(containsString("Failed")));
 		}
 
 		@Test
@@ -323,12 +329,12 @@ public class UserGroupControllerTest {
 			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
 			mvc.perform(
-											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().is4xxClientError())
-							.andExpect(content().string(containsString("not found")));
+					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(content().string(containsString("not found")));
 		}
 
 		@Test
@@ -346,12 +352,12 @@ public class UserGroupControllerTest {
 			doNothing().when(groupPermissionManager).delete(any(), any());
 
 			var result = mvc.perform(
-											delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().isNoContent())
-							.andReturn();
+					delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isNoContent())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -371,12 +377,12 @@ public class UserGroupControllerTest {
 			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
 
 			mvc.perform(
-											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().is4xxClientError())
-							.andExpect(content().string(containsString("not found")));
+					post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(content().string(containsString("not found")));
 		}
 
 		@Test
@@ -390,14 +396,14 @@ public class UserGroupControllerTest {
 			when(groupPermissionManager.update(any(), any())).thenReturn(List.of(permission));
 
 			var result = mvc.perform(
-											put("/usergroups/{group_code}/permissions", userGroup.getCode())
-															.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(permission.getId()))))
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().isOk())
-							.andExpect(jsonPath("$.[0].id").value(permission.getId()))
-							.andReturn();
+					put("/usergroups/{group_code}/permissions", userGroup.getCode())
+						.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(permission.getId()))))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.[0].id").value(permission.getId()))
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}
@@ -408,13 +414,13 @@ public class UserGroupControllerTest {
 		void shouldFailToUpdateUserGroupPermissionsWhenInsufficientPermissions() throws Exception {
 
 			var result = mvc.perform(
-											put("/usergroups/{group_code}/permissions", "12")
-															.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(44))))
-															.contentType(MediaType.APPLICATION_JSON)
-							)
-							.andDo(log())
-							.andExpect(status().isForbidden())
-							.andReturn();
+					put("/usergroups/{group_code}/permissions", "12")
+						.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(44))))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isForbidden())
+				.andReturn();
 
 			LOGGER.debug("result: {}", result);
 		}

--- a/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
+++ b/src/test/java/org/isf/usergroups/rest/UserGroupControllerTest.java
@@ -21,7 +21,22 @@
  */
 package org.isf.usergroups.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
 import org.isf.OpenHospitalApiApplication;
 import org.isf.menu.TestPermission;
 import org.isf.menu.TestUserGroup;
@@ -52,370 +67,362 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = OpenHospitalApiApplication.class)
 @AutoConfigureMockMvc
 public class UserGroupControllerTest {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(UserGroupControllerTest.class);
-
-    @Autowired
-    private MockMvc mvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private UserGroupMapper userGroupMapper;
-
-    @Autowired
-    private PermissionMapper permissionMapper;
-
-    @MockBean
-    private UserBrowsingManager userManager;
-
-    @MockBean
-    private PermissionManager permissionManager;
-
-    @MockBean
-    private GroupPermissionManager groupPermissionManager;
-
-    @Test
-    @WithMockUser(username = "admin", authorities = {"usergroups.read"})
-    @DisplayName("Get all user groups")
-    void getAllUserGroups() throws Exception {
-        List<UserGroup> userGroups = List.of(UserGroupHelper.generateUserGroup());
-        List<UserGroupDTO> userGroupDTOS = userGroups.stream().map(userGroup -> userGroupMapper.map2DTO(userGroup)).toList();
-
-        when(userManager.getUserGroup()).thenReturn(userGroups);
-
-        var result = mvc.perform(
-                        get("/usergroups").contentType(MediaType.APPLICATION_JSON))
-                .andDo(log())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
-                .andReturn();
-
-        LOGGER.debug("result: {}", result);
-    }
-
-    @Test
-    @WithMockUser(username = "admin", authorities = {"usergroups.create"})
-    @DisplayName("Create user group")
-    void createUserGroup() throws Exception {
-        List<Permission> permissions = TestPermission.generatePermissions(4);
-        UserGroup userGroup = UserGroupHelper.generateUserGroup();
-
-        List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-        userGroupDTO.setPermissions(permissionDTOS);
-
-        when(userManager.newUserGroup(any(), any())).thenReturn(userGroup);
-        when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-
-        var result = mvc.perform(
-                        post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
-                .andDo(log())
-                .andExpect(status().isCreated())
-                .andReturn();
-
-        LOGGER.debug("result: {}", result);
-    }
-
-    @Test
-    @WithMockUser(username = "admin", authorities = {"usergroups.read"})
-    @DisplayName("Get user group")
-    void getUserGroup() throws Exception {
-        List<Permission> permissions = TestPermission.generatePermissions(4);
-        UserGroup userGroup = UserGroupHelper.generateUserGroup();
-
-        List<GroupPermission> groupPermissions = permissions.stream().map(permission -> {
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            return groupPermission;
-        }).toList();
-
-        List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-        userGroupDTO.setPermissions(permissionDTOS);
-
-        when(userManager.findUserGroupByCode(userGroup.getCode())).thenReturn(userGroup);
-        when(groupPermissionManager.findUserGroupPermissions(any())).thenReturn(groupPermissions);
-
-        var result = mvc.perform(
-                        get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-                .andDo(log())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
-                .andReturn();
-
-        LOGGER.debug("result: {}", result);
-    }
-
-    @Test
-    @WithMockUser(username = "admin", authorities = {"usergroups.delete"})
-    @DisplayName("Delete user groups")
-    void deleteUserGroup() throws Exception {
-        UserGroup userGroup = UserGroupHelper.generateUserGroup();
-        UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-
-        when(userManager.getUserGroup()).thenReturn(List.of(userGroup));
-        doNothing().when(userManager).deleteGroup(any());
-
-        var result = mvc.perform(
-                        delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
-                .andDo(log())
-                .andExpect(status().isNoContent())
-                .andReturn();
-
-        LOGGER.debug("result: {}", result);
-    }
-
-    @Nested
-    @DisplayName("Update user group")
-    class UpdateUserGroup {
-        @Test
-        @WithMockUser(username = "admin", authorities = {"usergroups.update"})
-        @DisplayName("Should update user group")
-        void shouldUpdateUserGroup() throws Exception {
-            List<Permission> permissions = TestPermission.generatePermissions(4);
-            UserGroup userGroup = UserGroupHelper.generateUserGroup();
-
-            List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
-            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-            userGroupDTO.setPermissions(permissionDTOS);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-            when(userManager.updateUserGroup(any(), any())).thenReturn(true);
-
-            var result = mvc.perform(
-                            put("/usergroups/{group_code}", userGroupDTO.getCode())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(userGroupDTO))
-                    )
-                    .andDo(log())
-                    .andExpect(status().isOk())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"usergroups.update"})
-        @DisplayName("Should fail to update user group when invalid payload")
-        void shouldFailUpdateUserGroupWhenInvalidPayload() throws Exception {
-            UserGroup userGroup = UserGroupHelper.generateUserGroup();
-
-            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-
-            var result = mvc.perform(
-                            put("/usergroups/{group_code}", "DD")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(userGroupDTO))
-                    )
-                    .andDo(log())
-                    .andExpect(status().isBadRequest())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-
-        @Test
-        @WithMockUser(username = "admin")
-        @DisplayName("Should throw forbidden error when updating user group")
-        void shouldThrowForbiddenErrorWhenUpdatingUserGroup() throws Exception {
-            UserGroup userGroup = UserGroupHelper.generateUserGroup();
-
-            UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
-
-            var result = mvc.perform(
-                            put("/usergroups/{group_code}", userGroupDTO.getCode())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(userGroupDTO))
-                    )
-                    .andDo(log())
-                    .andExpect(status().isForbidden())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-    }
-
-    @Nested
-    @DisplayName("Assign / revoke permission")
-    class UserGroupPermissions {
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-        @DisplayName("Assign a permission to a user group")
-        void assignPermissionToUserGroup() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
-
-            var result = mvc.perform(
-                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().isCreated())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-        @DisplayName("Assign already assigned permission to a user group")
-        void assignAlreadyAssignedPermissionToUserGroup() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-            when(groupPermissionManager.create(any(), any())).thenThrow(
-                    new OHDataValidationException(new OHExceptionMessage(""))
-            );
-
-            mvc.perform(
-                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().string(containsString("Failed")));
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"usergroups.create", "grouppermission.create"})
-        @DisplayName("Assign non existing permission to a user group")
-        void assignNonExistingPermissionToUserGroup() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(null);
-            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
-            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
-
-            mvc.perform(
-                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().string(containsString("not found")));
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"grouppermission.delete"})
-        @DisplayName("Revoke a permission from a user group")
-        void revokePermissionFromUserGroup() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
-            doNothing().when(groupPermissionManager).delete(any(), any());
-
-            var result = mvc.perform(
-                            delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().isNoContent())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"grouppermission.create"})
-        @DisplayName("Revoke not assigned permission to a user group")
-        void revokeNotAssignedPermissionToUserGroup() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-            GroupPermission groupPermission = new GroupPermission();
-            groupPermission.setUserGroup(userGroup);
-            groupPermission.setPermission(permission);
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(null);
-            when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
-            when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
-
-            mvc.perform(
-                            post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().string(containsString("not found")));
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"grouppermission.create", "grouppermission.delete"})
-        @DisplayName("Should update user group permissions")
-        void shouldUpdateUserGroupPermissions() throws Exception {
-            UserGroup userGroup = new TestUserGroup().setup(false);
-            Permission permission = TestPermission.generatePermission();
-
-            when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
-            when(groupPermissionManager.update(any(), any())).thenReturn(List.of(permission));
-
-            var result = mvc.perform(
-                            put("/usergroups/{group_code}/permissions", userGroup.getCode())
-                                    .content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(permission.getId()))))
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.[0].id").value(permission.getId()))
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-
-        @Test
-        @WithMockUser(username = "admin", authorities = {"grouppermission.delete"})
-        @DisplayName("Should fail to update user group permissions when insufficient permissions")
-        void shouldFailToUpdateUserGroupPermissionsWhenInsufficientPermissions() throws Exception {
-
-            var result = mvc.perform(
-                            put("/usergroups/{group_code}/permissions", "12")
-                                    .content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(44))))
-                                    .contentType(MediaType.APPLICATION_JSON)
-                    )
-                    .andDo(log())
-                    .andExpect(status().isForbidden())
-                    .andReturn();
-
-            LOGGER.debug("result: {}", result);
-        }
-    }
+	private final Logger LOGGER = LoggerFactory.getLogger(UserGroupControllerTest.class);
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserGroupMapper userGroupMapper;
+
+	@Autowired
+	private PermissionMapper permissionMapper;
+
+	@MockBean
+	private UserBrowsingManager userManager;
+
+	@MockBean
+	private PermissionManager permissionManager;
+
+	@MockBean
+	private GroupPermissionManager groupPermissionManager;
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "usergroups.read" })
+	@DisplayName("Get all user groups")
+	void getAllUserGroups() throws Exception {
+		List<UserGroup> userGroups = List.of(UserGroupHelper.generateUserGroup());
+		List<UserGroupDTO> userGroupDTOS = userGroups.stream().map(userGroup -> userGroupMapper.map2DTO(userGroup)).toList();
+
+		when(userManager.getUserGroup()).thenReturn(userGroups);
+
+		var result = mvc.perform(
+										get("/usergroups").contentType(MediaType.APPLICATION_JSON))
+						.andDo(log())
+						.andExpect(status().isOk())
+						.andExpect(content().string(containsString(UserGroupHelper.asJsonString(userGroupDTOS))))
+						.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "usergroups.create" })
+	@DisplayName("Create user group")
+	void createUserGroup() throws Exception {
+		List<Permission> permissions = TestPermission.generatePermissions(4);
+		UserGroup userGroup = UserGroupHelper.generateUserGroup();
+
+		List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+		userGroupDTO.setPermissions(permissionDTOS);
+
+		when(userManager.newUserGroup(any(), any())).thenReturn(userGroup);
+		when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+
+		var result = mvc.perform(
+										post("/usergroups").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userGroupDTO)))
+						.andDo(log())
+						.andExpect(status().isCreated())
+						.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "usergroups.read" })
+	@DisplayName("Get user group")
+	void getUserGroup() throws Exception {
+		List<Permission> permissions = TestPermission.generatePermissions(4);
+		UserGroup userGroup = UserGroupHelper.generateUserGroup();
+
+		List<GroupPermission> groupPermissions = permissions.stream().map(permission -> {
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			return groupPermission;
+		}).toList();
+
+		List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+		userGroupDTO.setPermissions(permissionDTOS);
+
+		when(userManager.findUserGroupByCode(userGroup.getCode())).thenReturn(userGroup);
+		when(groupPermissionManager.findUserGroupPermissions(any())).thenReturn(groupPermissions);
+
+		var result = mvc.perform(
+										get("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+						.andDo(log())
+						.andExpect(status().isOk())
+						.andExpect(content().string(containsString(objectMapper.writeValueAsString(userGroupDTO))))
+						.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "usergroups.delete" })
+	@DisplayName("Delete user groups")
+	void deleteUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupHelper.generateUserGroup();
+		UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+
+		when(userManager.getUserGroup()).thenReturn(List.of(userGroup));
+		doNothing().when(userManager).deleteGroup(any());
+
+		var result = mvc.perform(
+										delete("/usergroups/{group_code}", userGroup.getCode()).contentType(MediaType.APPLICATION_JSON))
+						.andDo(log())
+						.andExpect(status().isNoContent())
+						.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Nested
+	@DisplayName("Update user group")
+	class UpdateUserGroup {
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "usergroups.update" })
+		@DisplayName("Should update user group")
+		void shouldUpdateUserGroup() throws Exception {
+			List<Permission> permissions = TestPermission.generatePermissions(4);
+			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+
+			List<PermissionDTO> permissionDTOS = permissionMapper.map2DTOList(permissions);
+			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+			userGroupDTO.setPermissions(permissionDTOS);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+			when(userManager.updateUserGroup(any(), any())).thenReturn(true);
+
+			var result = mvc.perform(
+											put("/usergroups/{group_code}", userGroupDTO.getCode())
+															.contentType(MediaType.APPLICATION_JSON)
+															.content(objectMapper.writeValueAsString(userGroupDTO))
+							)
+							.andDo(log())
+							.andExpect(status().isOk())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "usergroups.update" })
+		@DisplayName("Should fail to update user group when invalid payload")
+		void shouldFailUpdateUserGroupWhenInvalidPayload() throws Exception {
+			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+
+			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+
+			var result = mvc.perform(
+											put("/usergroups/{group_code}", "DD")
+															.contentType(MediaType.APPLICATION_JSON)
+															.content(objectMapper.writeValueAsString(userGroupDTO))
+							)
+							.andDo(log())
+							.andExpect(status().isBadRequest())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+
+		@Test
+		@WithMockUser(username = "admin")
+		@DisplayName("Should throw forbidden error when updating user group")
+		void shouldThrowForbiddenErrorWhenUpdatingUserGroup() throws Exception {
+			UserGroup userGroup = UserGroupHelper.generateUserGroup();
+
+			UserGroupDTO userGroupDTO = userGroupMapper.map2DTO(userGroup);
+
+			var result = mvc.perform(
+											put("/usergroups/{group_code}", userGroupDTO.getCode())
+															.contentType(MediaType.APPLICATION_JSON)
+															.content(objectMapper.writeValueAsString(userGroupDTO))
+							)
+							.andDo(log())
+							.andExpect(status().isForbidden())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+	}
+
+	@Nested
+	@DisplayName("Assign / revoke permission")
+	class UserGroupPermissions {
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "usergroups.create", "grouppermission.create" })
+		@DisplayName("Assign a permission to a user group")
+		void assignPermissionToUserGroup() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+
+			var result = mvc.perform(
+											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().isCreated())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "usergroups.create", "grouppermission.create" })
+		@DisplayName("Assign already assigned permission to a user group")
+		void assignAlreadyAssignedPermissionToUserGroup() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+			when(groupPermissionManager.create(any(), any())).thenThrow(
+							new OHDataValidationException(new OHExceptionMessage(""))
+			);
+
+			mvc.perform(
+											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().is4xxClientError())
+							.andExpect(content().string(containsString("Failed")));
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "usergroups.create", "grouppermission.create" })
+		@DisplayName("Assign non existing permission to a user group")
+		void assignNonExistingPermissionToUserGroup() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(null);
+			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
+			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+
+			mvc.perform(
+											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().is4xxClientError())
+							.andExpect(content().string(containsString("not found")));
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "grouppermission.delete" })
+		@DisplayName("Revoke a permission from a user group")
+		void revokePermissionFromUserGroup() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(permission);
+			doNothing().when(groupPermissionManager).delete(any(), any());
+
+			var result = mvc.perform(
+											delete("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().isNoContent())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "grouppermission.create" })
+		@DisplayName("Revoke not assigned permission to a user group")
+		void revokeNotAssignedPermissionToUserGroup() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+			GroupPermission groupPermission = new GroupPermission();
+			groupPermission.setUserGroup(userGroup);
+			groupPermission.setPermission(permission);
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(null);
+			when(permissionManager.retrievePermissionById(anyInt())).thenReturn(null);
+			when(groupPermissionManager.create(any(), any())).thenReturn(groupPermission);
+
+			mvc.perform(
+											post("/usergroups/{group_code}/permissions/{id}", userGroup.getCode(), permission.getId())
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().is4xxClientError())
+							.andExpect(content().string(containsString("not found")));
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "grouppermission.create", "grouppermission.delete" })
+		@DisplayName("Should update user group permissions")
+		void shouldUpdateUserGroupPermissions() throws Exception {
+			UserGroup userGroup = new TestUserGroup().setup(false);
+			Permission permission = TestPermission.generatePermission();
+
+			when(userManager.findUserGroupByCode(any())).thenReturn(userGroup);
+			when(groupPermissionManager.update(any(), any())).thenReturn(List.of(permission));
+
+			var result = mvc.perform(
+											put("/usergroups/{group_code}/permissions", userGroup.getCode())
+															.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(permission.getId()))))
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().isOk())
+							.andExpect(jsonPath("$.[0].id").value(permission.getId()))
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+
+		@Test
+		@WithMockUser(username = "admin", authorities = { "grouppermission.delete" })
+		@DisplayName("Should fail to update user group permissions when insufficient permissions")
+		void shouldFailToUpdateUserGroupPermissionsWhenInsufficientPermissions() throws Exception {
+
+			var result = mvc.perform(
+											put("/usergroups/{group_code}/permissions", "12")
+															.content(objectMapper.writeValueAsString(new GroupPermissionsDTO(List.of(44))))
+															.contentType(MediaType.APPLICATION_JSON)
+							)
+							.andDo(log())
+							.andExpect(status().isForbidden())
+							.andReturn();
+
+			LOGGER.debug("result: {}", result);
+		}
+	}
 }


### PR DESCRIPTION
The new endpoints `PUT /usergroups/{group_code}/permissions` and  `PATCH /usergroups/{group_code}/permissions` accept a list of permissions ids(through the UserGroupPermissionsDTO).
For both endpoints:

-  Ids corresponding to permissions already assigned to the group will be skipped.
- ids that corresponding permission are not yet assigned to the groups will be assigned.
- Permissions ids that don't exist are ignored
- The full list of group permissions(PermissionDTO) is return.

For the patch endpoint:
- User group permissions that don't have their id in the permission ids payload will be removed
- That mean the PATCH endpoint just replace the group permissions with the ones provided in the payload.

See [OH2-395](https://openhospital.atlassian.net/browse/OH2-395)
Paired with [#1426](https://github.com/informatici/openhospital-core/pull/1426)

[OH2-395]: https://openhospital.atlassian.net/browse/OH2-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ