### PR TITLE
OP-1216 Convert money and quantity DTO fields to DECIMAL/INT

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -7086,12 +7086,10 @@ components:
           example: O
         amount:
           type: number
-          format: double
           description: Bill Amount
           example: 1000
         balance:
           type: number
-          format: double
           description: Bill balance
           example: 1500
         user:
@@ -7445,18 +7443,18 @@ components:
           description: The number of pieces per packet
           example: 100
         inqty:
-          type: number
-          format: double
+          type: integer
+          format: int32
           description: The input quantity of the medical
           example: 340
         outqty:
-          type: number
-          format: double
+          type: integer
+          format: int32
           description: The out quantity of the medical
           example: 8
         minqty:
-          type: number
-          format: double
+          type: integer
+          format: int32
           description: The min quantity of the medical
           example: 15
         lock:
@@ -7805,7 +7803,6 @@ components:
           example: Acetone 99 % 1ltr
         itemAmount:
           type: number
-          format: double
           description: Item amount
           example: 1000
         itemQuantity:
@@ -7852,7 +7849,6 @@ components:
           example: 2020-03-19T14:58:00.000Z
         amount:
           type: number
-          format: double
           description: The payment amount
           example: 500
         user:
@@ -8201,7 +8197,6 @@ components:
           description: The medical concerned by the movement
         quantity:
           type: number
-          format: double
           description: The quantity of the medical concerned by the movement
           example: 145
         units:
@@ -8294,7 +8289,6 @@ components:
           maxLength: 100
         price:
           type: number
-          format: double
           description: Price
           example: 1500
         lock:
@@ -8363,13 +8357,12 @@ components:
           description: The medical ward's id
           example: 1
         in_quantity:
-          type: number
-          format: float
+          type: integer
+          format: int32
           description: The in-quantity
           example: 150
         out_quantity:
           type: number
-          format: float
           description: The out-quantity
           example: 89
         lock:

--- a/src/main/java/org/isf/accounting/dto/BillDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillDTO.java
@@ -21,6 +21,7 @@
  */
 package org.isf.accounting.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
@@ -68,11 +69,11 @@ public class BillDTO {
 
 	@NotNull
 	@Schema(description = "Bill Amount", example = "1000")
-	private Double amount;
+	private BigDecimal amount;
 
 	@NotNull
 	@Schema(description = "Bill balance", example = "1500")
-	private Double balance;
+	private BigDecimal balance;
 
 	@NotNull
 	@Schema(description = "user name who create the bill", example = "admin")
@@ -121,11 +122,11 @@ public class BillDTO {
 		return this.status;
 	}
 
-	public Double getAmount() {
+	public BigDecimal getAmount() {
 		return this.amount;
 	}
 
-	public Double getBalance() {
+	public BigDecimal getBalance() {
 		return this.balance;
 	}
 
@@ -173,11 +174,11 @@ public class BillDTO {
 		this.status = status;
 	}
 
-	public void setAmount(Double amount) {
+	public void setAmount(BigDecimal amount) {
 		this.amount = amount;
 	}
 
-	public void setBalance(Double balance) {
+	public void setBalance(BigDecimal balance) {
 		this.balance = balance;
 	}
 

--- a/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillItemsDTO.java
@@ -21,6 +21,8 @@
  */
 package org.isf.accounting.dto;
 
+import java.math.BigDecimal;
+
 import jakarta.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -47,7 +49,7 @@ public class BillItemsDTO {
 
 	@NotNull
 	@Schema(description = "Item amount", example = "1000")
-	private double itemAmount;
+	private BigDecimal itemAmount;
 
 	@NotNull
 	@Schema(description = "Item quantity", example = "1")
@@ -88,7 +90,7 @@ public class BillItemsDTO {
 		return this.itemDescription;
 	}
 
-	public double getItemAmount() {
+	public BigDecimal getItemAmount() {
 		return this.itemAmount;
 	}
 
@@ -124,7 +126,7 @@ public class BillItemsDTO {
 		this.itemDescription = itemDescription;
 	}
 
-	public void setItemAmount(double itemAmount) {
+	public void setItemAmount(BigDecimal itemAmount) {
 		this.itemAmount = itemAmount;
 	}
 

--- a/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
+++ b/src/main/java/org/isf/accounting/dto/BillPaymentsDTO.java
@@ -21,6 +21,7 @@
  */
 package org.isf.accounting.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
@@ -43,7 +44,7 @@ public class BillPaymentsDTO {
 
 	@NotNull
 	@Schema(description = "The payment amount", example = "500")
-	private double amount;
+	private BigDecimal amount;
 
 	@NotNull
 	@Schema(description = "The current user", example = "admin")
@@ -63,7 +64,7 @@ public class BillPaymentsDTO {
 		return this.date;
 	}
 
-	public double getAmount() {
+	public BigDecimal getAmount() {
 		return this.amount;
 	}
 
@@ -88,7 +89,7 @@ public class BillPaymentsDTO {
 		this.date = date;
 	}
 
-	public void setAmount(double amount) {
+	public void setAmount(BigDecimal amount) {
 		this.amount = amount;
 	}
 

--- a/src/main/java/org/isf/medical/dto/MedicalDTO.java
+++ b/src/main/java/org/isf/medical/dto/MedicalDTO.java
@@ -46,13 +46,13 @@ public class MedicalDTO {
 	private Integer pcsperpck;
 
 	@Schema(description = "The input quantity of the medical", example = "340")
-	private double inqty;
+	private int inqty;
 
 	@Schema(description = "The out quantity of the medical", example = "8")
-	private double outqty;
+	private int outqty;
 
 	@Schema(description = "The min quantity of the medical", example = "15")
-	private double minqty;
+	private int minqty;
 
 	@Schema(description = "Lock", example = "0")
 	private int lock;
@@ -64,7 +64,7 @@ public class MedicalDTO {
 	 * Constructor
 	 */
 	public MedicalDTO(Integer code, MedicalTypeDTO type, String prod_code, String description, double initialqty,
-			Integer pcsperpck, double minqty, double inqty, double outqty) {
+			Integer pcsperpck, int minqty, int inqty, int outqty) {
 		this.code = code;
 		this.type = type;
 		this.prod_code = prod_code;
@@ -108,15 +108,15 @@ public class MedicalDTO {
 		return this.pcsperpck;
 	}
 
-	public double getInqty() {
+	public int getInqty() {
 		return this.inqty;
 	}
 
-	public double getOutqty() {
+	public int getOutqty() {
 		return this.outqty;
 	}
 
-	public double getMinqty() {
+	public int getMinqty() {
 		return this.minqty;
 	}
 
@@ -144,15 +144,15 @@ public class MedicalDTO {
 		this.pcsperpck = pcsperpck;
 	}
 
-	public void setInqty(double inqty) {
+	public void setInqty(int inqty) {
 		this.inqty = inqty;
 	}
 
-	public void setOutqty(double outqty) {
+	public void setOutqty(int outqty) {
 		this.outqty = outqty;
 	}
 
-	public void setMinqty(double minqty) {
+	public void setMinqty(int minqty) {
 		this.minqty = minqty;
 	}
 }

--- a/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MedicalWardDTO.java
@@ -21,6 +21,8 @@
  */
 package org.isf.medicalstockward.dto;
 
+import java.math.BigDecimal;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class MedicalWardDTO {
@@ -29,10 +31,10 @@ public class MedicalWardDTO {
 	private MedicalWardIdDTO id;
 
 	@Schema(description = "The in-quantity", example = "150")
-	private float in_quantity;
+	private int in_quantity;
 
 	@Schema(description = "The out-quantity", example = "89")
-	private float out_quantity;
+	private BigDecimal out_quantity;
 
 	@Schema(description = "Lock", example = "0")
 	private int lock;
@@ -40,7 +42,7 @@ public class MedicalWardDTO {
 	public MedicalWardDTO() {
 	}
 
-	public MedicalWardDTO(MedicalWardIdDTO id, float in_quantity, float out_quantity) {
+	public MedicalWardDTO(MedicalWardIdDTO id, int in_quantity, BigDecimal out_quantity) {
 		this.id = id;
 		this.in_quantity = in_quantity;
 		this.out_quantity = out_quantity;
@@ -50,11 +52,11 @@ public class MedicalWardDTO {
 		return this.id;
 	}
 
-	public float getIn_quantity() {
+	public int getIn_quantity() {
 		return this.in_quantity;
 	}
 
-	public float getOut_quantity() {
+	public BigDecimal getOut_quantity() {
 		return this.out_quantity;
 	}
 
@@ -62,11 +64,11 @@ public class MedicalWardDTO {
 		this.id = id;
 	}
 
-	public void setIn_quantity(float in_quantity) {
+	public void setIn_quantity(int in_quantity) {
 		this.in_quantity = in_quantity;
 	}
 
-	public void setOut_quantity(float out_quantity) {
+	public void setOut_quantity(BigDecimal out_quantity) {
 		this.out_quantity = out_quantity;
 	}
 

--- a/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
+++ b/src/main/java/org/isf/medicalstockward/dto/MovementWardDTO.java
@@ -21,6 +21,7 @@
  */
 package org.isf.medicalstockward.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
@@ -66,7 +67,7 @@ public class MovementWardDTO {
 
 	@NotNull
 	@Schema(description = "The quantity of the medical concerned by the movement", example = "145")
-	private Double quantity;
+	private BigDecimal quantity;
 
 	@NotNull
 	@Schema(description = "The measure's unit of the medical concerned by the movement", example = "pct")
@@ -82,7 +83,7 @@ public class MovementWardDTO {
 	}
 
 	public MovementWardDTO(int code, WardDTO ward, LocalDate date, boolean isPatient, PatientDTO patient, int age,
-			float weight, String description, MedicalDTO medical, Double quantity, String units, WardDTO wardTo,
+			float weight, String description, MedicalDTO medical, BigDecimal quantity, String units, WardDTO wardTo,
 			WardDTO wardFrom) {
 		this.code = code;
 		this.ward = ward;
@@ -135,7 +136,7 @@ public class MovementWardDTO {
 		return this.medical;
 	}
 
-	public Double getQuantity() {
+	public BigDecimal getQuantity() {
 		return this.quantity;
 	}
 
@@ -187,7 +188,7 @@ public class MovementWardDTO {
 		this.medical = medical;
 	}
 
-	public void setQuantity(Double quantity) {
+	public void setQuantity(BigDecimal quantity) {
 		this.quantity = quantity;
 	}
 

--- a/src/main/java/org/isf/priceslist/dto/PriceDTO.java
+++ b/src/main/java/org/isf/priceslist/dto/PriceDTO.java
@@ -21,6 +21,8 @@
  */
 package org.isf.priceslist.dto;
 
+import java.math.BigDecimal;
+
 import jakarta.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -49,7 +51,7 @@ public class PriceDTO {
 
 	@NotNull
 	@Schema(description = "Price", example = "1500")
-	private Double price;
+	private BigDecimal price;
 
 	@Schema(description = "Lock", example = "0")
 	private int lock;
@@ -93,7 +95,7 @@ public class PriceDTO {
 		return this.description;
 	}
 
-	public Double getPrice() {
+	public BigDecimal getPrice() {
 		return this.price;
 	}
 
@@ -117,7 +119,7 @@ public class PriceDTO {
 		this.description = description;
 	}
 
-	public void setPrice(Double price) {
+	public void setPrice(BigDecimal price) {
 		this.price = price;
 	}
 


### PR DESCRIPTION
## OP-1216 — Align REST DTOs with the DECIMAL/INT type change

Aligns the API DTOs with the core type change (OP-1216).

### Changes
- **BigDecimal**: `BillDTO.amount/balance`, `BillItemsDTO.itemAmount`,
  `BillPaymentsDTO.amount`, `PriceDTO.price`, `MovementWardDTO.quantity`,
  `MedicalWardDTO.out_quantity`.
- **int**: `MedicalDTO` in/out/min quantity, `MedicalWardDTO.in_quantity`.
- Regenerated `openapi/oh.yaml` accordingly.

### Verification
- Full controller test suite green.
- OpenAPI gate replicated locally: ran the app, `mvn springdoc-openapi:generate`,
  and compared as sorted JSON (`yq`/`jq`) — the committed `oh.yaml` is byte-equal
  to the live-generated spec. The changes are additive/type-only (non-breaking).

Requires the core change. Companion PRs (same branch name) are linked in a comment below.

JIRA: https://openhospital.atlassian.net/browse/OP-1216
