### PR TITLE
Add DELETE endpoint for patient examination (OP-266)

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -1558,6 +1558,26 @@ paths:
                 $ref: "#/components/schemas/PatientExaminationDTO"
       security:
       - bearerAuth: []
+    delete:
+      tags:
+      - Examinations
+      operationId: deletePatientExamination
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+      security:
+      - bearerAuth: []
   /diseasetypes:
     get:
       tags:

--- a/src/main/java/org/isf/examination/rest/ExaminationController.java
+++ b/src/main/java/org/isf/examination/rest/ExaminationController.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -161,6 +162,24 @@ public class ExaminationController {
 		}
 
 		return patientExaminationMapper.map2DTO(patientExamination);
+	}
+
+	@DeleteMapping("/examinations/{id}")
+	public boolean deletePatientExamination(@PathVariable Integer id) throws OHServiceException {
+		LOGGER.info("Delete patient examination id: {}.", id);
+		PatientExamination patientExamination = examinationBrowserManager.getByID(id);
+
+		if (patientExamination == null) {
+			throw new OHAPIException(new OHExceptionMessage("Patient examination not found."), HttpStatus.NOT_FOUND);
+		}
+
+		try {
+			examinationBrowserManager.remove(List.of(patientExamination));
+			return true;
+		} catch (OHServiceException serviceException) {
+			LOGGER.error("Delete patient examination: {} failed.", id);
+			throw new OHAPIException(new OHExceptionMessage("Patient examination not deleted."));
+		}
 	}
 
 	@GetMapping("/examinations/lastByPatientId/{patId}")

--- a/src/test/java/org/isf/examination/rest/ExaminationControllerTest.java
+++ b/src/test/java/org/isf/examination/rest/ExaminationControllerTest.java
@@ -24,7 +24,9 @@ package org.isf.examination.rest;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -248,5 +250,37 @@ class ExaminationControllerTest {
 			.andDo(log())
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString(objectMapper.writeValueAsString(patientExaminationDTO))));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = {"examinations.delete"})
+	@DisplayName("Should delete patient examination using ID")
+	void testDeletePatientExamination() throws Exception {
+		Patient patient = PatientHelper.setup();
+		PatientExamination patientExamination = new TestPatientExamination().setup(patient, false);
+
+		when(manager.getByID(anyInt())).thenReturn(patientExamination);
+
+		mvc.perform(delete("/examinations/{id}", "1")
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("true")));
+
+		verify(manager).remove(List.of(patientExamination));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = {"examinations.delete"})
+	@DisplayName("Should fail to delete patient examination with wrong ID")
+	void testDeletePatientExaminationWithWrongId() throws Exception {
+		when(manager.getByID(anyInt())).thenReturn(null);
+
+		mvc.perform(delete("/examinations/{id}", "1")
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(log())
+			.andExpect(status().isNotFound());
 	}
 }


### PR DESCRIPTION
## What
Adds a `DELETE /examinations/{id}` endpoint to `ExaminationController`, completing the CRUD surface for patient examinations.

Resolves [OP-266](https://openhospital.atlassian.net/browse/OP-266) — originally raised while reviewing #59.

## How
- The endpoint fetches the examination via `ExaminationBrowserManager.getByID(id)`:
  - returns **404 Not Found** when no examination matches the id;
  - otherwise removes it through `ExaminationBrowserManager.remove(...)` and returns `true`.
- Follows the existing delete-endpoint convention in the codebase (e.g. `OperationController.deleteOperation`, `OpdController.deleteOpd`): primitive `boolean` return, `OHAPIException` handling, logging.
- Authorization was already wired in `SecurityConfig` (`DELETE /examinations/** -> examinations.delete`); no change needed there.

## Tests
- Added controller tests for the success (200) and not-found (404) cases, including a `verify` that the removal is actually invoked.
- Full API test suite passes locally.

## OpenAPI
- Updated the committed spec `openapi/oh.yaml` with the new operation, regenerated from the running application so it matches the CI-generated spec.

[OP-266]: https://openhospital.atlassian.net/browse/OP-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ