### PR TITLE
Chore: move to last 3.x.x version of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
After this is merged work on the 4.x.x. track can start with its braking changes.

Tested Core/GUI/API

Paired with https://github.com/informatici/openhospital-core/pull/1585