### PR TITLE
OP-1409 Remove duplicate AuditorAware bean from SecurityConfig

### DIFF
--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -24,11 +24,6 @@ api.protocol=http
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.doc-expansion=none
 
-### Without the following overriding property the following error is generated:
-### Caused by: org.springframework.beans.factory.support.BeanDefinitionOverrideException: Invalid bean definition with name 'org.springframework.transaction.config.internalTransactionAdvisor' defined in class path resource [org/springframework/transaction/annotation/ProxyTransactionManagementConfiguration.class]: Cannot register bean definition [Root bean: class [null]; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration; factoryMethodName=transactionAdvisor; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [org/springframework/transaction/annotation/ProxyTransactionManagementConfiguration.class]] for bean 'org.springframework.transaction.config.internalTransactionAdvisor': There is already [Root bean: class [org.springframework.transaction.interceptor.BeanFactoryTransactionAttributeSourceAdvisor]; scope=; abstract=false; lazyInit=null; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=null; factoryMethodName=null; initMethodName=null; destroyMethodName=null] bound.
-### Seems like a Hibernate/SpringBoot conflict: see https://stackoverflow.com/questions/55545627/springboot-conflicts-with-hibernate
-spring.main.allow-bean-definition-overriding=true
-
 ### Without the following SpringBoot 2.6.x has a conflict with a bug in SpringFox
 ### See: https://stackoverflow.com/questions/70036953/springboot-2-6-0-spring-fox-3-failed-to-start-bean-documentationpluginsboot/70037507#70037507
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -24,10 +24,6 @@ api.protocol=http
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.doc-expansion=none
 
-### Without the following SpringBoot 2.6.x has a conflict with a bug in SpringFox
-### See: https://stackoverflow.com/questions/70036953/springboot-2-6-0-spring-fox-3-failed-to-start-bean-documentationpluginsboot/70037507#70037507
-spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 ### Security token secret (JWT)
 jwt.token.secret=JWT_TOKEN_SECRET
 

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -24,13 +24,11 @@ package org.isf.config;
 import java.util.Arrays;
 
 import org.isf.permissions.manager.PermissionManager;
-import org.isf.security.ApiAuditorAwareImpl;
 import org.isf.security.CustomLogoutHandler;
 import org.isf.security.OHSimpleUrlAuthenticationSuccessHandler;
 import org.isf.security.RestAuthenticationEntryPoint;
 import org.isf.security.jwt.JWTFilter;
 import org.isf.security.jwt.TokenProvider;
-import org.isf.utils.db.AuditorAwareInterface;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -351,10 +349,5 @@ public class SecurityConfig {
 	@Bean
 	public SimpleUrlAuthenticationSuccessHandler successHandler() {
 		return new OHSimpleUrlAuthenticationSuccessHandler(tokenProvider);
-	}
-
-	@Bean
-	public AuditorAwareInterface auditorAwareCustomizer() {
-		return new ApiAuditorAwareImpl();
 	}
 }

--- a/src/test/java/org/isf/security/ApiAuditorAwareImplTest.java
+++ b/src/test/java/org/isf/security/ApiAuditorAwareImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.isf.OpenHospitalApiApplication;
+import org.isf.utils.db.AuditorAwareInterface;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(classes = OpenHospitalApiApplication.class)
+class ApiAuditorAwareImplTest {
+
+	@Autowired
+	private AuditorAwareInterface auditorAware;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void shouldUseSecurityContextUserAsCurrentAuditor() {
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken("apiuser", "password", List.of(new SimpleGrantedAuthority("ROLE_USER")))
+		);
+
+		assertThat(auditorAware).isInstanceOf(ApiAuditorAwareImpl.class);
+		assertThat(auditorAware.getCurrentAuditor()).contains("apiuser");
+	}
+}


### PR DESCRIPTION
See OP-1409.

`spring.main.allow-bean-definition-overriding=true` is no longer needed

also removed obsolete SpringFox path matching workaround: `spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER`

Paired with https://github.com/informatici/openhospital-core/pull/1586.