### PR TITLE
OP-1391 Bump springdoc-openapi-starter-webmvc-ui

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -103,7 +103,12 @@ jobs:
           popd
           
       - name: Generate OpenAPI yaml
-        run: mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
+        run: |
+          mvn springdoc-openapi:generate -Dspringdoc.outputFileName=oh_rev.yaml
+          if [ ! -f "openapi/oh_rev.yaml" ]; then
+            echo "Error: oh_rev.yaml was not generated. The command may have failed."
+            exit 1
+          fi
 
       # Step 1: Check if oh_rev.yaml differs from the committed version
       - name: Install yq

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -767,30 +767,6 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
-  /patients/by-codes:
-     post:
-      tags:
-      - Patients
-      operationId: getPatientByCodes
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                type: integer
-                format: int32
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/PatientDTO"
-      security:
-      - bearerAuth: []
   /patientconsensus/{patientId}:
     get:
       tags:
@@ -2696,6 +2672,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PatientDTO"
+      security:
+      - bearerAuth: []
+  /patients/by-codes:
+    post:
+      tags:
+      - Patients
+      operationId: getPatientByCodes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int32
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PatientDTO"
       security:
       - bearerAuth: []
   /operationtypes:
@@ -6287,11 +6288,11 @@ components:
           description: lock
           format: int32
           example: 0
-        opd:
+        female:
           type: boolean
         male:
           type: boolean
-        female:
+        opd:
           type: boolean
         pharmacy:
           type: boolean


### PR DESCRIPTION
See OP-1391.

- [x] Better error handling of the workflow’s step “Generate OpenAPI yaml”
- [ ] Bump springdoc-openapi-starter-webmvc-ui
- [x] Also address new specs from OH2-456