### PR TITLE
OP-1349: Configure token expiration times

### DIFF
--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -36,11 +36,11 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 ### Security token secret (JWT)
 jwt.token.secret=JWT_TOKEN_SECRET
 
-### JWT token validity, 30 minutes (900,000 milliseconds)
-jwt.token.validityInMilliseconds=900000
+### JWT token validity, 30 minutes (1,800 seconds)
+jwt.token.validityInSeconds=1800
 
-### JWT token validity for remember me, 3 days (604,800,000 milliseconds)
-jwt.token.validityInMillisecondsForRememberMe=604800000
+### JWT token validity for remember me, 3 days (259,200 seconds)
+jwt.token.validityInSecondsForRememberMe=259200
 
 # Hibernate properties
 # needed to start application even without DB connection

--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -36,6 +36,12 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 ### Security token secret (JWT)
 jwt.token.secret=JWT_TOKEN_SECRET
 
+### JWT token validity, 30 minutes (900,000 milliseconds)
+jwt.token.validityInMilliseconds=900000
+
+### JWT token validity for remember me, 3 days (604,800,000 milliseconds)
+jwt.token.validityInMillisecondsForRememberMe=604800000
+
 # Hibernate properties
 # needed to start application even without DB connection
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect

--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -88,6 +88,7 @@ public class TokenProvider implements Serializable {
 
 		// default 3 days (604,800,000 milliseconds)
 		this.tokenValidityInMillisecondsForRememberMe = env.getProperty("jwt.token.validityInMillisecondsForRememberMe", Long.class, 1000L * 60 * 60 * 24 * 3);
+		LOGGER.debug("Setting token validity - tokenValidityInMilliseconds: {}, tokenValidityInMillisecondsForRememberMe: {}", this.tokenValidityInMilliseconds, this.tokenValidityInMillisecondsForRememberMe);
 
 		this.jwtParser = Jwts.parserBuilder().setSigningKey(this.key).build();
 	}

--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -83,11 +83,14 @@ public class TokenProvider implements Serializable {
 		byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
 		this.key = Keys.hmacShaKeyFor(keyBytes);
 
-		// default 30 minutes (900,000 milliseconds)
-		this.tokenValidityInMilliseconds = env.getProperty("jwt.token.validityInMilliseconds", Long.class, 1000L * 60 * 30);
+		// default 30 minutes (1800 milliseconds)
+		Long tokenValidityInSeconds = env.getProperty("jwt.token.validityInSeconds", Long.class, 60L * 30);
+		this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
 
-		// default 3 days (604,800,000 milliseconds)
-		this.tokenValidityInMillisecondsForRememberMe = env.getProperty("jwt.token.validityInMillisecondsForRememberMe", Long.class, 1000L * 60 * 60 * 24 * 3);
+		// default 3 days (259,200 seconds milliseconds)
+		Long validityInSecondsForRememberMe = env.getProperty("jwt.token.validityInSecondsForRememberMe", Long.class, 60L * 60 * 24 * 3);
+		this.tokenValidityInMillisecondsForRememberMe = validityInSecondsForRememberMe * 1000;
+
 		LOGGER.debug("Setting token validity - tokenValidityInMilliseconds: {}, tokenValidityInMillisecondsForRememberMe: {}", this.tokenValidityInMilliseconds, this.tokenValidityInMillisecondsForRememberMe);
 
 		this.jwtParser = Jwts.parserBuilder().setSigningKey(this.key).build();

--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -83,11 +83,11 @@ public class TokenProvider implements Serializable {
 		byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
 		this.key = Keys.hmacShaKeyFor(keyBytes);
 
-		// 30 minutes (900,000 milliseconds)
-		this.tokenValidityInMilliseconds = 1000L * 60 * 30;
+		// default 30 minutes (900,000 milliseconds)
+		this.tokenValidityInMilliseconds = env.getProperty("jwt.token.validityInMilliseconds", Long.class, 1000L * 60 * 30);
 
-		// 3 days (604,800,000 milliseconds)
-		this.tokenValidityInMillisecondsForRememberMe = 1000L * 60 * 60 * 24 * 3;
+		// default 3 days (604,800,000 milliseconds)
+		this.tokenValidityInMillisecondsForRememberMe = env.getProperty("jwt.token.validityInMillisecondsForRememberMe", Long.class, 1000L * 60 * 60 * 24 * 3);
 
 		this.jwtParser = Jwts.parserBuilder().setSigningKey(this.key).build();
 	}


### PR DESCRIPTION
This PR will fix [OP-1349](https://openhospital.atlassian.net/browse/OP-1349)

- Extracted `tokenValidityInMilliseconds` & `tokenValidityInMillisecondsForRememberMe` in `/openhospital-api/src/main/java/org/isf/security/jwt/TokenProvider.java` class into `application.properties`

[OP-1349]: https://openhospital.atlassian.net/browse/OP-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ