### PR TITLE
OH2-474 | Implement plugin system

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,9 +55,9 @@ jobs:
 
               if curl -s -o /dev/null -w "%{http_code}" "$CHECK_BRANCH_URL" | grep -q "200"; then
                 echo "Branch $BRANCH_NAME exists in $FORK_REPO."
-              else
+              # else
                 # Fallback to the main repository if the branch doesn’t exist in the fork
-                FORK_REPO="informatici/openhospital-core"
+                # FORK_REPO="informatici/openhospital-core"
               fi
             fi
           fi
@@ -71,11 +71,11 @@ jobs:
           echo "FORK_REPO: ${{ env.FORK_REPO }}"
           echo "BRANCH_NAME: ${{ env.BRANCH_NAME }}"
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
           java-package: jdk
 
       - name: Checkout core

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,9 +55,9 @@ jobs:
 
               if curl -s -o /dev/null -w "%{http_code}" "$CHECK_BRANCH_URL" | grep -q "200"; then
                 echo "Branch $BRANCH_NAME exists in $FORK_REPO."
-              # else
+              else
                 # Fallback to the main repository if the branch doesn’t exist in the fork
-                # FORK_REPO="informatici/openhospital-core"
+                FORK_REPO="informatici/openhospital-core"
               fi
             fi
           fi

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -47,9 +47,9 @@ jobs:
 
               if curl -s -o /dev/null -w "%{http_code}" "$CHECK_BRANCH_URL" | grep -q "200"; then
                 echo "Branch $BRANCH_NAME exists in $FORK_REPO."
-              else
+              # else
                 # Fallback to the main repository if the branch doesn’t exist in the fork
-                FORK_REPO="informatici/openhospital-core"
+                # FORK_REPO="informatici/openhospital-core"
               fi
             fi
           fi
@@ -63,11 +63,11 @@ jobs:
           echo "FORK_REPO: ${{ env.FORK_REPO }}"
           echo "BRANCH_NAME: ${{ env.BRANCH_NAME }}"
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
           java-package: jdk
 
       - name: Checkout core

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 HELP.md
 /target/
 /rsc/*.properties
+/rsc/*.yaml
+/rsc/plugins/**/
 !.mvn/wrapper/maven-wrapper.jar
 /oh-rest-api.log.*.gz
 logs/
@@ -44,5 +46,7 @@ OH_API_PID
 /deps/
 OH_API_PID
 
-### Git ###
-/**/.gitkeep
+### Log files ###
+*.log
+logs/
+LOG_DEST

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is the API project of [Open Hospital][openhospital]: it exposes a REST API 
   * [How to build a war file](#how-to-build-a-war-file)
   * [How to deploy backend in docker environment](#how-to-deploy-backend-in-docker-environment)
   * [How to generate openapi specs](#how-to-generate-openapi-specs)
+  * [Plugin gateway](#plugin-gateway)
   * [Cleaning](#cleaning)
   * [How to contribute](#how-to-contribute)
   * [Community](#community)
@@ -160,6 +161,19 @@ To redirect the output to another file, use:
 
 	mvn springdoc-openapi:generate -Dspringdoc.outputFileName=my_revision.yaml
 	
+
+## Plugin gateway
+
+The API includes a built-in gateway that proxies requests to external plugin services.
+Plugins are defined in `rsc/plugins.yaml` and health-checked at startup. Only reachable
+plugins are registered; unreachable plugins produce a startup warning and their routes
+return `404`.
+
+All plugin routes require a valid JWT. The gateway injects `X-User` and `X-Permissions`
+headers into every forwarded request so the upstream plugin can identify the caller.
+
+For full configuration reference, authorization model, MFE asset serving, and a
+step-by-step guide to adding a new plugin, see **[docs/plugins.md](docs/plugins.md)**.
 
 ## Cleaning
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,473 @@
+# Plugin Gateway
+
+The Open Hospital API includes a built-in reverse-proxy gateway that discovers, health-checks, and securely proxies requests to external plugin services. This document is the reference for configuring the gateway and understanding how it integrates with the frontend host application.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Configuration — `plugins.yaml`](#configuration--pluginsyaml)
+3. [Authorization Model](#authorization-model)
+4. [Identity Headers](#identity-headers)
+5. [Health Checks](#health-checks)
+6. [API Endpoints](#api-endpoints)
+7. [Serving MFE Assets](#serving-mfe-assets)
+8. [Architecture & Request Flow](#architecture--request-flow)
+9. [Adding a New Plugin](#adding-a-new-plugin)
+
+---
+
+## Overview
+
+Each plugin consists of two parts:
+
+- **A backend service** — a standalone HTTP service (e.g. Spring Boot) that the gateway proxies requests to.
+- **A frontend micro-frontend (MFE)** — a Module Federation remote built with Vite, whose static assets are served directly by the OH API.
+
+The gateway sits between the browser and the plugin backend:
+
+```
+Browser → OH API /plugins/{id}/{*path} → Plugin backend service
+Browser → OH API /assets/plugins/{id}/** → Plugin MFE static files
+```
+
+The browser never communicates directly with a plugin backend. All requests are authenticated, authorized, and forwarded by the gateway.
+
+---
+
+## Configuration — `plugins.yaml`
+
+Plugins are defined in `rsc/plugins.yaml`, imported automatically by Spring Boot at startup.
+
+### Full field reference
+
+```yaml
+plugins:
+  definitions:
+    - id: my-plugin           # (string, required)
+                              # Unique identifier. Used as:
+                              #   • URL path segment:  /plugins/my-plugin/**
+                              #   • MFE asset path:    /assets/plugins/my-plugin/**
+                              #   • MF remote name in the frontend
+
+      url: http://localhost:8042/api
+                              # (string, required)
+                              # Base URL of the plugin's backend service.
+                              # No trailing slash. All proxied requests are
+                              # forwarded to: {url}{subPath}
+
+      health: /actuator/health
+                              # (string, required)
+                              # Health-check path relative to `url`.
+                              # Probed once at startup with a 3-second timeout.
+                              # Must return HTTP 2xx for the plugin to be registered.
+
+      configuration:
+        bundle:
+          label: My Plugin    # (string, required)
+                              # Display name shown in the OH frontend nav menu.
+
+          manifest: mf-manifest.json
+                              # (string, required)
+                              # Filename of the MF manifest inside the plugin's
+                              # asset directory. Resolved to:
+                              # /assets/plugins/{id}/{manifest}
+
+          type: module        # (string, required)
+                              # Module type of the remote entry. Always "module"
+                              # for Vite-built MF remotes.
+
+          location: main      # (string, required)
+                              # Where the plugin renders in the UI.
+                              # Allowed values:
+                              #   main    — top-level route  /<plugin-id>
+                              #   patient — patient details tab
+
+          styles: assets/style.css
+                              # (string, optional)
+                              # Relative path to the plugin's CSS file inside
+                              # its asset directory. Injected by the frontend
+                              # into a <style> tag before the plugin mounts.
+
+        permissions:          # (list, optional)
+                              # Role-based access control. If absent or empty,
+                              # any authenticated user may access all routes.
+                              # DENY BY DEFAULT — if present, only explicitly
+                              # listed role+route+method combinations are allowed.
+
+          - role: admin       # (string, required)
+                              # Matches the UserGroup code of the authenticated user.
+
+            routes:           # (list, optional)
+                              # If empty, this role has no access to any route.
+
+              - path: /documents
+                              # (string, required)
+                              # Prefix match. Grants access to:
+                              #   /documents
+                              #   /documents/123
+                              #   /documents/123/attachments
+                              # Does NOT match /documents-other (must be exact or sub-path).
+
+                methods: [GET, POST, DELETE]
+                              # (list, optional)
+                              # HTTP methods allowed on this path.
+                              # Case-insensitive. If empty, no methods are allowed.
+
+          - role: doctor
+            routes:
+              - path: /documents
+                methods: [GET]
+```
+
+## Authorization Model
+
+### Principals
+
+Authorization is **role-based** using the authenticated user's `UserGroup` code (resolved at request time via `UserBrowsingManager`). Each user belongs to exactly one group.
+
+### Algorithm
+
+```
+For every request to /plugins/{id}/{subPath}:
+
+1. Resolve plugin from registry by id → 404 if not found
+2. Require authenticated principal → 401/500 if missing
+3. Resolve role from UserGroup → 403 if not resolvable
+4. If plugin has no permissions configured → ALLOW (any authenticated user)
+5. Filter permissions entries matching the user's role
+6. If no matching role entries → DENY
+7. For each matching role entry, check all routes:
+     pathMatches  = subPath == route.path  OR  subPath.startsWith(route.path + "/")
+     methodMatches = request method in route.methods (case-insensitive)
+8. If any route entry satisfies both → ALLOW
+9. Otherwise → DENY (403)
+```
+
+### Key properties
+
+- **Deny by default** — if the `permissions` list is present but contains no entry granting access, the request is denied.
+- **Prefix matching** — `/documents` grants access to `/documents`, `/documents/123`, and `/documents/123/attachments` but NOT `/documents-other`.
+- **OR across groups** — if a user's role appears in multiple permission entries (unusual but valid), access is granted if any one entry matches.
+- **No unauthenticated access** — all plugin endpoints require a valid JWT Bearer token.
+
+### Example authorization matrix
+
+Given the configuration in the [example above](#example-same-plugin-in-both-locations):
+
+| User role | Path | Method | Result |
+|---|---|---|---|
+| `admin` | `/documents` | `GET` | ✅ allowed |
+| `admin` | `/documents/42` | `DELETE` | ✅ allowed |
+| `doctor` | `/documents` | `GET` | ✅ allowed |
+| `doctor` | `/documents/42` | `POST` | ❌ denied (method not in list) |
+| `doctor` | `/documents/42` | `DELETE` | ❌ denied |
+| `nurse` | `/documents` | `GET` | ❌ denied (role not configured) |
+| `admin` | `/reports` | `GET` | ❌ denied (path not in routes) |
+
+---
+
+## Identity Headers
+
+The gateway forwards the following headers to the upstream plugin backend on every request:
+
+| Header | Value | Notes |
+|---|---|---|
+| `X-User` | Authenticated OH username | Always set |
+| `X-Permissions` | Comma-separated granted authorities | Always set |
+| `Authorization` | `Bearer <JWT>` | Forwarded from the original request |
+
+All other request headers are forwarded as-is, **except `Host`** which is stripped (the upstream receives its own host).
+
+Your plugin backend can trust these headers for identity purposes — the gateway has already validated the JWT before forwarding.
+
+> **Important:** Never expose your plugin backend directly to the internet. It is designed to receive requests only from the OH API gateway, and relies on the forwarded `X-User`/`X-Permissions` headers for identity.
+
+---
+
+## Health Checks
+
+On every `ApplicationReadyEvent` (after Spring Boot fully starts):
+
+1. The gateway reads all `PluginDefinition` entries from `plugins.yaml`.
+2. For each plugin it sends `GET {url}{health}` with a **3-second timeout**.
+3. If the response is HTTP 2xx → plugin is registered and available.
+4. If the response is non-2xx, a timeout, or a connection error → plugin is **skipped** with a `WARN` log. The application continues normally.
+5. Skipped plugins do not appear in `GET /plugins` and their routes return 404.
+
+```mermaid
+flowchart TD
+    A[ApplicationReadyEvent] --> B[Read plugins.yaml definitions]
+    B --> C{For each plugin}
+    C --> D[GET url+health - 3s timeout]
+    D --> E{HTTP 2xx?}
+    E -->|Yes| F[Register in PluginRegistry]
+    E -->|No / timeout / error| G[WARN log - skip plugin]
+    F --> H[Available in GET /plugins]
+    G --> I[Not registered - 404 on proxy]
+    H --> C
+    I --> C
+```
+
+**To re-enable a plugin** after its backend becomes reachable: **restart the OH API**. There is no live re-registration mechanism.
+
+---
+
+## API Endpoints
+
+All endpoints require a valid `Authorization: Bearer <token>` header.
+
+### `GET /plugins`
+
+Returns all plugins that passed the startup health check.
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": "smart-doc",
+    "url": "http://localhost:8042/api",
+    "health": "/actuator/health",
+    "configuration": {
+      "bundle": {
+        "label": "Smart Doc",
+        "manifest": "mf-manifest.json",
+        "type": "module",
+        "location": "main",
+        "styles": "assets/style.css"
+      },
+      "permissions": [
+        {
+          "role": "admin",
+          "routes": [
+            { "path": "/documents", "methods": ["GET", "POST", "DELETE"] }
+          ]
+        }
+      ]
+    }
+  }
+]
+```
+
+The frontend host calls this endpoint at application startup to build the MF remote registry and inject routes.
+
+---
+
+### `ANY /plugins/{id}/{path}`
+
+Proxies a request to the upstream plugin backend after authorization.
+
+**Path parameters:**
+
+| Parameter | Description |
+|---|---|
+| `id` | Plugin identifier, must match a registered plugin |
+| `path` | Sub-path forwarded to the upstream service |
+
+**Supported methods:** `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`, `HEAD`
+
+**Responses:**
+
+| Code | Meaning |
+|---|---|
+| `200` / `201` / etc. | Upstream response forwarded transparently (status, headers, body) |
+| `403` | Authenticated user lacks required privileges for this path/method |
+| `404` | Plugin not found or did not pass the startup health check |
+| `502` | Upstream plugin returned an unexpected error (the upstream response is forwarded) |
+
+**Forwarding behaviour:**
+- Request method, query string, body, and all headers (except `Host`) are forwarded verbatim.
+- `X-User`, `X-Permissions` are injected.
+- Multipart/form-data bodies are handled correctly (form parameters are separated from query parameters).
+- The upstream response body, status code, and headers are returned directly to the browser.
+
+---
+
+## Serving MFE Assets
+
+The gateway serves the plugin's static MFE files (JavaScript bundles, CSS, the MF manifest) under:
+
+```
+GET /assets/plugins/{plugin-id}/**
+```
+
+These are served from `classpath:/plugins/{plugin-id}/` — concretely, from `rsc/plugins/` in the repository (packaged into the jar).
+
+> **Note:** `rsc/plugins/` is not tracked in git. Plugin MFE bundles are external artifacts
+> that must be placed here before building or starting the application. The mechanism for
+> obtaining them (e.g. downloading from a release, a CI step) is left to the deployment workflow.
+
+### Directory layout
+
+```
+rsc/plugins/
+└── my-plugin/
+    ├── mf-manifest.json      ← MF manifest — host reads this at runtime
+    ├── my-plugin.js          ← MF remote entry
+    └── assets/
+        ├── my-plugin-[hash].js
+        └── style.css
+```
+
+The `manifest` field in `plugins.yaml` is resolved against this base path:
+
+```
+/assets/plugins/{id}/{manifest}
+→ /assets/plugins/my-plugin/mf-manifest.json
+```
+
+### `mf-manifest.json` format
+
+Generated by `@module-federation/vite` when `manifest: true` is set in the plugin's Vite config. The host reads it to discover the remote entry file and shared dependency versions.
+
+Key fields the host uses:
+
+```json
+{
+  "id": "my-plugin",
+  "metaData": {
+    "remoteEntry": {
+      "name": "my-plugin.js",
+      "type": "module"
+    },
+    "publicPath": "http://<oh-host>/assets/plugins/my-plugin/"
+  },
+  "exposes": [
+    { "id": "my-plugin:app", "name": "app", "path": "./app" }
+  ],
+  "shared": [
+    { "name": "react", "version": "19.2.4" },
+    { "name": "react-dom", "version": "19.2.4" },
+    { "name": "react-router", "version": "7.x" }
+  ]
+}
+```
+
+> The `publicPath` in the manifest must match the `base` set in the plugin's
+> `vite.plugin.config.ts`. This is what allows the MF runtime to resolve chunk URLs correctly.
+
+---
+
+## Architecture & Request Flow
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant G as OH API Gateway
+    participant R as PluginRegistry
+    participant A as PluginAuthorizationChecker
+    participant F as PluginRequestForwarder
+    participant U as Plugin Backend (upstream)
+
+    Note over G: ApplicationReadyEvent
+    G->>U: GET {url}{health}  (3s timeout)
+    U-->>G: 200 OK
+    G->>R: register(pluginDefinition)
+
+    Note over B,G: User navigates to /<plugin-id>
+    B->>G: GET /assets/plugins/my-plugin/mf-manifest.json
+    G-->>B: mf-manifest.json (served from classpath:/plugins/)
+    B->>G: GET /assets/plugins/my-plugin/[scripts].js
+    G-->>B: remote JS bundle
+
+    Note over B,G: Plugin makes an API call
+    B->>G: GET /plugins/my-plugin/documents (Bearer token)
+    G->>R: find("my-plugin")
+    R-->>G: PluginDefinition
+    G->>A: assertAccess(plugin, "/documents", "GET")
+    A->>A: resolve role from UserGroup
+    A->>A: match role → routes → path+method
+    A-->>G: access granted (or throws 403)
+    G->>F: forward(plugin, "/documents", request, username, authorities)
+    F->>F: build URI: http://localhost:8042/api/documents
+    F->>F: build headers (strip Host, add X-User, X-Permissions)
+    F->>U: GET http://localhost:8042/api/documents
+    U-->>F: 200 OK [{...}]
+    F-->>G: ResponseEntity<byte[]>
+    G-->>B: 200 OK [{...}]
+```
+
+---
+
+## Adding a New Plugin
+
+### 1. Deploy the plugin backend
+
+Start your backend service. Ensure it exposes a health endpoint that returns `HTTP 2xx` (e.g. `/actuator/health` for Spring Boot, `/health` for Express).
+
+### 2. Build the plugin frontend
+
+In your plugin's frontend project, run:
+
+```bash
+npm run build:plugin
+# produces dist/<plugin-id>/
+```
+
+The `vite.plugin.config.ts` must set:
+- `base`: `http://<oh-host>/assets/plugins/<plugin-id>`
+- `build.outDir`: `dist/<plugin-id>`
+- `manifest: true` in the `federation({...})` config
+
+See [openhospital-ui/docs/plugins.md](../../openhospital-ui/docs/plugins.md) for the full frontend build guide.
+
+### 3. Place MFE assets in the API
+
+Plugin MFE assets are not tracked in git. Place the built bundle for your plugin at
+`rsc/plugins/<plugin-id>/` before building or starting the OH API. How you obtain the
+bundle (local build, CI artifact, release download, etc.) is up to your deployment workflow.
+
+After placing the files, the plugin's `mf-manifest.json` will be served at:
+```
+GET /assets/plugins/<plugin-id>/mf-manifest.json
+```
+
+### 4. Register in `plugins.yaml`
+
+Add an entry to `rsc/plugins.yaml`:
+
+```yaml
+plugins:
+  definitions:
+    - id: my-plugin
+      url: http://<plugin-backend-host>:<port>/api
+      health: /actuator/health
+      configuration:
+        bundle:
+          label: My Plugin
+          manifest: mf-manifest.json
+          type: module
+          location: main        # or: patient
+          styles: assets/style.css
+        permissions:
+          - role: admin
+            routes:
+              - path: /
+                methods: [GET, POST, PUT, DELETE]
+```
+
+### 5. Restart the OH API
+
+The health check runs only on startup. After restart:
+
+```bash
+# Verify the plugin is registered
+curl -H "Authorization: Bearer <token>" http://localhost:8080/plugins
+# → should include your plugin in the array
+```
+
+### 6. Verify in the frontend
+
+- **`location: main`** — Navigate to `/<plugin-id>`. The plugin appears in the global nav dropdown.
+- **`location: patient`** — Open any patient's details page. Your plugin appears as a new tab in the sidebar.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Plugin missing from `GET /plugins` | Health check failed at startup. Check logs for `WARN` from `PluginHealthChecker`. Ensure the backend is running and the `url`+`health` path is correct. |
+| `404` on proxy requests | Plugin backend is registered but the sub-path is wrong, or the plugin was not registered (health check failed). |
+| `403` on proxy requests | User's role is not in the `permissions` list, or the path/method combination is not covered. |
+| MFE blank page / console MF errors | `publicPath` in `mf-manifest.json` does not match `base` in `vite.plugin.config.ts`, or files are missing from `rsc/plugins/<id>/`. |
+| `502` response | Upstream plugin backend returned an error. The gateway forwards the upstream response body — inspect it for details. |

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -9,9 +9,12 @@ info:
     url: https://github.com/informatici/openhospital-api?tab=GPL-3.0-1-ov-file#readme
   version: 0.1.0
 servers:
-- url: http://localhost:8080
+- url: http://localhost
 security:
 - bearerAuth: []
+tags:
+- name: Plugins
+  description: Dynamic gateway to registered external plugin services
 paths:
   /wards:
     get:
@@ -3907,6 +3910,25 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /plugins:
+    get:
+      tags:
+      - Plugins
+      summary: List all registered plugins
+      description: Returns all plugins that passed the startup health check and are
+        currently available through the gateway.
+      operationId: listPlugins
+      responses:
+        "200":
+          description: Plugin list returned successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PluginDefinition"
+      security:
+      - bearerAuth: []
   /permissions:
     get:
       tags:
@@ -6239,6 +6261,357 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /plugins/{id}/{path}:
+    get:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_2
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    delete:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_3
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    options:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_6
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    head:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_5
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
+    patch:
+      tags:
+      - Plugins
+      summary: Proxy a request to an external plugin
+      description: "Resolves the plugin by ID, checks authorization, then forwards\
+        \ the request to the plugin's upstream URL. The sub-path after /plugins/{pluginId}\
+        \ is appended to the plugin base URL. All HTTP methods are supported."
+      operationId: proxy_4
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Upstream response forwarded successfully
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Authenticated user lacks required privileges for this plugin
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Plugin not found or unavailable
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "502":
+          description: Upstream plugin returned an unexpected error
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth: []
 components:
   schemas:
     WardDTO:
@@ -6281,11 +6654,11 @@ components:
           format: int32
           description: lock
           example: 0
+        opd:
+          type: boolean
         female:
           type: boolean
         male:
-          type: boolean
-        opd:
           type: boolean
         pharmacy:
           type: boolean
@@ -8315,6 +8688,65 @@ components:
       - item
       - list
       - price
+    PluginBundle:
+      type: object
+      properties:
+        label:
+          type: string
+        manifest:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          enum:
+          - main
+          - patient
+        styles:
+          type: string
+      required:
+      - label
+      - location
+      - manifest
+      - type
+    PluginConfiguration:
+      type: object
+      properties:
+        bundle:
+          $ref: "#/components/schemas/PluginBundle"
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PluginPermission"
+    PluginDefinition:
+      type: object
+      properties:
+        id:
+          type: string
+        url:
+          type: string
+        health:
+          type: string
+        configuration:
+          $ref: "#/components/schemas/PluginConfiguration"
+    PluginPermission:
+      type: object
+      properties:
+        role:
+          type: string
+        routes:
+          type: array
+          items:
+            $ref: "#/components/schemas/PluginRoute"
+    PluginRoute:
+      type: object
+      properties:
+        path:
+          type: string
+        methods:
+          type: array
+          items:
+            type: string
     PageInfoDTO:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,18 @@
             <version>4.4.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.5.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.jasperreports</groupId>
+            <artifactId>jasperreports</artifactId>
+            <version>6.21.3</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -29,10 +29,6 @@ springdoc.swagger-ui.doc-expansion=none
 ### Seems like a Hibernate/SpringBoot conflict: see https://stackoverflow.com/questions/55545627/springboot-conflicts-with-hibernate
 spring.main.allow-bean-definition-overriding=true
 
-### Without the following SpringBoot 2.6.x has a conflict with a bug in SpringFox
-### See: https://stackoverflow.com/questions/70036953/springboot-2-6-0-spring-fox-3-failed-to-start-bean-documentationpluginsboot/70037507#70037507
-spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 ### Security token secret (JWT)
 jwt.token.secret=JWT_TOKEN_SECRET
 

--- a/rsc/plugins.yaml.dist
+++ b/rsc/plugins.yaml.dist
@@ -1,0 +1,60 @@
+# =============================================================================
+# Open Hospital — Plugin Gateway Configuration
+# =============================================================================
+#
+# This file defines the external plugins registered with the OH-API gateway.
+# On application startup each plugin's health endpoint is probed; only healthy
+# plugins are registered and their routes become available at:
+#
+#   /plugins/{id}/**  →  {url}/**
+#
+# Example: GET /plugins/smart-doc/document-types
+#          → GET http://localhost:8042/api/document-types
+#
+# Fields per plugin:
+#   id            Unique identifier used as the URL path segment.
+#                 Must be URL-safe (lowercase letters, digits, hyphens).
+#   url           Base URL of the upstream service. No trailing slash.
+#   health        Path on the upstream service used for the startup health probe.
+#                 A 2xx response marks the plugin as available.
+#   configuration
+#     permissions Restrictive access-control rules per user-group role.
+#                 Routes NOT listed here are blocked. A plugin with no permissions
+#                 configured is inaccessible to all users.
+#       role      The user-group name (UserGroup.code) that this entry applies to.
+#       routes    List of upstream path + method combinations the role may access.
+#         path    Path prefix on the upstream service (e.g. /documents).
+#                 Any sub-path is allowed (e.g. /documents/123 matches /documents).
+#         methods HTTP methods permitted on this path (e.g. GET, POST, DELETE).
+#
+# =============================================================================
+
+plugins:
+  definitions:
+
+    # -------------------------------------------------------------------------
+    # smart-doc — Documentation digitalization service
+    # -------------------------------------------------------------------------
+    - id: smart-doc
+      url: http://localhost:8042/api
+      health: /actuator/health
+      configuration:
+        bundle:
+          label: Smart Doc
+          manifest: mf-manifest.json
+          styles: assets/style.css
+          type: module
+          location: main
+        permissions:
+          - role: admin
+            routes:
+              - path: /documents
+                methods:
+                  - GET
+                  - POST
+                  - DELETE
+          - role: doctor
+            routes:
+              - path: /documents
+                methods:
+                  - GET

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -21,8 +21,6 @@
  */
 package org.isf.config;
 
-import java.util.Arrays;
-
 import org.isf.permissions.manager.PermissionManager;
 import org.isf.security.ApiAuditorAwareImpl;
 import org.isf.security.CustomLogoutHandler;
@@ -50,33 +48,32 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
 	private final TokenProvider tokenProvider;
-
-	@Autowired
-	private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
-
 	@Autowired
 	protected PermissionManager permissionManager;
+	@Autowired
+	private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+	@Autowired
+	private CustomLogoutHandler customLogoutHandler;
+	@Value("${cors.allowed.origins}")
+	private String allowedOrigins;
 
 	public SecurityConfig(TokenProvider tokenProvider, PermissionManager permissionManager) {
 		this.tokenProvider = tokenProvider;
 		this.permissionManager = permissionManager;
 	}
 
-	@Autowired
-	private CustomLogoutHandler customLogoutHandler;
-
 	@Bean
 	public PasswordEncoder encoder() {
 		return new BCryptPasswordEncoder();
 	}
-
-	@Value("${cors.allowed.origins}")
-	private String allowedOrigins;
 
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
@@ -85,7 +82,7 @@ public class SecurityConfig {
 		for (String origin : allowedOrigins.split(",")) {
 			configuration.addAllowedOriginPattern(origin.trim());
 		}
-		configuration.setAllowedMethods(Arrays.asList("*")); // Allows all HTTP methods
+		configuration.setAllowedMethods(List.of("*")); // Allows all HTTP methods
 		configuration.addAllowedHeader("*"); // Allows all headers
 		configuration.setAllowCredentials(true); // Allows credentials (e.g., cookies)
 		configuration.setMaxAge(3600L); // Cache preflight responses for 1 hour
@@ -328,6 +325,11 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
 				.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
 				.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
+
+				// Assets
+				.requestMatchers("/assets/**").permitAll()
+				// Plugins
+				.requestMatchers(HttpMethod.GET, "/plugins").permitAll()
 
 				.anyRequest().authenticated()
 

--- a/src/main/java/org/isf/plugins/config/PluginBundle.java
+++ b/src/main/java/org/isf/plugins/config/PluginBundle.java
@@ -1,0 +1,12 @@
+package org.isf.plugins.config;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PluginBundle(
+	@NotNull String label,
+	@NotNull String manifest,
+	@NotNull String type,
+	@NotNull PluginLocation location,
+	String styles
+) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginConfiguration.java
+++ b/src/main/java/org/isf/plugins/config/PluginConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
+
+/**
+ * Groups the access-control configuration for a single plugin.
+ *
+ * <p>Bound from the {@code configuration} key under a plugin definition in
+ * {@code plugins.yaml}. A {@code null} or empty {@code permissions} list means that
+ * <strong>no role has access</strong> — the gateway enforces a restrictive default.</p>
+ *
+ * <p>Example YAML fragment:</p>
+ * <pre>{@code
+ * configuration:
+ * 	 bundle:
+ * 	 	label: "Document Manager"
+ * 	 	manifest: "mf-manifest.json"
+ * 	    type: "module"
+ * 	    location: "main"
+ * 	    styles: "assets/styles.css"
+ *   permissions:
+ *     - role: admin
+ *       routes:
+ *         - path: /documents
+ *           methods: [GET, POST, DELETE]
+ * }</pre>
+ *
+ * @param permissions list of role-to-routes mappings; defaults to an empty list if omitted
+ * @author Steve Tsala
+ */
+public record PluginConfiguration(
+	PluginBundle bundle,
+	@DefaultValue List<PluginPermission> permissions) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginDefinition.java
+++ b/src/main/java/org/isf/plugins/config/PluginDefinition.java
@@ -1,0 +1,61 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+/**
+ * Immutable description of a single external plugin registered with the gateway.
+ *
+ * <p>Instances are populated by Spring Boot's {@code @ConfigurationProperties} binding
+ * from {@code plugins.yaml} via the canonical record constructor. Every component maps
+ * directly to a YAML key under the {@code plugins.definitions[*]} list.</p>
+ *
+ * <p>Example YAML fragment:</p>
+ * <pre>{@code
+ * plugins:
+ *   definitions:
+ *     - id: smart-doc
+ *       url: http://localhost:4000/api
+ *       health: /health
+ *       configuration:
+ *         permissions:
+ *           - role: admin
+ *             routes:
+ *               - path: /documents
+ *                 methods: [GET, POST, DELETE]
+ * }</pre>
+ *
+ * @param id            unique identifier used as the URL path segment in
+ *                      {@code /plugins/{id}/**}; must be URL-safe (lowercase, hyphens allowed)
+ * @param url           base URL of the upstream plugin service (no trailing slash);
+ *                      all proxied requests are forwarded to {@code url + subPath}
+ * @param health        health check path relative to {@link #url()} (e.g. {@code "/health"});
+ *                      probed at startup — a non-2xx or connection failure excludes the plugin
+ * @param configuration access-control configuration for this plugin; a {@code null} or
+ *                      empty configuration means no role has access (restrictive default)
+ * @author Steve Tsala
+ */
+public record PluginDefinition(
+	String id,
+	String url,
+	String health,
+	PluginConfiguration configuration) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginLocation.java
+++ b/src/main/java/org/isf/plugins/config/PluginLocation.java
@@ -1,0 +1,17 @@
+package org.isf.plugins.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PluginLocation {
+	@JsonProperty("main") MAIN("main"), @JsonProperty("patient") PATIENT("patient");
+	final String value;
+
+	PluginLocation(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value;
+	}
+}

--- a/src/main/java/org/isf/plugins/config/PluginPermission.java
+++ b/src/main/java/org/isf/plugins/config/PluginPermission.java
@@ -1,0 +1,58 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
+
+/**
+ * Represents the access-control entry for a single user-group role within a plugin definition.
+ *
+ * <p>Each {@code PluginPermission} binds a user-group role (matched against
+ * {@code UserGroup.code}, e.g. {@code "admin"}) to the set of upstream routes
+ * ({@link PluginRoute}) that members of that group may access. Authorization is enforced
+ * by comparing the authenticated user's group code against {@link #role()} and then
+ * verifying that the request path and HTTP method match at least one declared
+ * {@link PluginRoute}.</p>
+ *
+ * <p>Example YAML fragment:</p>
+ * <pre>{@code
+ * permissions:
+ *   - role: admin
+ *     routes:
+ *       - path: /documents
+ *         methods:
+ *           - GET
+ *           - POST
+ * }</pre>
+ *
+ * @param role   user-group code (e.g. {@code "admin"}, {@code "doctor"}) matched against
+ *               {@code UserGroup.getCode()} for the authenticated user
+ * @param routes upstream path + method combinations accessible to this role;
+ *               defaults to an empty list if omitted in YAML
+ * @author Steve Tsala
+ */
+public record PluginPermission(
+	String role,
+	@DefaultValue List<PluginRoute> routes) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginProperties.java
+++ b/src/main/java/org/isf/plugins/config/PluginProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
+
+/**
+ * Type-safe binding of the {@code plugins} namespace from {@code plugins.yaml}.
+ *
+ * <p>Activated by {@link PluginsConfig} via {@code @EnableConfigurationProperties}.
+ *
+ * <p>Example {@code plugins.yaml}:</p>
+ * <pre>{@code
+ * plugins:
+ *   definitions:
+ *     - id: smart-doc
+ *       url: http://localhost:4000/api
+ *       health: /health
+ *       permissions:
+ *         - role: admin
+ *           privileges:
+ *             - smart-doc.read
+ *             - smart-doc.write
+ * }</pre>
+ *
+ * @param definitions the list of plugin definitions loaded from {@code plugins.yaml};
+ *                    defaults to an empty list when the file is absent or the key is omitted
+ * @author Steve Tsala
+ */
+@ConfigurationProperties(prefix = "plugins")
+public record PluginProperties(
+	@DefaultValue List<PluginDefinition> definitions) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginRoute.java
+++ b/src/main/java/org/isf/plugins/config/PluginRoute.java
@@ -1,0 +1,53 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
+
+/**
+ * Declares a single upstream path and the HTTP methods that are permitted on it.
+ *
+ * <p>Path matching uses a <em>prefix</em> strategy: a configured {@code path} of
+ * {@code /documents} will match any incoming sub-path such as
+ * {@code /documents/123} or {@code /documents/123/attachments}.</p>
+ *
+ * <p>Example YAML fragment:</p>
+ * <pre>{@code
+ * routes:
+ *   - path: /documents
+ *     methods:
+ *       - GET
+ *       - POST
+ * }</pre>
+ *
+ * @param path    path prefix on the upstream service (e.g. {@code "/documents"});
+ *                matched as a prefix against the incoming sub-path
+ * @param methods HTTP methods permitted on this path (e.g. {@code "GET"}, {@code "POST"});
+ *                defaults to an empty list if omitted in YAML
+ * @author Steve Tsala
+ */
+public record PluginRoute(
+	String path,
+	@DefaultValue List<String> methods) {
+}

--- a/src/main/java/org/isf/plugins/config/PluginsConfig.java
+++ b/src/main/java/org/isf/plugins/config/PluginsConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.config;
+
+import org.isf.security.jwt.JWTFilter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Loads {@code rsc/plugins.yaml} into the Spring {@link org.springframework.core.env.Environment}
+ * and activates type-safe binding via {@link PluginProperties}.
+ *
+ * @author Steve Tsala
+ */
+@Configuration
+@EnableConfigurationProperties(PluginProperties.class)
+public class PluginsConfig implements WebMvcConfigurer {
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler("/assets/plugins/**")
+			.addResourceLocations("classpath:/plugins/");
+	}
+}

--- a/src/main/java/org/isf/plugins/exception/PluginAccessDeniedException.java
+++ b/src/main/java/org/isf/plugins/exception/PluginAccessDeniedException.java
@@ -1,0 +1,38 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.exception;
+
+/**
+ * Thrown when the authenticated user does not hold any of the privileges required to
+ * access a plugin's routes, as declared in the plugin's {@code permissions} configuration.
+ *
+ * <p>Mapped to HTTP {@code 403 Forbidden} by
+ * {@link org.isf.plugins.proxy.PluginProxyController}.</p>
+ *
+ * @author Steve Tsala
+ */
+public class PluginAccessDeniedException extends RuntimeException {
+
+	public PluginAccessDeniedException(String pluginId, String username) {
+		super("Access denied for user '" + username + "' to plugin '" + pluginId + "'");
+	}
+}

--- a/src/main/java/org/isf/plugins/exception/PluginNotFoundException.java
+++ b/src/main/java/org/isf/plugins/exception/PluginNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.exception;
+
+/**
+ * Thrown when a request targets a plugin whose ID is not present in the
+ * {@link org.isf.plugins.registry.PluginRegistry} — either because the plugin was never
+ * defined, or because its health check failed at startup and it was skipped.
+ *
+ * <p>Mapped to HTTP {@code 404 Not Found} by
+ * {@link org.isf.plugins.proxy.PluginProxyController}.</p>
+ *
+ * @author Steve Tsala
+ */
+public class PluginNotFoundException extends RuntimeException {
+
+	public PluginNotFoundException(String pluginId) {
+		super("Plugin not found or unavailable: '" + pluginId + "'");
+	}
+}

--- a/src/main/java/org/isf/plugins/health/IPluginHealthChecker.java
+++ b/src/main/java/org/isf/plugins/health/IPluginHealthChecker.java
@@ -1,0 +1,63 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.health;
+
+import org.isf.plugins.config.PluginDefinition;
+import org.isf.plugins.registry.IPluginRegistry;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+/**
+ * Probes each configured plugin's health endpoint at application startup and populates
+ * the {@link IPluginRegistry} with only the plugins that respond successfully.
+ *
+ * <h3>Startup sequence</h3>
+ * <ol>
+ *   <li>Listens for {@link ApplicationReadyEvent} — fired after the full Spring context
+ *       and embedded server are up.</li>
+ *   <li>For each {@link PluginDefinition}, issues a {@code GET} to
+ *       {@code plugin.url + plugin.health}.</li>
+ *   <li>Plugins that return any {@code 2xx} response are registered as healthy.</li>
+ *   <li>Plugins that fail are logged at {@code WARN} level and excluded from the registry.
+ *       The application continues to start normally.</li>
+ * </ol>
+ *
+ * @author Steve Tsala
+ */
+public interface IPluginHealthChecker {
+
+	/**
+	 * Triggered once the application context is fully started.
+	 * Iterates over all configured plugins, probes their health endpoints, and registers
+	 * healthy ones into the {@link IPluginRegistry}.
+	 *
+	 * @param event the {@link ApplicationReadyEvent} (triggers the method)
+	 */
+	void onApplicationReady(ApplicationReadyEvent event);
+
+	/**
+	 * Probes a single plugin's health endpoint.
+	 *
+	 * @param plugin the plugin definition to check
+	 * @return {@code true} if the health endpoint returned a {@code 2xx} status within the timeout
+	 */
+	boolean isHealthy(PluginDefinition plugin);
+}

--- a/src/main/java/org/isf/plugins/health/PluginHealthChecker.java
+++ b/src/main/java/org/isf/plugins/health/PluginHealthChecker.java
@@ -1,0 +1,129 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.health;
+
+import org.isf.plugins.config.PluginDefinition;
+import org.isf.plugins.config.PluginProperties;
+import org.isf.plugins.registry.IPluginRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Steve Tsala
+ */
+@Component
+public class PluginHealthChecker implements IPluginHealthChecker {
+
+	/**
+	 * Maximum seconds to wait for a plugin's health endpoint to respond.
+	 */
+	static final int HEALTH_CHECK_TIMEOUT_SECONDS = 3;
+	private static final Logger LOGGER = LoggerFactory.getLogger(PluginHealthChecker.class);
+	private final PluginProperties pluginProperties;
+	private final IPluginRegistry pluginRegistry;
+	private final RestClient restClient;
+
+	public PluginHealthChecker(PluginProperties pluginProperties, IPluginRegistry pluginRegistry) {
+		this.pluginProperties = pluginProperties;
+		this.pluginRegistry = pluginRegistry;
+		this.restClient = RestClient.builder()
+			.requestInitializer(request -> {
+				request.getHeaders().set("Connection", "close");
+			})
+			.build();
+	}
+
+	@Override
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationReady(ApplicationReadyEvent event) {
+		List<PluginDefinition> definitions = pluginProperties.definitions();
+
+		if (definitions.isEmpty()) {
+			LOGGER.info("No plugins configured. Plugin gateway is inactive.");
+			return;
+		}
+
+		LOGGER.info("Starting health checks for {} configured plugin(s)...", definitions.size());
+
+		Map<String, PluginDefinition> healthy = new LinkedHashMap<>();
+
+		for (PluginDefinition plugin : definitions) {
+			if (isHealthy(plugin)) {
+				healthy.put(plugin.id(), plugin);
+			}
+		}
+
+		pluginRegistry.register(healthy);
+
+		int skipped = definitions.size() - healthy.size();
+		if (skipped > 0) {
+			LOGGER.warn("{} plugin(s) failed health checks and will not be available.", skipped);
+		}
+	}
+
+	@Override
+	public boolean isHealthy(PluginDefinition plugin) {
+		String healthUrl = buildHealthUrl(plugin);
+		try {
+			LOGGER.debug("Checking health of plugin '{}' at '{}'...", plugin.id(), healthUrl);
+
+			ResponseEntity<Void> response = restClient.get()
+				.uri(healthUrl)
+				.retrieve()
+				.onStatus(status -> !status.is2xxSuccessful(), (req, res) -> {
+					// Don't throw — we handle non-2xx below via the response object
+				})
+				.toBodilessEntity();
+
+			if (response.getStatusCode().is2xxSuccessful()) {
+				LOGGER.info("Plugin '{}' is healthy (HTTP {}).", plugin.id(), response.getStatusCode().value());
+				return true;
+			} else {
+				LOGGER.warn("Plugin '{}' health check at '{}' returned HTTP {}. Plugin will be skipped.",
+					plugin.id(), healthUrl, response.getStatusCode().value());
+				return false;
+			}
+		} catch (RestClientException ex) {
+			LOGGER.warn("Plugin '{}' health check at '{}' failed: {}. Plugin will be skipped.",
+				plugin.id(), healthUrl, ex.getMessage());
+			return false;
+		}
+	}
+
+	private String buildHealthUrl(PluginDefinition plugin) {
+		String base = plugin.url().endsWith("/")
+			? plugin.url().substring(0, plugin.url().length() - 1)
+			: plugin.url();
+		String path = plugin.health().startsWith("/") ? plugin.health() : "/" + plugin.health();
+		return base + path;
+	}
+}

--- a/src/main/java/org/isf/plugins/proxy/IPluginRequestForwarder.java
+++ b/src/main/java/org/isf/plugins/proxy/IPluginRequestForwarder.java
@@ -1,0 +1,97 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.proxy;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.isf.plugins.config.PluginDefinition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Constructs and dispatches HTTP requests to upstream plugin services, then returns
+ * the raw response back to the caller unchanged.
+ *
+ * <h3>Request forwarding rules</h3>
+ * <ul>
+ *   <li>Target URL: {@code plugin.url + subPath [+ ?queryString]}</li>
+ *   <li>Method, body, and all original headers are forwarded as-is, except {@code Host}
+ *       (removed to avoid conflicts with the upstream server).</li>
+ *   <li>The original {@code Authorization: Bearer <token>} header is forwarded so that
+ *       the plugin can optionally re-validate it.</li>
+ *   <li>Two identity headers are added:
+ *     <ul>
+ *       <li>{@code X-User} — the authenticated username</li>
+ *       <li>{@code X-Permissions} — comma-separated granted authorities from the JWT</li>
+ *     </ul>
+ *   </li>
+ *   <li>The full upstream response (status, headers, body) is returned unmodified.</li>
+ * </ul>
+ *
+ * <h3>Error handling</h3>
+ * If the upstream service returns an error HTTP status, that status and body are passed
+ * through to the client without modification — the gateway does not swallow upstream errors.
+ * {@link RestClientResponseException} is re-thrown as-is and handled by
+ * {@link PluginProxyController}.
+ *
+ * @author Steve Tsala
+ */
+public interface IPluginRequestForwarder {
+
+	/**
+	 * Forwards an incoming request to the appropriate upstream plugin endpoint.
+	 *
+	 * @param plugin      the target plugin definition
+	 * @param subPath     the path segment after {@code /plugins/{id}} (e.g. {@code "/documents/123"})
+	 * @param request     the original HTTP servlet request (provides method, headers, body)
+	 * @param username    the authenticated username (added as {@code X-User})
+	 * @param authorities the user's granted authorities (added as {@code X-Permissions})
+	 * @return the upstream response with its original status, headers, and body
+	 */
+	ResponseEntity<byte[]> forward(
+		PluginDefinition plugin,
+		String subPath,
+		HttpServletRequest request,
+		String username,
+		Collection<? extends GrantedAuthority> authorities);
+
+	/**
+	 * Extracts only the form parameters from a multipart request, excluding any query parameters.
+	 *
+	 * @param multipartRequest the incoming multipart HTTP request
+	 * @return a map of form parameter names to their values, excluding query parameters
+	 */
+	Map<String, String[]> getFormParametersOnly(MultipartHttpServletRequest multipartRequest);
+
+	/**
+	 * Copies all headers from the {@link HttpServletRequest} into an {@link HttpHeaders} map.
+	 *
+	 * @param request the incoming servlet request
+	 * @return assembled {@link HttpHeaders}
+	 */
+	HttpHeaders buildRequestHeaders(HttpServletRequest request);
+}

--- a/src/main/java/org/isf/plugins/proxy/PluginHeadersBuilder.java
+++ b/src/main/java/org/isf/plugins/proxy/PluginHeadersBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.proxy;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Package-private helper responsible for assembling the {@link HttpHeaders} that are
+ * forwarded to an upstream plugin.
+ *
+ * <p>Extracted from {@link PluginRequestForwarder} to satisfy the Single Responsibility
+ * Principle — header construction is a distinct concern from HTTP dispatch.</p>
+ *
+ * <p>Forwarding rules:</p>
+ * <ul>
+ *   <li>All incoming headers are copied except {@code Host}.</li>
+ *   <li>{@value PluginRequestForwarder#HEADER_X_USER} is set to the authenticated username.</li>
+ *   <li>{@value PluginRequestForwarder#HEADER_X_PERMISSIONS} is set to a comma-separated
+ *       list of the user's granted authorities.</li>
+ * </ul>
+ *
+ * @author Steve Tsala
+ */
+abstract class PluginHeadersBuilder {
+
+	/**
+	 * Headers that must not be forwarded to the upstream plugin.
+	 */
+	private static final Set<String> EXCLUDED_REQUEST_HEADERS = Set.of(
+		HttpHeaders.HOST.toLowerCase()
+	);
+
+	/**
+	 * Builds the headers to send to the upstream plugin.
+	 * Copies all incoming headers except those in {@link #EXCLUDED_REQUEST_HEADERS},
+	 * then appends the identity headers.
+	 *
+	 * @param incomingHeaders original request headers
+	 * @param username        authenticated username
+	 * @param authorities     the user's granted authorities
+	 * @return the assembled {@link HttpHeaders} for the upstream request
+	 */
+	static HttpHeaders build(
+		HttpHeaders incomingHeaders,
+		String username,
+		Collection<? extends GrantedAuthority> authorities) {
+
+		HttpHeaders headers = new HttpHeaders();
+
+		incomingHeaders.forEach((name, values) -> {
+			if (!EXCLUDED_REQUEST_HEADERS.contains(name.toLowerCase())) {
+				headers.addAll(name, values);
+			}
+		});
+
+		// Identity headers — always set, overwriting any client-supplied values.
+		headers.set(PluginRequestForwarder.HEADER_X_USER, username);
+		headers.set(PluginRequestForwarder.HEADER_X_PERMISSIONS, buildPermissionsHeader(authorities));
+
+		return headers;
+	}
+
+	/**
+	 * Converts a collection of GrantedAuthority into a comma-separated string for the
+	 *
+	 * @param authorities the user's granted authorities
+	 * @return a comma-separated string of authority names, or an empty string if there are none
+	 */
+	private static String buildPermissionsHeader(Collection<? extends GrantedAuthority> authorities) {
+		return authorities.stream()
+			.map(GrantedAuthority::getAuthority)
+			.reduce((a, b) -> a + "," + b)
+			.orElse("");
+	}
+}

--- a/src/main/java/org/isf/plugins/proxy/PluginRequestForwarder.java
+++ b/src/main/java/org/isf/plugins/proxy/PluginRequestForwarder.java
@@ -1,0 +1,179 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.proxy;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.isf.plugins.config.PluginDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * @author Steve Tsala
+ */
+@Component
+public class PluginRequestForwarder implements IPluginRequestForwarder {
+
+	/**
+	 * Identity header carrying the authenticated username.
+	 */
+	public static final String HEADER_X_USER = "X-User";
+	/**
+	 * Identity header carrying the comma-separated permission list from the JWT.
+	 */
+	public static final String HEADER_X_PERMISSIONS = "X-Permissions";
+	private static final Logger LOGGER = LoggerFactory.getLogger(PluginRequestForwarder.class);
+	private final RestClient restClient;
+
+	public PluginRequestForwarder() {
+		this(RestClient.builder().build());
+	}
+
+	public PluginRequestForwarder(RestClient restClient) {
+		this.restClient = restClient;
+	}
+
+	@Override
+	public ResponseEntity<byte[]> forward(PluginDefinition plugin, String subPath, HttpServletRequest request, String username, Collection<? extends GrantedAuthority> authorities) {
+
+		LOGGER.debug("Routing [{}] /plugins/{}{} → {}{}", request.getMethod(), plugin.id(), subPath, plugin.url(), subPath);
+
+		URI targetUri = PluginUriBuilder.build(plugin, subPath, request.getQueryString());
+
+		LOGGER.info("Forwarding request to plugin '{}' at {}", plugin.id(), targetUri);
+
+		HttpHeaders forwardHeaders = PluginHeadersBuilder.build(buildRequestHeaders(request), username, authorities);
+
+		HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+		LOGGER.debug("Proxying {} {} → {}", method, subPath, targetUri);
+
+		try (var inputStream = request.getInputStream()) {
+			RestClient.RequestBodySpec requestSpec = restClient.method(method).uri(targetUri).headers(h -> h.addAll(forwardHeaders));
+
+			String contentType = request.getContentType();
+
+			if (contentType != null && contentType.contains(MediaType.MULTIPART_FORM_DATA_VALUE)) {
+				MultipartHttpServletRequest multipartRequest = (MultipartHttpServletRequest) request;
+				MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+				var paramtersMap = getFormParametersOnly(multipartRequest);
+				paramtersMap.forEach((key, values) -> {
+					for (String value : values) {
+						body.add(key, value);
+					}
+				});
+
+				for (Map.Entry<String, MultipartFile> entry : multipartRequest.getFileMap().entrySet()) {
+					MultipartFile file = entry.getValue();
+					body.add(entry.getKey(), file.getResource());
+				}
+
+				requestSpec.body(body);
+			} else {
+
+				requestSpec.body(inputStream::transferTo);
+			}
+
+			return requestSpec.retrieve().onStatus(status -> true, (req, res) -> {
+				// Pass all statuses through — do not throw on 4xx/5xx from upstream.
+			}).toEntity(byte[].class);
+
+		} catch (RestClientResponseException ex) {
+			LOGGER.warn("Upstream plugin '{}' returned error {}: {}", plugin.id(), ex.getStatusCode(), ex.getMessage());
+			throw ex;
+		} catch (IOException ex) {
+			LOGGER.error("I/O error forwarding request to plugin '{}': {}", plugin.id(), ex.getMessage());
+			throw new RuntimeException("I/O error forwarding request to plugin", ex);
+		}
+	}
+
+	@Override
+	public Map<String, String[]> getFormParametersOnly(MultipartHttpServletRequest multipartRequest) {
+		Map<String, String[]> allParams = multipartRequest.getParameterMap();
+		if (allParams.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Set<String> queryKeys = new HashSet<>();
+		String query = multipartRequest.getQueryString();
+		if (query != null && !query.isEmpty()) {
+			String[] pairs = query.split("&");
+			for (String pair : pairs) {
+				int eqIndex = pair.indexOf('=');
+				String key = (eqIndex > 0) ? pair.substring(0, eqIndex) : pair;
+				key = URLDecoder.decode(key, StandardCharsets.UTF_8);
+				queryKeys.add(key);
+			}
+		}
+
+		Map<String, String[]> formOnly = new LinkedHashMap<>();
+		for (Map.Entry<String, String[]> entry : allParams.entrySet()) {
+			String key = entry.getKey();
+			if (!queryKeys.contains(key)) {
+				formOnly.put(key, entry.getValue());
+			}
+		}
+
+		return formOnly;
+	}
+
+	/**
+	 * Copies all headers from the {@link HttpServletRequest} into an {@link HttpHeaders} map.
+	 *
+	 * @param request the incoming servlet request
+	 * @return assembled {@link HttpHeaders}
+	 */
+	@Override
+	public HttpHeaders buildRequestHeaders(HttpServletRequest request) {
+		HttpHeaders headers = new HttpHeaders();
+		java.util.Enumeration<String> headerNames = request.getHeaderNames();
+		if (headerNames != null) {
+			while (headerNames.hasMoreElements()) {
+				String name = headerNames.nextElement();
+				java.util.Enumeration<String> values = request.getHeaders(name);
+				while (values.hasMoreElements()) {
+					headers.add(name, values.nextElement());
+				}
+			}
+		}
+		headers.set("Content-Length", null);
+		return headers;
+	}
+}

--- a/src/main/java/org/isf/plugins/proxy/PluginUriBuilder.java
+++ b/src/main/java/org/isf/plugins/proxy/PluginUriBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.proxy;
+
+import org.isf.plugins.config.PluginDefinition;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * Package-private helper responsible for assembling the target {@link URI} when
+ * forwarding a request to an upstream plugin.
+ *
+ * <p>Extracted from {@link PluginRequestForwarder} to satisfy the Single Responsibility
+ * Principle — URI construction is a distinct concern from HTTP dispatch.</p>
+ *
+ * @author Steve Tsala
+ */
+abstract class PluginUriBuilder {
+	/**
+	 * Builds the full target URI by joining the plugin base URL, sub-path, and optional
+	 * query string. Ensures no double slashes at the join point.
+	 *
+	 * @param plugin      plugin definition (provides base URL)
+	 * @param subPath     path after the plugin prefix; must start with {@code /} or be empty
+	 * @param queryString raw query string, may be {@code null} or empty
+	 * @return the resolved {@link URI}
+	 */
+	static URI build(PluginDefinition plugin, String subPath, String queryString) {
+		String base = plugin.url().endsWith("/")
+			? plugin.url().substring(0, plugin.url().length() - 1)
+			: plugin.url();
+
+		String path = StringUtils.hasText(subPath)
+			? (subPath.startsWith("/") ? subPath : "/" + subPath)
+			: "";
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(base + path);
+
+		if (StringUtils.hasText(queryString)) {
+			builder.query(queryString);
+		}
+
+		return builder.build(true).toUri();
+	}
+}

--- a/src/main/java/org/isf/plugins/registry/IPluginRegistry.java
+++ b/src/main/java/org/isf/plugins/registry/IPluginRegistry.java
@@ -1,0 +1,74 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.registry;
+
+import org.isf.plugins.config.PluginDefinition;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Runtime store of healthy plugin definitions.
+ *
+ * <p>Populated once at startup by {@link org.isf.plugins.health.IPluginHealthChecker}.
+ * After startup the registry is effectively immutable and safe for concurrent reads
+ * with no additional synchronization required during normal request processing.
+ *
+ * @author Steve Tsala
+ */
+public interface IPluginRegistry {
+
+	/**
+	 * Replaces the current registry contents with the supplied map.
+	 *
+	 * <p>Intended to be called exactly once at application startup after all plugin
+	 * health checks have completed. Subsequent calls replace the entire registry.
+	 *
+	 * @param definitions map of plugin ID → {@link PluginDefinition} for all healthy plugins;
+	 *                    must not be {@code null}
+	 */
+	void register(Map<String, PluginDefinition> definitions);
+
+	/**
+	 * Returns the plugin definition for the given ID, if it is registered and healthy.
+	 *
+	 * @param pluginId the unique plugin identifier (e.g. {@code "smart-doc"})
+	 * @return an {@link Optional} containing the definition, or empty if the plugin is
+	 * unknown or was excluded due to a failed health check
+	 */
+	Optional<PluginDefinition> find(String pluginId);
+
+	/**
+	 * Returns all currently registered plugin definitions.
+	 *
+	 * @return unmodifiable collection of all healthy plugin definitions; never {@code null}
+	 */
+	Collection<PluginDefinition> all();
+
+	/**
+	 * Returns the number of currently registered plugins.
+	 *
+	 * @return count of healthy registered plugins
+	 */
+	int size();
+}

--- a/src/main/java/org/isf/plugins/registry/PluginRegistry.java
+++ b/src/main/java/org/isf/plugins/registry/PluginRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.registry;
+
+import org.isf.plugins.config.PluginDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * @author Steve Tsala
+ */
+@Component
+public class PluginRegistry implements IPluginRegistry {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PluginRegistry.class);
+
+	/**
+	 * Insertion-ordered map of pluginId → definition for all healthy plugins.
+	 */
+	private Map<String, PluginDefinition> registry = Collections.emptyMap();
+
+	@Override
+	public void register(Map<String, PluginDefinition> definitions) {
+		this.registry = Collections.unmodifiableMap(new LinkedHashMap<>(definitions));
+		LOGGER.info("Plugin registry initialized with {} active plugin(s): {}", registry.size(), registry.keySet());
+	}
+
+	@Override
+	public Optional<PluginDefinition> find(String pluginId) {
+		return Optional.ofNullable(registry.get(pluginId));
+	}
+
+	@Override
+	public Collection<PluginDefinition> all() {
+		return registry.values();
+	}
+
+	@Override
+	public int size() {
+		return registry.size();
+	}
+}

--- a/src/main/java/org/isf/plugins/rest/PluginController.java
+++ b/src/main/java/org/isf/plugins/rest/PluginController.java
@@ -1,0 +1,179 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.isf.plugins.config.PluginDefinition;
+import org.isf.plugins.exception.PluginAccessDeniedException;
+import org.isf.plugins.exception.PluginNotFoundException;
+import org.isf.plugins.proxy.IPluginRequestForwarder;
+import org.isf.plugins.registry.IPluginRegistry;
+import org.isf.plugins.security.AuthenticationContext;
+import org.isf.plugins.security.IAuthenticationSupplier;
+import org.isf.plugins.security.IPluginAuthorizationChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Controller for all {@code /plugins} routes.
+ *
+ * @author Steve Tsala
+ */
+@RestController
+@RequestMapping("/plugins")
+@Tag(name = "Plugins", description = "Dynamic gateway to registered external plugin services")
+@SecurityRequirement(name = "bearerAuth")
+public class PluginController {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PluginController.class);
+
+	private final IPluginRegistry pluginRegistry;
+	private final IPluginAuthorizationChecker authorizationChecker;
+	private final IPluginRequestForwarder requestForwarder;
+	private final IAuthenticationSupplier authenticationSupplier;
+
+	public PluginController(IPluginRegistry pluginRegistry, IPluginAuthorizationChecker authorizationChecker, IPluginRequestForwarder requestForwarder, IAuthenticationSupplier authenticationSupplier) {
+		this.pluginRegistry = pluginRegistry;
+		this.authorizationChecker = authorizationChecker;
+		this.requestForwarder = requestForwarder;
+		this.authenticationSupplier = authenticationSupplier;
+	}
+
+	/**
+	 * Reads the raw request body, bypassing any servlet wrapper layers.
+	 *
+	 * <p>Spring's multipart support wraps the original request in a
+	 * {@link jakarta.servlet.http.HttpServletRequestWrapper} (specifically
+	 * {@code StandardMultipartHttpServletRequest}) that may replace the
+	 * {@code InputStream} with a parsed view of the parts. Unwrapping to the
+	 * underlying container request guarantees that the raw bytes — including the
+	 * multipart boundary — are read unmodified, so they can be forwarded verbatim
+	 * to the upstream plugin together with the original {@code Content-Type} header.
+	 *
+	 * @param request the incoming servlet request (possibly wrapped)
+	 * @return the raw request body bytes; empty array if the body is absent
+	 * @throws IOException if reading the stream fails
+	 */
+	private static byte[] readRawBody(HttpServletRequest request) throws IOException {
+		HttpServletRequest target = request;
+		while (target instanceof HttpServletRequestWrapper wrapper) {
+			target = (HttpServletRequest) wrapper.getRequest();
+		}
+		return target.getInputStream().readAllBytes();
+	}
+
+	/**
+	 * Returns the full list of plugins that are registered and healthy.
+	 * Any authenticated user may call this endpoint.
+	 *
+	 * @return {@code 200 OK} with a JSON array of {@link PluginDefinition}
+	 */
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	@Operation(summary = "List all registered plugins",
+		description = "Returns all plugins that passed the startup health check and are currently available through the gateway.")
+	@ApiResponse(responseCode = "200", description = "Plugin list returned successfully")
+	public Collection<PluginDefinition> listPlugins() {
+		return pluginRegistry.all();
+	}
+
+	/**
+	 * Catch-all handler for every HTTP method under {@code /plugins/{id}/**}.
+	 *
+	 * @param request the original {@link HttpServletRequest}
+	 * @return the upstream plugin's response, forwarded transparently
+	 * @throws IOException if reading the request body fails
+	 */
+	@RequestMapping(value = "/{id}/{*path}")
+	@Operation(summary = "Proxy a request to an external plugin",
+		description = "Resolves the plugin by ID, checks authorization, then forwards the request " +
+			"to the plugin's upstream URL. The sub-path after /plugins/{pluginId} is appended to the " +
+			"plugin base URL. All HTTP methods are supported.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Upstream response forwarded successfully"),
+		@ApiResponse(responseCode = "403", description = "Authenticated user lacks required privileges for this plugin"),
+		@ApiResponse(responseCode = "404", description = "Plugin not found or unavailable"),
+		@ApiResponse(responseCode = "502", description = "Upstream plugin returned an unexpected error")
+	})
+	public ResponseEntity<byte[]> proxy(
+		@Parameter(hidden = true) HttpServletRequest request,
+		@PathVariable(required = false) String id,
+		@PathVariable(required = false) String path) throws IOException {
+
+		PluginDefinition plugin = pluginRegistry.find(id).orElseThrow(() -> new PluginNotFoundException(id));
+
+		// Extract sub-path (everything after /plugins/{id}).
+		// Spring's {*path} catch-all may or may not include a leading slash depending on
+		// the container version, so normalise defensively.
+		String rawPath = path != null ? path : "";
+		String subPath = rawPath.startsWith("/") ? rawPath : "/" + rawPath;
+
+		authorizationChecker.assertAccess(plugin, subPath, request.getMethod());
+
+		AuthenticationContext authContext = authenticationSupplier.get();
+
+		return requestForwarder.forward(plugin, subPath, request, authContext.authentication().getName(), authContext.authentication().getAuthorities());
+	}
+
+	@ExceptionHandler(PluginNotFoundException.class)
+	public ResponseEntity<PluginErrorResponse> handlePluginNotFound(PluginNotFoundException ex) {
+		LOGGER.warn("Plugin not found: {}", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON).body(new PluginErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(PluginAccessDeniedException.class)
+	public ResponseEntity<PluginErrorResponse> handleAccessDenied(PluginAccessDeniedException ex) {
+		LOGGER.warn("Plugin access denied: {}", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).contentType(MediaType.APPLICATION_JSON).body(new PluginErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(RestClientResponseException.class)
+	public ResponseEntity<byte[]> handleUpstreamError(RestClientResponseException ex) {
+		LOGGER.warn("Upstream plugin error: HTTP {} — {}", ex.getStatusCode(), ex.getMessage());
+		return ResponseEntity.status(ex.getStatusCode()).headers(ex.getResponseHeaders()).body(ex.getResponseBodyAsByteArray());
+	}
+
+	// -------------------------------------------------------------------------
+	// Nested error response DTO
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Minimal error payload returned by the plugin gateway for {@code 404} and {@code 403}
+	 * responses. Kept as a nested class since it is exclusive to this controller.
+	 */
+	public record PluginErrorResponse(int status, String message) {
+	}
+}

--- a/src/main/java/org/isf/plugins/security/AuthenticationContext.java
+++ b/src/main/java/org/isf/plugins/security/AuthenticationContext.java
@@ -1,0 +1,42 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Value object that bundles the current {@link Authentication} with the resolved
+ * user-group role (i.e. {@code UserGroup.getCode()}) of the authenticated user.
+ *
+ * <p>The role is resolved by looking up the full {@code User} entity via
+ * {@code UserBrowsingManager.getUserByName(username)} and reading
+ * {@code user.getUserGroupName().getCode()}. If resolution fails (e.g. due to a
+ * database error), {@code role} is set to {@code null} and access is denied by
+ * the authorization checker.</p>
+ *
+ * @param authentication the current Spring Security {@link Authentication} object
+ * @param role           the user-group code for the authenticated user, or {@code null}
+ *                       if the role could not be resolved
+ * @author Steve Tsala
+ */
+public record AuthenticationContext(Authentication authentication, String role) {
+}

--- a/src/main/java/org/isf/plugins/security/IAuthenticationSupplier.java
+++ b/src/main/java/org/isf/plugins/security/IAuthenticationSupplier.java
@@ -1,0 +1,62 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+/**
+ * Functional interface that resolves the current authentication context — both the
+ * raw {@link org.springframework.security.core.Authentication} and the user's resolved
+ * role (user-group code) — for the incoming request.
+ *
+ * <p>The returned {@link AuthenticationContext} bundles:</p>
+ * <ul>
+ *   <li>the Spring Security {@link org.springframework.security.core.Authentication} object
+ *       (used for username, authorities, and authenticated flag), and</li>
+ *   <li>the user-group {@code role} string resolved by looking up the full {@code User}
+ *       entity via {@code UserBrowsingManager.getUserByName(username)} and reading
+ *       {@code user.getUserGroupName().getCode()}.</li>
+ * </ul>
+ *
+ * <p>If role resolution fails (e.g. database error) the {@code role} field is {@code null}.
+ * The authorization checker treats a {@code null} role as an unknown group and denies
+ * access.</p>
+ *
+ * <p>Abstracting this behind an interface allows controller and service classes to avoid
+ * static calls to {@code SecurityContextHolder}, making them fully testable without
+ * requiring a real security context or database.</p>
+ *
+ * <p>The default Spring bean is registered in {@link PluginSecurityConfig}.</p>
+ *
+ * @author Steve Tsala
+ */
+@FunctionalInterface
+public interface IAuthenticationSupplier {
+
+	/**
+	 * Returns the current {@link AuthenticationContext} for the active request.
+	 *
+	 * @return the authentication context (authentication + role); never {@code null},
+	 *         but {@link AuthenticationContext#authentication()} may be {@code null}
+	 *         if no principal is present, and {@link AuthenticationContext#role()} may
+	 *         be {@code null} if role resolution failed
+	 */
+	AuthenticationContext get();
+}

--- a/src/main/java/org/isf/plugins/security/IPluginAuthorizationChecker.java
+++ b/src/main/java/org/isf/plugins/security/IPluginAuthorizationChecker.java
@@ -1,0 +1,86 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+import org.isf.plugins.config.PluginDefinition;
+import org.isf.plugins.config.PluginPermission;
+import org.isf.plugins.config.PluginRoute;
+
+/**
+ * Enforces plugin-level access control using a <em>restrictive</em> policy:
+ * any route not explicitly declared in the plugin's configuration is blocked.
+ *
+ * <h3>Authorization model</h3>
+ * Each plugin declares a {@code configuration.permissions} list. Every entry binds
+ * a user-group role (matched against {@code UserGroup.getCode()}) to a set of
+ * {@link org.isf.plugins.config.PluginRoute} objects, each specifying a path prefix
+ * and a list of allowed HTTP methods.
+ *
+ * <p>Access is granted when <strong>all</strong> of the following hold:</p>
+ * <ol>
+ *   <li>The authenticated user's group code equals {@code permission.role()} for at
+ *       least one entry in the permissions list.</li>
+ *   <li>Within that matching entry, at least one route whose {@code path} is a
+ *       <em>prefix</em> of the incoming sub-path also includes the request's HTTP
+ *       method in its {@code methods} list.</li>
+ * </ol>
+ *
+ * <p>If the plugin has no {@code configuration} or an empty {@code permissions}
+ * list, access is denied for <em>all</em> users.</p>
+ *
+ * <h3>Path matching</h3>
+ * Matching is a simple prefix check: a configured path of {@code /documents} matches
+ * {@code /documents}, {@code /documents/123}, {@code /documents/123/attachments}, etc.
+ *
+ * <h3>Integration</h3>
+ * The check runs entirely within the controller layer, after the {@code JWTFilter} has
+ * already validated the token and populated the security context. No changes to
+ * {@link org.isf.config.SecurityConfig} are required.
+ *
+ * @author Steve Tsala
+ */
+public interface IPluginAuthorizationChecker {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>Enforcement algorithm (restrictive — deny by default):</p>
+	 * <ol>
+	 *   <li>Verify a valid, authenticated principal exists.</li>
+	 *   <li>If the plugin has no {@code configuration} or empty {@code permissions}
+	 *       → deny.</li>
+	 *   <li>Find all {@link PluginPermission} entries whose {@code role} matches the
+	 *       user's group code (case-sensitive).</li>
+	 *   <li>Within those entries, look for any {@link PluginRoute} where:
+	 *       <ul>
+	 *         <li>{@code requestPath} starts with {@code route.path()} (prefix match), and</li>
+	 *         <li>{@code httpMethod} is contained in {@code route.methods()}
+	 *             (case-insensitive).</li>
+	 *       </ul></li>
+	 *   <li>If no matching route is found → deny.</li>
+	 * </ol>
+	 *
+	 * @throws IllegalStateException if there is no authenticated principal in the
+	 *                               security context
+	 */
+	void assertAccess(PluginDefinition plugin, String requestPath, String httpMethod);
+}

--- a/src/main/java/org/isf/plugins/security/PluginAuthorizationChecker.java
+++ b/src/main/java/org/isf/plugins/security/PluginAuthorizationChecker.java
@@ -1,0 +1,113 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+import org.isf.plugins.config.PluginConfiguration;
+import org.isf.plugins.config.PluginDefinition;
+import org.isf.plugins.config.PluginPermission;
+import org.isf.plugins.config.PluginRoute;
+import org.isf.plugins.exception.PluginAccessDeniedException;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * @author Steve Tsala
+ */
+@Component
+public class PluginAuthorizationChecker implements IPluginAuthorizationChecker {
+
+	private final IAuthenticationSupplier authenticationSupplier;
+
+	public PluginAuthorizationChecker(IAuthenticationSupplier authenticationSupplier) {
+		this.authenticationSupplier = authenticationSupplier;
+	}
+
+	@Override
+	public void assertAccess(PluginDefinition plugin, String requestPath, String httpMethod) {
+		AuthenticationContext ctx = authenticationSupplier.get();
+		Authentication authentication = ctx.authentication();
+
+		List<PluginPermission> permissions = getPluginPermissions(plugin, authentication);
+
+		String userRole = ctx.role();
+
+		boolean hasAccess = permissions.stream()
+			.filter(p -> p.role() != null && p.role().equals(userRole))
+			.flatMap(p -> p.routes() == null ? java.util.stream.Stream.empty() : p.routes().stream())
+			.anyMatch(route -> pathMatches(route, requestPath) && methodMatches(route, httpMethod));
+
+		if (!hasAccess) {
+			throw new PluginAccessDeniedException(plugin.id(), authentication.getName());
+		}
+	}
+
+	private static @NonNull List<PluginPermission> getPluginPermissions(PluginDefinition plugin, Authentication authentication) {
+		if (authentication == null || !authentication.isAuthenticated()) {
+			throw new IllegalStateException("No authenticated principal found in SecurityContext");
+		}
+
+		PluginConfiguration configuration = plugin.configuration();
+
+		// Restrictive default: no configuration or empty permissions → deny everyone.
+		if (configuration == null) {
+			throw new PluginAccessDeniedException(plugin.id(), authentication.getName());
+		}
+
+		List<PluginPermission> permissions = configuration.permissions();
+		if (permissions == null || permissions.isEmpty()) {
+			throw new PluginAccessDeniedException(plugin.id(), authentication.getName());
+		}
+		return permissions;
+	}
+
+	/**
+	 * Returns {@code true} if {@code requestPath} starts with {@code route.path()},
+	 * implementing prefix-based path matching.
+	 *
+	 * <p>Examples:</p>
+	 * <ul>
+	 *   <li>{@code route.path() = "/documents"}, {@code requestPath = "/documents"} → {@code true}</li>
+	 *   <li>{@code route.path() = "/documents"}, {@code requestPath = "/documents/123"} → {@code true}</li>
+	 *   <li>{@code route.path() = "/documents"}, {@code requestPath = "/other"} → {@code false}</li>
+	 * </ul>
+	 */
+	private static boolean pathMatches(PluginRoute route, String requestPath) {
+		if (route.path() == null || requestPath == null) {
+			return false;
+		}
+		return requestPath.equals(route.path()) || requestPath.startsWith(route.path() + "/");
+	}
+
+	/**
+	 * Returns {@code true} if the route's {@code methods} list contains
+	 * {@code httpMethod} (case-insensitive).
+	 */
+	private static boolean methodMatches(PluginRoute route, String httpMethod) {
+		if (route.methods() == null || httpMethod == null) {
+			return false;
+		}
+		return route.methods().stream().anyMatch(m -> m.equalsIgnoreCase(httpMethod));
+	}
+}

--- a/src/main/java/org/isf/plugins/security/PluginSecurityConfig.java
+++ b/src/main/java/org/isf/plugins/security/PluginSecurityConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+import org.isf.menu.manager.UserBrowsingManager;
+import org.isf.menu.model.User;
+import org.isf.utils.exception.OHServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Registers security-related beans used by the plugin subsystem.
+ *
+ * @author Steve Tsala
+ */
+@Configuration
+public class PluginSecurityConfig {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PluginSecurityConfig.class);
+
+	/**
+	 * Provides the {@link IAuthenticationSupplier} bean that resolves the current
+	 * {@link AuthenticationContext} for each incoming request.
+	 *
+	 * <p>The role is resolved by calling
+	 * {@link UserBrowsingManager#getUserByName(String)} with the authenticated
+	 * username and reading {@code user.getUserGroupName().getCode()}. If resolution
+	 * fails (e.g. database error or unknown user) a warning is logged and
+	 * {@code role} is set to {@code null}, which will cause the authorization
+	 * checker to deny access.</p>
+	 *
+	 * @param userBrowsingManager the manager used to look up the full {@link User} entity
+	 * @return the {@link IAuthenticationSupplier} bean
+	 */
+	@Bean
+	public IAuthenticationSupplier authenticationSupplier(UserBrowsingManager userBrowsingManager) {
+		return () -> {
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			if (authentication == null || !authentication.isAuthenticated()) {
+				return new AuthenticationContext(authentication, null);
+			}
+			String role = resolveRole(authentication.getName(), userBrowsingManager);
+			return new AuthenticationContext(authentication, role);
+		};
+	}
+
+	private static String resolveRole(String username, UserBrowsingManager userBrowsingManager) {
+		try {
+			User user = userBrowsingManager.getUserByName(username);
+			if (user == null || user.getUserGroupName() == null) {
+				LOGGER.warn("Plugin auth: no user or group found for username '{}'", username);
+				return null;
+			}
+			return user.getUserGroupName().getCode();
+		} catch (OHServiceException e) {
+			LOGGER.warn("Plugin auth: failed to resolve role for username '{}': {}", username, e.getMessage());
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/isf/plugins/proxy/PluginRequestForwarderTest.java
+++ b/src/test/java/org/isf/plugins/proxy/PluginRequestForwarderTest.java
@@ -1,0 +1,313 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.proxy;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.isf.plugins.config.PluginDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.RequestBodySpec;
+import org.springframework.web.client.RestClient.RequestBodyUriSpec;
+import org.springframework.web.client.RestClient.ResponseSpec;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PluginRequestForwarderTest {
+
+	private static final PluginDefinition PLUGIN = new PluginDefinition("smart-doc", "http://localhost:4000/api", "/health", null);
+	@Mock
+	private RestClient mockRestClient;
+	@Mock
+	private RequestBodyUriSpec uriSpec;
+	@Mock
+	private RequestBodySpec requestBodySpec;
+	@Mock
+	private ResponseSpec responseSpec;
+	private PluginRequestForwarder forwarder;
+
+	@BeforeEach
+	void setUp() {
+		forwarder = new PluginRequestForwarder(mockRestClient);
+
+		lenient().when(mockRestClient.method(any(HttpMethod.class))).thenReturn(uriSpec);
+		lenient().when(uriSpec.uri(any(URI.class))).thenReturn(requestBodySpec);
+		lenient().when(requestBodySpec.headers(any())).thenReturn(requestBodySpec);
+		lenient().when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+		lenient().when(responseSpec.onStatus(any(Predicate.class), any())).thenReturn(responseSpec);
+	}
+
+	private HttpServletRequest mockRequest(HttpMethod method, HttpHeaders headers, byte[] body) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		if (method != null) {
+			request.setMethod(method.name());
+		}
+		request.setQueryString(null);
+		request.setContent(body);
+		headers.forEach(request::addHeader);
+		return request;
+	}
+
+	@Test
+	@DisplayName("Should return upstream response for a GET request")
+	void shouldReturnUpstreamResponseForGetRequest() {
+		ResponseEntity<byte[]> upstreamResponse = ResponseEntity.ok("hello".getBytes());
+		when(responseSpec.toEntity(eq(byte[].class))).thenReturn(upstreamResponse);
+
+		ResponseEntity<byte[]> result = forwarder.forward(PLUGIN, "/documents/1", mockRequest(HttpMethod.GET, new HttpHeaders(), null), "alice", List.of(new SimpleGrantedAuthority("smart-doc.read")));
+
+		assertThat(result.getStatusCode().value()).isEqualTo(200);
+		assertThat(result.getBody()).isEqualTo("hello".getBytes());
+	}
+
+	@Test
+	@DisplayName("Should return upstream response for a POST request with body")
+	void shouldReturnUpstreamResponseForPostRequestWithBody() {
+		ResponseEntity<byte[]> upstreamResponse = ResponseEntity.status(201).body(new byte[0]);
+		when(requestBodySpec.body(any())).thenReturn(requestBodySpec);
+		when(responseSpec.toEntity(eq(byte[].class))).thenReturn(upstreamResponse);
+
+		byte[] requestBody = "{\"name\":\"doc\"}".getBytes();
+		ResponseEntity<byte[]> result = forwarder.forward(PLUGIN, "/documents", mockRequest(HttpMethod.POST, new HttpHeaders(), requestBody), "alice", List.of());
+
+		assertThat(result.getStatusCode().value()).isEqualTo(201);
+	}
+
+	@Test
+	@DisplayName("Should add X-User header with authenticated username")
+	void shouldSetXUserHeaderWithAuthenticatedUsername() {
+		// Capture the headers consumer argument to verify identity headers are added
+		HttpHeaders[] capturedHeaders = new HttpHeaders[1];
+		when(requestBodySpec.headers(any())).thenAnswer(inv -> {
+			Consumer<HttpHeaders> consumer = inv.getArgument(0);
+			HttpHeaders h = new HttpHeaders();
+			consumer.accept(h);
+			capturedHeaders[0] = h;
+			return requestBodySpec;
+		});
+
+		ResponseEntity<byte[]> upstreamResponse = ResponseEntity.ok(new byte[0]);
+		when(responseSpec.toEntity(eq(byte[].class))).thenReturn(upstreamResponse);
+
+		forwarder.forward(PLUGIN, "/path", mockRequest(HttpMethod.GET, new HttpHeaders(), null), "bob", List.of(new SimpleGrantedAuthority("smart-doc.read")));
+
+		assertThat(capturedHeaders[0]).isNotNull();
+		assertThat(capturedHeaders[0].getFirst(PluginRequestForwarder.HEADER_X_USER)).isEqualTo("bob");
+	}
+
+	@Test
+	@DisplayName("Should set X-Permissions header as comma-separated list of authorities")
+	void shouldSetXPermissionsHeaderAsCommaSeparatedList() {
+		HttpHeaders[] capturedHeaders = new HttpHeaders[1];
+		when(requestBodySpec.headers(any())).thenAnswer(inv -> {
+			Consumer<HttpHeaders> consumer = inv.getArgument(0);
+			HttpHeaders h = new HttpHeaders();
+			consumer.accept(h);
+			capturedHeaders[0] = h;
+			return requestBodySpec;
+		});
+
+		ResponseEntity<byte[]> upstreamResponse = ResponseEntity.ok(new byte[0]);
+		when(responseSpec.toEntity(eq(byte[].class))).thenReturn(upstreamResponse);
+
+		forwarder.forward(PLUGIN, "/path", mockRequest(HttpMethod.GET, new HttpHeaders(), null), "alice", List.of(new SimpleGrantedAuthority("smart-doc.read"), new SimpleGrantedAuthority("smart-doc.write")));
+
+		String permHeader = capturedHeaders[0].getFirst(PluginRequestForwarder.HEADER_X_PERMISSIONS);
+		assertThat(permHeader).contains("smart-doc.read", "smart-doc.write");
+	}
+
+	@Test
+	@DisplayName("Should strip Host header from forwarded request")
+	void shouldStripHostHeaderFromForwardedRequest() {
+		HttpHeaders[] capturedHeaders = new HttpHeaders[1];
+		when(requestBodySpec.headers(any())).thenAnswer(inv -> {
+			Consumer<HttpHeaders> consumer = inv.getArgument(0);
+			HttpHeaders h = new HttpHeaders();
+			consumer.accept(h);
+			capturedHeaders[0] = h;
+			return requestBodySpec;
+		});
+
+		ResponseEntity<byte[]> upstreamResponse = ResponseEntity.ok(new byte[0]);
+		when(responseSpec.toEntity(eq(byte[].class))).thenReturn(upstreamResponse);
+
+		HttpHeaders incoming = new HttpHeaders();
+		incoming.add(HttpHeaders.HOST, "api.example.com");
+		incoming.add("X-Custom", "value");
+
+		forwarder.forward(PLUGIN, "/path", mockRequest(HttpMethod.GET, incoming, null), "alice", List.of());
+
+		assertThat(capturedHeaders[0].containsKey(HttpHeaders.HOST)).isFalse();
+		assertThat(capturedHeaders[0].getFirst("X-Custom")).isEqualTo("value");
+	}
+
+	// -------------------------------------------------------------------------
+	// buildRequestHeaders
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("buildRequestHeaders copies all request headers into HttpHeaders")
+	void buildRequestHeadersCopiesAllHeaders() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Custom", "value");
+		request.addHeader("Accept", "application/json");
+
+		HttpHeaders result = forwarder.buildRequestHeaders(request);
+
+		assertThat(result.getFirst("X-Custom")).isEqualTo("value");
+		assertThat(result.getFirst("Accept")).isEqualTo("application/json");
+	}
+
+	@Test
+	@DisplayName("buildRequestHeaders copies multiple values for the same header name")
+	void buildRequestHeadersCopiesMultiValueHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Accept", "application/json");
+		request.addHeader("Accept", "text/plain");
+
+		HttpHeaders result = forwarder.buildRequestHeaders(request);
+
+		assertThat(result.get("Accept")).containsExactlyInAnyOrder("application/json", "text/plain");
+	}
+
+	@Test
+	@DisplayName("buildRequestHeaders returns headers without Content-Length")
+	void buildRequestHeadersStripsContentLength() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(HttpHeaders.CONTENT_LENGTH, "42");
+		request.addHeader("X-Custom", "keep-me");
+
+		HttpHeaders result = forwarder.buildRequestHeaders(request);
+
+		// Content-Length is set to null (removed) so the upstream can determine its own length
+		assertThat(result.getContentLength()).isEqualTo(-1);
+		assertThat(result.getFirst("X-Custom")).isEqualTo("keep-me");
+	}
+
+	@Test
+	@DisplayName("buildRequestHeaders returns empty HttpHeaders when request has no headers")
+	void buildRequestHeadersReturnsEmptyWhenNoHeaders() {
+		// MockHttpServletRequest with no headers added still injects some defaults;
+		// the important assertion is that buildRequestHeaders never throws and always
+		// returns a non-null object.
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		HttpHeaders result = forwarder.buildRequestHeaders(request);
+
+		assertThat(result).isNotNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// getFormParametersOnly
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("getFormParametersOnly returns all params when there is no query string")
+	void getFormParametersOnlyReturnsAllParamsWithNoQueryString() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.addParameter("title", "hello");
+		request.addParameter("type", "RX");
+		// no query string → all parameters are form parameters
+
+		Map<String, String[]> result = forwarder.getFormParametersOnly(request);
+
+		assertThat(result).containsKey("title");
+		assertThat(result).containsKey("type");
+		assertThat(result.get("title")).containsExactly("hello");
+		assertThat(result.get("type")).containsExactly("RX");
+	}
+
+	@Test
+	@DisplayName("getFormParametersOnly excludes params that appear in the query string")
+	void getFormParametersOnlyExcludesQueryParams() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.setQueryString("type=RX");
+		request.addParameter("type", "RX");   // duplicated from query string — must be excluded
+		request.addParameter("title", "hello"); // form-only — must be kept
+
+		Map<String, String[]> result = forwarder.getFormParametersOnly(request);
+
+		assertThat(result).containsKey("title");
+		assertThat(result).doesNotContainKey("type");
+	}
+
+	@Test
+	@DisplayName("getFormParametersOnly returns empty map when parameter map is empty")
+	void getFormParametersOnlyReturnsEmptyMapWhenNoParams() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+
+		Map<String, String[]> result = forwarder.getFormParametersOnly(request);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("getFormParametersOnly handles URL-encoded keys in query string")
+	void getFormParametersOnlyHandlesUrlEncodedQueryKeys() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		// "my param" URL-encoded as "my+param" or "my%20param" — the key must be decoded
+		request.setQueryString("my%20param=value");
+		request.addParameter("my param", "value"); // decoded key in parameterMap
+		request.addParameter("other", "keep");
+
+		Map<String, String[]> result = forwarder.getFormParametersOnly(request);
+
+		assertThat(result).doesNotContainKey("my param");
+		assertThat(result).containsKey("other");
+	}
+
+	@Test
+	@DisplayName("getFormParametersOnly keeps form params whose key differs from every query key")
+	void getFormParametersOnlyKeepsUnrelatedFormParams() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.setQueryString("page=1&size=10");
+		request.addParameter("page", "1");    // query param — excluded
+		request.addParameter("size", "10");   // query param — excluded
+		request.addParameter("notes", "abc"); // form-only — kept
+		request.addParameter("tag", "x");     // form-only — kept
+
+		Map<String, String[]> result = forwarder.getFormParametersOnly(request);
+
+		assertThat(result).containsOnlyKeys("notes", "tag");
+	}
+}

--- a/src/test/java/org/isf/plugins/registry/PluginRegistryTest.java
+++ b/src/test/java/org/isf/plugins/registry/PluginRegistryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.registry;
+
+import org.isf.OpenHospitalApiApplication;
+import org.isf.plugins.config.PluginDefinition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = OpenHospitalApiApplication.class)
+class PluginRegistryTest {
+
+	private static final PluginDefinition SMART_DOC = new PluginDefinition(
+		"smart-doc", "http://localhost:4000/api", "/health", null);
+	private static final PluginDefinition REPORTS = new PluginDefinition(
+		"reports", "http://localhost:5000", "/ping", null);
+
+	@Autowired
+	private IPluginRegistry registry;
+
+	@Test
+	@DisplayName("Should register a single plugin and find it by ID")
+	void shouldFindPluginAfterRegisteringIt() {
+		registry.register(Map.of("smart-doc", SMART_DOC));
+
+		assertThat(registry.size()).isEqualTo(1);
+		Optional<PluginDefinition> found = registry.find("smart-doc");
+		assertThat(found).isPresent();
+		assertThat(found.get().id()).isEqualTo("smart-doc");
+		assertThat(found.get().url()).isEqualTo("http://localhost:4000/api");
+	}
+
+	@Test
+	@DisplayName("Should register multiple plugins and find them by ID")
+	void shouldFindAllPluginsAfterRegisteringMultiple() {
+		registry.register(Map.of("smart-doc", SMART_DOC, "reports", REPORTS));
+
+		assertThat(registry.size()).isEqualTo(2);
+		assertThat(registry.find("smart-doc")).isPresent();
+		assertThat(registry.find("reports")).isPresent();
+	}
+
+	@Test
+	@DisplayName("Finding an unknown plugin ID should return empty")
+	void shouldReturnEmptyWhenPluginNotFound() {
+		registry.register(Map.of("smart-doc", SMART_DOC));
+
+		assertThat(registry.find("no-such-plugin")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Should return all registered plugin definitions")
+	void shouldReturnAllRegisteredDefinitions() {
+		registry.register(Map.of("smart-doc", SMART_DOC, "reports", REPORTS));
+
+		assertThat(registry.all())
+			.hasSize(2)
+			.containsExactlyInAnyOrder(SMART_DOC, REPORTS);
+	}
+
+	@Test
+	@DisplayName("Should register a new set of plugins and replace the old contents")
+	void shouldReplaceContentsOnSecondRegisterCall() {
+		registry.register(Map.of("smart-doc", SMART_DOC));
+		assertThat(registry.size()).isEqualTo(1);
+
+		registry.register(Map.of("reports", REPORTS));
+		assertThat(registry.size()).isEqualTo(1);
+		assertThat(registry.find("smart-doc")).isEmpty();
+		assertThat(registry.find("reports")).isPresent();
+	}
+
+	@Test
+	@DisplayName("Should register an empty map and clear the registry")
+	void shouldClearRegistryWhenRegisteredWithEmptyMap() {
+		registry.register(Map.of("smart-doc", SMART_DOC));
+		registry.register(Map.of());
+
+		assertThat(registry.size()).isZero();
+		assertThat(registry.all()).isEmpty();
+	}
+}

--- a/src/test/java/org/isf/plugins/rest/PluginControllerTest.java
+++ b/src/test/java/org/isf/plugins/rest/PluginControllerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.rest;
+
+import org.isf.OpenHospitalApiApplication;
+import org.isf.plugins.config.*;
+import org.isf.plugins.exception.PluginAccessDeniedException;
+import org.isf.plugins.proxy.IPluginRequestForwarder;
+import org.isf.plugins.registry.IPluginRegistry;
+import org.isf.plugins.security.AuthenticationContext;
+import org.isf.plugins.security.IAuthenticationSupplier;
+import org.isf.plugins.security.IPluginAuthorizationChecker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = OpenHospitalApiApplication.class)
+class PluginControllerTest {
+
+
+	private static final PluginBundle PLUGIN_BUNDLE = new PluginBundle("Smart Doc", "mf-manifest.json", "module", PluginLocation.MAIN, "assets/styles.css");
+
+	/**
+	 * A plugin definition with admin-only GET/POST/DELETE on /documents.
+	 */
+	private static final PluginDefinition SMART_DOC = new PluginDefinition("smart-doc", "http://localhost:4000/api", "/health", new PluginConfiguration(PLUGIN_BUNDLE, List.of(new PluginPermission("admin", List.of(new PluginRoute("/documents", List.of("GET", "POST", "DELETE")))))));
+
+	@MockitoBean
+	private IPluginRegistry pluginRegistry;
+	@MockitoBean
+	private IPluginAuthorizationChecker authorizationChecker;
+	@MockitoBean
+	private IPluginRequestForwarder requestForwarder;
+	@MockitoBean
+	private IAuthenticationSupplier authenticationSupplier;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void stubAuthenticationSupplier() {
+		// Delegate to SecurityContextHolder so @WithMockUser authentication is returned
+		// when the controller calls authenticationSupplier.get() during request processing.
+		lenient().when(authenticationSupplier.get()).thenAnswer(inv -> new AuthenticationContext(SecurityContextHolder.getContext().getAuthentication(), "admin"));
+	}
+
+	// -------------------------------------------------------------------------
+	// GET /plugins — list registered plugins
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser
+	@DisplayName("GET /plugins returns the list of registered plugins")
+	void shouldReturnListOfRegisteredPlugins() throws Exception {
+		PluginDefinition billing = new PluginDefinition("billing", "http://localhost:5000/api", "/health", null);
+		when(pluginRegistry.all()).thenReturn(List.of(SMART_DOC, billing));
+
+		mockMvc.perform(get("/plugins")).andExpect(status().isOk()).andExpect(jsonPath("$.length()").value(2)).andExpect(jsonPath("$[0].id").value("smart-doc")).andExpect(jsonPath("$[1].id").value("billing"));
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("GET /plugins returns empty array when no plugins are registered")
+	void shouldReturnEmptyArrayWhenNoPluginsRegistered() throws Exception {
+		when(pluginRegistry.all()).thenReturn(List.of());
+
+		mockMvc.perform(get("/plugins")).andExpect(status().isOk()).andExpect(jsonPath("$.length()").value(0));
+	}
+
+	// -------------------------------------------------------------------------
+	// ANY /plugins/{id}/** — proxy handler
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should return upstream response for a proxied GET request")
+	void shouldReturnUpstreamResponseForProxiedGetRequest() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doNothing().when(authorizationChecker).assertAccess(any(), any(), any());
+		when(requestForwarder.forward(any(), any(), any(), any(), any())).thenReturn(ResponseEntity.ok("upstream-body".getBytes()));
+
+		MvcResult result = mockMvc.perform(get("/plugins/smart-doc/documents/42")).andExpect(status().isOk()).andReturn();
+
+		assertThat(result.getResponse().getContentAsString()).isEqualTo("upstream-body");
+	}
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should forward body and return 201 for a proxied POST request")
+	void shouldForwardBodyAndReturn201ForProxiedPostRequest() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doNothing().when(authorizationChecker).assertAccess(any(), any(), any());
+		when(requestForwarder.forward(any(), any(), any(), any(), any())).thenReturn(ResponseEntity.status(HttpStatus.CREATED).body(new byte[0]));
+
+		mockMvc.perform(post("/plugins/smart-doc/documents").contentType(MediaType.APPLICATION_JSON).content("{\"title\":\"test\"}")).andExpect(status().isCreated());
+	}
+
+	// -------------------------------------------------------------------------
+	// Verify assertAccess is called with the correct path and method
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should call assertAccess with the sub-path and HTTP method")
+	void shouldCallAssertAccessWithSubPathAndMethod() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doNothing().when(authorizationChecker).assertAccess(any(), any(), any());
+		when(requestForwarder.forward(any(), any(), any(), any(), any())).thenReturn(ResponseEntity.ok(new byte[0]));
+
+		mockMvc.perform(get("/plugins/smart-doc/documents/123"));
+
+		verify(authorizationChecker).assertAccess(SMART_DOC, "/documents/123", "GET");
+	}
+
+	// -------------------------------------------------------------------------
+	// 404 — plugin not found
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should return 404 when the plugin is not found")
+	void shouldReturn404WhenPluginNotFound() throws Exception {
+		when(pluginRegistry.find("unknown")).thenReturn(Optional.empty());
+
+		mockMvc.perform(get("/plugins/unknown/path")).andExpect(status().isNotFound()).andExpect(jsonPath("$.status").value(404)).andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("unknown")));
+	}
+
+	// -------------------------------------------------------------------------
+	// 403 — access denied
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should return 403 when access is denied")
+	void shouldReturn403WhenAccessIsDenied() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doThrow(new PluginAccessDeniedException("smart-doc", "alice")).when(authorizationChecker).assertAccess(any(), any(), any());
+
+		mockMvc.perform(get("/plugins/smart-doc/documents")).andExpect(status().isForbidden()).andExpect(jsonPath("$.status").value(403)).andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("alice")));
+	}
+
+	// -------------------------------------------------------------------------
+	// Upstream error passthrough
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should pass through 502 from upstream service")
+	void shouldPassThrough502FromUpstream() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doNothing().when(authorizationChecker).assertAccess(any(), any(), any());
+
+		RestClientResponseException upstream = new RestClientResponseException("Bad Gateway", 502, "Bad Gateway", new org.springframework.http.HttpHeaders(), "upstream error".getBytes(), null);
+		when(requestForwarder.forward(any(), any(), any(), any(), any())).thenThrow(upstream);
+
+		mockMvc.perform(get("/plugins/smart-doc/documents")).andExpect(status().isBadGateway());
+	}
+
+	// -------------------------------------------------------------------------
+	// Multipart forwarding
+	// -------------------------------------------------------------------------
+
+	@Test
+	@WithMockUser(username = "alice")
+	@DisplayName("Should forward multipart body raw and return 201")
+	void shouldForwardMultipartBodyAndReturn201() throws Exception {
+		when(pluginRegistry.find("smart-doc")).thenReturn(Optional.of(SMART_DOC));
+		doNothing().when(authorizationChecker).assertAccess(any(), any(), any());
+		when(requestForwarder.forward(any(), any(), any(), any(), any())).thenReturn(ResponseEntity.status(HttpStatus.CREATED).body(new byte[0]));
+
+		MockMultipartFile file = new MockMultipartFile("document", "id-card.png", MediaType.IMAGE_PNG_VALUE, "image-content".getBytes());
+
+		mockMvc.perform(multipart("/plugins/smart-doc/documents").file(file)).andExpect(status().isCreated());
+
+		verify(requestForwarder).forward(any(), any(), any(), any(), any());
+	}
+
+	// -------------------------------------------------------------------------
+	// PluginErrorResponse record
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should expose status and message via record accessors")
+	void shouldExposeStatusAndMessageViaRecordAccessors() {
+		PluginController.PluginErrorResponse response = new PluginController.PluginErrorResponse(404, "not found");
+
+		assertThat(response.status()).isEqualTo(404);
+		assertThat(response.message()).isEqualTo("not found");
+	}
+}

--- a/src/test/java/org/isf/plugins/security/PluginAuthorizationCheckerTest.java
+++ b/src/test/java/org/isf/plugins/security/PluginAuthorizationCheckerTest.java
@@ -1,0 +1,295 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.plugins.security;
+
+import org.isf.plugins.config.*;
+import org.isf.plugins.exception.PluginAccessDeniedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+/**
+ * Unit tests for {@link PluginAuthorizationChecker}.
+ *
+ * <p>The real {@link org.isf.menu.manager.UserBrowsingManager} bean is intentionally
+ * <em>not</em> used here (it cannot be mocked with Byte Buddy on Java 25+).
+ * Instead, the {@link IAuthenticationSupplier} is built as a simple lambda that reads
+ * the Spring Security context and resolves the role from an in-memory
+ * {@code Map<String, String>} (username → group code), bypassing the database entirely.</p>
+ */
+class PluginAuthorizationCheckerTest {
+
+	/**
+	 * In-memory username → role map used by the test supplier.
+	 */
+	private final Map<String, String> userRoles = new HashMap<>();
+
+	private static final PluginBundle PLUGIN_BUNDLE = new PluginBundle("Smart Doc", "mf-manifest.json", "module", PluginLocation.MAIN, "assets/styles.css");
+
+	private IPluginAuthorizationChecker checker;
+
+	/**
+	 * Build a PluginDefinition with a single-permission, single-route config.
+	 */
+	private static PluginDefinition pluginWithRoute(String role, String path, String... methods) {
+		PluginRoute route = new PluginRoute(path, List.of(methods));
+		PluginPermission perm = new PluginPermission(role, List.of(route));
+		return new PluginDefinition("smart-doc", "http://localhost:4000", "/health", new PluginConfiguration(PLUGIN_BUNDLE, List.of(perm)));
+	}
+
+	/**
+	 * Build a PluginDefinition with no configuration.
+	 */
+	private static PluginDefinition pluginWithNoConfiguration() {
+		return new PluginDefinition("smart-doc", "http://localhost:4000", "/health", null);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a PluginDefinition with an empty permissions list.
+	 */
+	private static PluginDefinition pluginWithEmptyPermissions() {
+		return new PluginDefinition("smart-doc", "http://localhost:4000", "/health", new PluginConfiguration(PLUGIN_BUNDLE, List.of()));
+	}
+
+	@BeforeEach
+	void setUp() {
+		// Build a supplier that reads the Security context and looks up the role
+		// in the local map — no UserBrowsingManager required.
+		IAuthenticationSupplier supplier = () -> {
+			var authentication = SecurityContextHolder.getContext().getAuthentication();
+			if (authentication == null || !authentication.isAuthenticated()) {
+				return new AuthenticationContext(authentication, null);
+			}
+			String role = userRoles.get(authentication.getName());
+			return new AuthenticationContext(authentication, role);
+		};
+		checker = new PluginAuthorizationChecker(supplier);
+	}
+
+	@AfterEach
+	void clearSecurityContext() {
+		SecurityContextHolder.clearContext();
+	}
+
+	/**
+	 * Populates the security context and registers the username → role mapping.
+	 */
+	private void authenticateAs(String username, String groupCode) {
+		userRoles.put(username, groupCode);
+		var auth = new UsernamePasswordAuthenticationToken(username, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+		SecurityContextHolder.getContext().setAuthentication(auth);
+	}
+
+	// -------------------------------------------------------------------------
+	// Restrictive default: no configuration / empty permissions → deny all
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should deny access when plugin has no configuration at all")
+	void shouldDenyAccessWhenNoConfiguration() {
+		authenticateAs("alice", "admin");
+
+		assertThatThrownBy(() -> checker.assertAccess(pluginWithNoConfiguration(), "/documents", "GET")).isInstanceOf(PluginAccessDeniedException.class).hasMessageContaining("alice").hasMessageContaining("smart-doc");
+	}
+
+	@Test
+	@DisplayName("Should deny access when plugin has an empty permissions list")
+	void shouldDenyAccessWhenEmptyPermissions() {
+		authenticateAs("alice", "admin");
+
+		assertThatThrownBy(() -> checker.assertAccess(pluginWithEmptyPermissions(), "/documents", "GET")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// Role matching
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should grant access when role, path prefix, and method all match")
+	void shouldGrantAccessWhenRolePathAndMethodMatch() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET", "POST");
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET"));
+	}
+
+	@Test
+	@DisplayName("Should deny access when user role does not match any permission entry")
+	void shouldDenyAccessWhenRoleDoesNotMatch() {
+		authenticateAs("bob", "nurse");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET")).isInstanceOf(PluginAccessDeniedException.class).hasMessageContaining("bob").hasMessageContaining("smart-doc");
+	}
+
+	@Test
+	@DisplayName("Should grant access when user matches one of multiple permission groups")
+	void shouldGrantAccessWhenUserMatchesOneOfMultiplePermissionGroups() {
+		authenticateAs("bob", "doctor");
+
+		PluginRoute adminRoute = new PluginRoute("/documents", List.of("GET", "POST", "DELETE"));
+		PluginRoute doctorRoute = new PluginRoute("/documents", List.of("GET"));
+		PluginPermission adminPerm = new PluginPermission("admin", List.of(adminRoute));
+		PluginPermission doctorPerm = new PluginPermission("doctor", List.of(doctorRoute));
+		PluginDefinition plugin = new PluginDefinition("smart-doc", "http://localhost:4000", "/health", new PluginConfiguration(PLUGIN_BUNDLE, List.of(adminPerm, doctorPerm)));
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents/42", "GET"));
+	}
+
+	// -------------------------------------------------------------------------
+	// Path prefix matching
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should grant access when request path exactly matches configured path")
+	void shouldGrantAccessOnExactPathMatch() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET"));
+	}
+
+	@Test
+	@DisplayName("Should grant access when request path is a sub-path of the configured prefix")
+	void shouldGrantAccessOnSubPathMatch() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents/12912", "GET"));
+	}
+
+	@Test
+	@DisplayName("Should grant access on deeply nested sub-path")
+	void shouldGrantAccessOnDeeplyNestedSubPath() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "DELETE");
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents/123/attachments", "DELETE"));
+	}
+
+	@Test
+	@DisplayName("Should deny access when path does not start with configured prefix")
+	void shouldDenyAccessWhenPathDoesNotMatchPrefix() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/reports", "GET")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+
+	@Test
+	@DisplayName("Should deny access to /documents-other when configured prefix is /documents")
+	void shouldDenyAccessWhenPathSharesPrefixButIsNotSubPath() {
+		authenticateAs("alice", "admin");
+		// /documents-other must NOT match /documents
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/documents-other", "GET")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// HTTP method matching
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should deny access when HTTP method is not in the allowed list")
+	void shouldDenyAccessWhenMethodNotAllowed() {
+		authenticateAs("alice", "doctor");
+		PluginDefinition plugin = pluginWithRoute("doctor", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/documents", "DELETE")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+
+	@Test
+	@DisplayName("HTTP method matching should be case-insensitive")
+	void shouldMatchMethodCaseInsensitively() {
+		authenticateAs("alice", "admin");
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "get");
+
+		assertThatNoException().isThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET"));
+	}
+
+	// -------------------------------------------------------------------------
+	// Unauthenticated / no principal
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should throw IllegalStateException when there is no authentication in the security context")
+	void shouldThrowIllegalStateWhenNoAuthentication() {
+		SecurityContextHolder.clearContext();
+
+		assertThatThrownBy(() -> checker.assertAccess(pluginWithRoute("admin", "/documents", "GET"), "/documents", "GET")).isInstanceOf(IllegalStateException.class).hasMessageContaining("No authenticated principal");
+	}
+
+	@Test
+	@DisplayName("Should throw IllegalStateException when authentication is present but not authenticated")
+	void shouldThrowIllegalStateWhenPrincipalIsNotAuthenticated() {
+		SecurityContextHolder.clearContext();
+
+		assertThatThrownBy(() -> checker.assertAccess(pluginWithEmptyPermissions(), "/documents", "GET")).isInstanceOf(IllegalStateException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// Role resolution failure (unknown user → null role) → deny
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisplayName("Should deny access when the user has no role mapping (simulates OHServiceException / user not found)")
+	void shouldDenyWhenRoleResolutionFails() {
+		// "eve" is authenticated but has no entry in userRoles → supplier returns role=null
+		var auth = new UsernamePasswordAuthenticationToken("eve", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+		SecurityContextHolder.getContext().setAuthentication(auth);
+		// intentionally do NOT call userRoles.put("eve", ...) so role resolves to null
+
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+
+	@Test
+	@DisplayName("Should deny access when user is not found in the database (null returned)")
+	void shouldDenyWhenUserNotFound() {
+		// "ghost" is authenticated but has no role mapping → role=null → access denied
+		var auth = new UsernamePasswordAuthenticationToken("ghost", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+		SecurityContextHolder.getContext().setAuthentication(auth);
+		// intentionally do NOT add "ghost" to userRoles
+
+		PluginDefinition plugin = pluginWithRoute("admin", "/documents", "GET");
+
+		assertThatThrownBy(() -> checker.assertAccess(plugin, "/documents", "GET")).isInstanceOf(PluginAccessDeniedException.class);
+	}
+}


### PR DESCRIPTION
This pull request introduces a plugin gateway to the API, allowing integration with external plugin services through a unified proxy, and updates the build and runtime configuration to support new features. It also adds new dependencies for report generation, updates Java version requirements, and provides example plugin configurations and assets.

**Plugin Gateway Integration:**

* Added comprehensive documentation for the new plugin gateway in `README.md`, describing how to configure plugins, authorization, identity headers, and health checks.
* Added a sample plugin gateway configuration file `rsc/plugins.yaml.dist` with an example for the "smart-doc" plugin, including permissions and bundle metadata.
* 
See [OH2-474](https://openhospital.atlassian.net/browse/OH2-474)

[OH2-474]: https://openhospital.atlassian.net/browse/OH2-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ