### PR TITLE
OP-1373 remove warns at api startup

### DIFF
--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -38,4 +38,5 @@ jwt.token.secret=JWT_TOKEN_SECRET
 
 # Hibernate properties
 # needed to start application even without DB connection
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=none

--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -12,6 +12,7 @@ server.servlet.session.cookie.http-only=true
 #server.servlet.session.cookie.secure=true # only over HTTPS
 spring.pid.fail-on-write-error=true
 spring.pid.file=OH_API_PID
+spring.mustache.check-template-location=false
 
 ### In production change to http://<domain>
 cors.allowed.origins=http://API_HOST:API_PORT,http://UI_HOST:UI_PORT
@@ -36,5 +37,4 @@ jwt.token.secret=JWT_TOKEN_SECRET
 
 # Hibernate properties
 # needed to start application even without DB connection
-spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=none

--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -13,6 +13,7 @@ server.servlet.session.cookie.http-only=true
 spring.pid.fail-on-write-error=true
 spring.pid.file=OH_API_PID
 spring.mustache.check-template-location=false
+spring.jpa.open-in-view=false
 
 ### In production change to http://<domain>
 cors.allowed.origins=http://API_HOST:API_PORT,http://UI_HOST:UI_PORT

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -36,12 +36,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -55,9 +53,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-
-	@Autowired
-	private UserDetailsService userDetailsService;
 
 	private final TokenProvider tokenProvider;
 
@@ -74,14 +69,6 @@ public class SecurityConfig {
 
 	@Autowired
 	private CustomLogoutHandler customLogoutHandler;
-
-	@Bean
-	public DaoAuthenticationProvider authenticationProvider() {
-		DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-		authProvider.setUserDetailsService(userDetailsService);
-		authProvider.setPasswordEncoder(encoder());
-		return authProvider;
-	}
 
 	@Bean
 	public PasswordEncoder encoder() {

--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -79,7 +79,7 @@ public class TokenProvider implements Serializable {
 	@PostConstruct
 	public void init() {
 		String secret = env.getProperty("jwt.token.secret");
-		LOGGER.info("Initializing JWT key with secret: {}", secret);
+		LOGGER.debug("Initializing JWT key with secret: {}", secret);
 		byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
 		this.key = Keys.hmacShaKeyFor(keyBytes);
 
@@ -131,8 +131,8 @@ public class TokenProvider implements Serializable {
 
 	public String generateJwtToken(Authentication authentication, boolean rememberMe) {
 		final String authorities = authentication.getAuthorities().stream()
-						.map(GrantedAuthority::getAuthority)
-						.collect(Collectors.joining(","));
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
 
 		long now = System.currentTimeMillis();
 		Date validity;
@@ -143,21 +143,21 @@ public class TokenProvider implements Serializable {
 		}
 
 		return Jwts.builder()
-						.setSubject(authentication.getName())
-						.claim(AUTHORITIES_KEY, authorities)
-						.setIssuedAt(new Date())
-						.signWith(key, SignatureAlgorithm.HS512)
-						.setExpiration(validity)
-						.compact();
+			.setSubject(authentication.getName())
+			.claim(AUTHORITIES_KEY, authorities)
+			.setIssuedAt(new Date())
+			.signWith(key, SignatureAlgorithm.HS512)
+			.setExpiration(validity)
+			.compact();
 	}
 
 	public String generateRefreshToken(Authentication authentication) {
 		return Jwts.builder()
-						.setSubject(authentication.getName())
-						.setIssuedAt(new Date())
-						.signWith(key, SignatureAlgorithm.HS512)
-						.setExpiration(new Date(System.currentTimeMillis() + this.tokenValidityInMillisecondsForRememberMe))
-						.compact();
+			.setSubject(authentication.getName())
+			.setIssuedAt(new Date())
+			.signWith(key, SignatureAlgorithm.HS512)
+			.setExpiration(new Date(System.currentTimeMillis() + this.tokenValidityInMillisecondsForRememberMe))
+			.compact();
 	}
 
 	public Authentication getAuthentication(String token) {
@@ -173,8 +173,8 @@ public class TokenProvider implements Serializable {
 		}
 
 		final Collection< ? extends GrantedAuthority> authorities = Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-						.map(SimpleGrantedAuthority::new)
-						.collect(Collectors.toList());
+			.map(SimpleGrantedAuthority::new)
+			.collect(Collectors.toList());
 
 		User principal = new User(claims.getSubject(), "", authorities);
 


### PR DESCRIPTION
See OP-1373.

Notes:
- we don't use [Mustache Templates](https://www.baeldung.com/mustache) and they are enabled by default in Spring Boot
- disabling `spring.jpa.open-in-view` is generally [recommended](https://www.baeldung.com/spring-open-session-in-view) for REST APIs to prevent performance issues and ensure explicit data fetching
- We don't need at the moment to define an authenticationProvider because we have only one UserDetailsService implementation (`org.isf.security.UserDetailsServiceImpl`) and only one PasswordEncoder bean (`BCryptPasswordEncoder`), so Spring Security uses the default DaoAuthenticationProvider. In the future, if we add more UserDetailsService implementations for multiple authentication data sources (e.g. Database, LDAP, Third-Party) we must define each provider and instruct the AuthenticationManager in which one to use for each case.

**NOTE**: `WARN - HHH90000025: MariaDBDialect ...` not eliminable because it is needed to start the application even without DB connection for the openapi workflow and in general
