### PR TITLE
OP-1069 Add GET /reports endpoint listing the available reports

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -3807,6 +3807,22 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /reports:
+    get:
+      tags:
+      - Reports
+      operationId: getReportsList
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReportLauncherDTO"
+      security:
+      - bearerAuth: []
   /reports/exams-list:
     get:
       tags:
@@ -8271,6 +8287,33 @@ components:
       required:
       - password
       - username
+    ReportLauncherDTO:
+      type: object
+      properties:
+        folder:
+          type: string
+          description: Folder holding the compiled report
+          example: rpt_stat
+          readOnly: true
+        fileName:
+          type: string
+          description: Name of the report file (without extension)
+          example: POI_ByAgeBySex
+          readOnly: true
+        title:
+          type: string
+          description: Localized title of the report
+          example: Patients by age and sex
+          readOnly: true
+        userInputParameters:
+          type: array
+          description: Names of the parameters the user is expected to provide
+          example:
+          - month
+          - year
+          items:
+            type: string
+          readOnly: true
     PriceDTO:
       type: object
       description: Class representing a prices

--- a/src/main/java/org/isf/stats/dto/ReportLauncherDTO.java
+++ b/src/main/java/org/isf/stats/dto/ReportLauncherDTO.java
@@ -1,0 +1,77 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.stats.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes a stat report that can be launched by the user.
+ */
+public class ReportLauncherDTO {
+
+	@Schema(description = "Folder holding the compiled report", example = "rpt_stat", accessMode = Schema.AccessMode.READ_ONLY)
+	private String folder;
+
+	@Schema(description = "Name of the report file (without extension)", example = "POI_ByAgeBySex", accessMode = Schema.AccessMode.READ_ONLY)
+	private String fileName;
+
+	@Schema(description = "Localized title of the report", example = "Patients by age and sex", accessMode = Schema.AccessMode.READ_ONLY)
+	private String title;
+
+	@Schema(description = "Names of the parameters the user is expected to provide", example = "[\"month\", \"year\"]",
+					accessMode = Schema.AccessMode.READ_ONLY)
+	private List<String> userInputParameters;
+
+	public String getFolder() {
+		return folder;
+	}
+
+	public void setFolder(String folder) {
+		this.folder = folder;
+	}
+
+	public String getFileName() {
+		return fileName;
+	}
+
+	public void setFileName(String fileName) {
+		this.fileName = fileName;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public List<String> getUserInputParameters() {
+		return userInputParameters;
+	}
+
+	public void setUserInputParameters(List<String> userInputParameters) {
+		this.userInputParameters = userInputParameters;
+	}
+}

--- a/src/main/java/org/isf/stats/mapper/ReportLauncherMapper.java
+++ b/src/main/java/org/isf/stats/mapper/ReportLauncherMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.stats.mapper;
+
+import org.isf.shared.GenericMapper;
+import org.isf.stat.dto.ReportLauncherDto;
+import org.isf.stats.dto.ReportLauncherDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReportLauncherMapper extends GenericMapper<ReportLauncherDto, ReportLauncherDTO> {
+
+	public ReportLauncherMapper() {
+		super(ReportLauncherDto.class, ReportLauncherDTO.class);
+	}
+}

--- a/src/main/java/org/isf/stats/rest/ReportsController.java
+++ b/src/main/java/org/isf/stats/rest/ReportsController.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -32,6 +33,8 @@ import org.apache.poi.util.IOUtils;
 import org.isf.shared.exceptions.OHAPIException;
 import org.isf.stat.dto.JasperReportResultDto;
 import org.isf.stat.manager.JasperReportsManager;
+import org.isf.stats.dto.ReportLauncherDTO;
+import org.isf.stats.mapper.ReportLauncherMapper;
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.springframework.core.io.Resource;
@@ -54,8 +57,21 @@ public class ReportsController {
 
 	private final JasperReportsManager reportsManager;
 
-	public ReportsController(JasperReportsManager reportsManager) {
+	private final ReportLauncherMapper reportLauncherMapper;
+
+	public ReportsController(JasperReportsManager reportsManager, ReportLauncherMapper reportLauncherMapper) {
 		this.reportsManager = reportsManager;
+		this.reportLauncherMapper = reportLauncherMapper;
+	}
+
+	/**
+	 * Returns the list of the stat reports the user can launch (formerly built in the GUI report launcher).
+	 *
+	 * @return the available reports
+	 */
+	@GetMapping("/reports")
+	public List<ReportLauncherDTO> getReportsList() {
+		return reportLauncherMapper.map2DTOList(reportsManager.getReportsList());
 	}
 
 	@GetMapping("/reports/exams-list")

--- a/src/test/java/org/isf/stats/rest/ReportsControllerTest.java
+++ b/src/test/java/org/isf/stats/rest/ReportsControllerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.stats.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
+import org.isf.stat.dto.ReportLauncherDto;
+import org.isf.stat.manager.JasperReportsManager;
+import org.isf.stats.mapper.ReportLauncherMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class ReportsControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReportsControllerTest.class);
+
+	@Mock
+	protected JasperReportsManager reportsManagerMock;
+
+	protected ReportLauncherMapper reportLauncherMapper = new ReportLauncherMapper();
+
+	private MockMvc mockMvc;
+
+	private AutoCloseable closeable;
+
+	@BeforeEach
+	void setup() {
+		closeable = MockitoAnnotations.openMocks(this);
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new ReportsController(reportsManagerMock, reportLauncherMapper))
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+		ReflectionTestUtils.setField(reportLauncherMapper, "modelMapper", new ModelMapper());
+	}
+
+	@AfterEach
+	void closeService() throws Exception {
+		closeable.close();
+	}
+
+	@Test
+	void testGetReportsList_200() throws Exception {
+		String request = "/reports";
+
+		ReportLauncherDto report = new ReportLauncherDto("rpt_stat", "POI_ByAgeBySex", "Patients by age and sex", List.of("month", "year"));
+		when(reportsManagerMock.getReportsList()).thenReturn(List.of(report));
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].folder").value("rpt_stat"))
+			.andExpect(jsonPath("$[0].fileName").value("POI_ByAgeBySex"))
+			.andExpect(jsonPath("$[0].title").value("Patients by age and sex"))
+			.andExpect(jsonPath("$[0].userInputParameters[0]").value("month"))
+			.andExpect(jsonPath("$[0].userInputParameters[1]").value("year"))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetReportsList_emptyList_200() throws Exception {
+		String request = "/reports";
+
+		when(reportsManagerMock.getReportsList()).thenReturn(List.of());
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("[]")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+}


### PR DESCRIPTION
## OP-1069 — Move report launcher logic from GUI to CORE

This is the **API** piece of [OP-1069](https://openhospital.atlassian.net/browse/OP-1069). The ticket's stated aim is an endpoint to retrieve the list of available reports; depends on the CORE PR (informatici/openhospital-core#1604).

### What
New `GET /reports` endpoint in `ReportsController` exposing `JasperReportsManager.getReportsList()`, mapping the CORE `ReportLauncherDto` to a new `ReportLauncherDTO` (folder, file name, title, prompt parameters). OpenAPI `oh.yaml` updated accordingly.

### Notes
- The endpoint lists reports found in the `rpt_stat`/`rpt_extra` folders resolved against the API process working directory. Those folders currently ship with the GUI, so on a standalone API deployment the list is empty until they are relocated (separate follow-up task) — the endpoint and contract are in place for when they are.

### Tests
- New `ReportsControllerTest` (returns the mapped list; empty-list case).
- Full API test suite 229 green (1 skipped).
- OpenAPI check replicated locally: committed `oh.yaml` is byte-equal to the spec generated from the running app.

### Verification
Ran the API against a demo DB with the report folders present → `POST /auth/login` → `GET /reports` returned **HTTP 200** with 32 reports as JSON (correct folder/title/file name/parameters).

Companion PRs (same branch name → CI cross-builds the core fork branch):
- CORE: informatici/openhospital-core#1604
- GUI: informatici/openhospital-gui#2215

[OP-1069]: https://openhospital.atlassian.net/browse/OP-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ