### PR TITLE
workflow: get fork and branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,12 +27,9 @@ jobs:
       - name: Determine PR source branch and fork repository
         id: vars
         run: |
-          # Set BRANCH_NAME based on event type
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          else
-            echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-          fi
+          # Set default FORK_REPO and BRANCH_NAME values.
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          FORK_REPO="${GITHUB_HEAD_REPOSITORY:-${GITHUB_ACTOR}/openhospital-core}"
           
           # Log and check if the branch exists in the contributor’s fork
           CHECK_BRANCH_URL="https://github.com/${GITHUB_ACTOR}/tree/$BRANCH_NAME"
@@ -41,14 +38,18 @@ jobs:
           # Determine FORK_REPO with fallback logic
           if [[ -n "${GITHUB_HEAD_REPOSITORY}" ]]; then
             echo "Using ${GITHUB_HEAD_REPOSITORY}."
-            echo "FORK_REPO=${GITHUB_HEAD_REPOSITORY}" >> $GITHUB_ENV
+            FORK_REPO=${GITHUB_HEAD_REPOSITORY}
           elif curl -s -o /dev/null -w "%{http_code}" $CHECK_BRANCH_URL | grep -q "200"; then
             echo "Using ${GITHUB_ACTOR}/openhospital-core."
-            echo "FORK_REPO=${GITHUB_ACTOR}/openhospital-core" >> $GITHUB_ENV
+            FORK_REPO=${GITHUB_ACTOR}/openhospital-core
           else
             echo "Using informatici/openhospital-core."
-            echo "FORK_REPO=informatici/openhospital-core" >> $GITHUB_ENV
+            FORK_REPO="informatici/openhospital-core"
           fi
+          
+          # Export FORK_REPO and BRANCH_NAME to GITHUB_ENV for the next step
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "FORK_REPO=$FORK_REPO" >> $GITHUB_ENV
 
       - name: Log variables
         run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,13 +33,20 @@ jobs:
           else
             echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
           fi
+          
+          # Log and check if the branch exists in the contributor’s fork
+          CHECK_BRANCH_URL="https://github.com/${GITHUB_ACTOR}/tree/$BRANCH_NAME"
+          echo "Checking branch existence with: curl -s -o /dev/null -w \"%{http_code}\" $CHECK_BRANCH_URL"
 
           # Determine FORK_REPO with fallback logic
           if [[ -n "${GITHUB_HEAD_REPOSITORY}" ]]; then
+            echo "Using ${GITHUB_HEAD_REPOSITORY}."
             echo "FORK_REPO=${GITHUB_HEAD_REPOSITORY}" >> $GITHUB_ENV
-          elif curl -s -o /dev/null -w "%{http_code}" "https://github.com/${GITHUB_ACTOR}/tree/$BRANCH_NAME" | grep -q "200"; then
+          elif curl -s -o /dev/null -w "%{http_code}" $CHECK_BRANCH_URL | grep -q "200"; then
+            echo "Using ${GITHUB_ACTOR}/openhospital-core."
             echo "FORK_REPO=${GITHUB_ACTOR}/openhospital-core" >> $GITHUB_ENV
           else
+            echo "Using informatici/openhospital-core."
             echo "FORK_REPO=informatici/openhospital-core" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,17 +30,14 @@ jobs:
           # Set default FORK_REPO and BRANCH_NAME values.
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
           FORK_REPO="${GITHUB_HEAD_REPOSITORY:-${GITHUB_ACTOR}/openhospital-core}"
-          
-          # Log and check if the branch exists in the contributor’s fork
           CHECK_BRANCH_URL="https://github.com/${GITHUB_ACTOR}/tree/$BRANCH_NAME"
-          echo "Checking branch existence with: curl -s -o /dev/null -w \"%{http_code}\" $CHECK_BRANCH_URL"
-
+          
           # Determine FORK_REPO with fallback logic
           if [[ -n "${GITHUB_HEAD_REPOSITORY}" ]]; then
             echo "Using ${GITHUB_HEAD_REPOSITORY}."
             FORK_REPO=${GITHUB_HEAD_REPOSITORY}
           elif curl -s -o /dev/null -w "%{http_code}" $CHECK_BRANCH_URL | grep -q "200"; then
-            echo "Using ${GITHUB_ACTOR}/openhospital-core."
+            echo "Checking branch existence with: curl -s -o /dev/null -w \"%{http_code}\" $CHECK_BRANCH_URL"
             FORK_REPO=${GITHUB_ACTOR}/openhospital-core
           else
             echo "Using informatici/openhospital-core."


### PR DESCRIPTION
When defining and exporting environment variables within a step, GitHub Actions doesn’t automatically carry them over within the same step. To ensure a variable is available within the step, we must declare and use it directly rather than relying on GitHub’s `$GITHUB_ENV`, then write these values to GITHUB_ENV only at the end.

- adding some logging for debug
- workaround in using variables