### PR TITLE
OP-890 Harden REST API responses against information disclosure

### DIFF
--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -37,3 +37,14 @@ jwt.token.validityInSecondsForRememberMe=259200
 # needed to start application even without DB connection
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=none
+
+### Security hardening - do not disclose technical/version information (OP-890, STRIDE I03)
+# Error responses must not leak messages, stack traces or exception class names
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.error.include-exception=false
+server.error.include-binding-errors=never
+# Return a clean 404 for unknown paths instead of a detailed error page
+spring.mvc.throw-exception-if-no-handler-found=true
+# Suppress the server identification (version) header
+server.server-header=


### PR DESCRIPTION
## What & why

OP-890 (Information Disclosure 1/2, STRIDE I03): the REST API must not reveal technical/version information in its responses.

## Changes (`rsc/application.properties.dist`)

```properties
server.error.include-message=never
server.error.include-stacktrace=never
server.error.include-exception=false
server.error.include-binding-errors=never
spring.mvc.throw-exception-if-no-handler-found=true
server.server-header=
```

Error responses no longer leak messages / stack traces / exception class names, unknown paths return a clean 404, and the server identification (version) header is suppressed.

## Notes on the ticket spec

- The settings live in `rsc/application.properties.dist` (the API's actual config template), not `src/main/resources/application.properties`, which does not exist in this project.
- `management.endpoints.web.exposure.exclude=*` was omitted: the Spring Boot Actuator is **not** a dependency, so `/actuator` already returns 404 — nothing to exclude.
- `X-Powered-By` is not emitted by Spring/Tomcat, so no removal is needed in code.
- The nginx/`Server` header part of the ticket is a deployment concern: the React UI is served via `serve`, not nginx, so there is no in-repo nginx config to change (documented in the AdminManual note).

## Testing (real run)

Started the API and verified with curl:
- Responses carry **no `Server` or `X-Powered-By`** header.
- A malformed request returns `{"title":"Bad Request","status":400,"detail":"Failed to read request"}` — no stack trace / exception class / SQL.
- `GET /swagger-ui/index.html` and `GET /v3/api-docs` → **200** (Swagger still available).
- `GET /actuator` → 404.

## Companion PR

Doc note: informatici/openhospital-doc (same branch).

Jira: OP-890
