### PR TITLE
OP-891 Mask internal errors in API responses

### DIFF
--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -21,41 +21,41 @@
  */
 package org.isf.shared.exceptions;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
 
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.ErrorDescription;
 import org.springframework.http.HttpStatus;
 
 /**
- * Exception DTO
+ * Exception DTO returned to API clients.
+ *
+ * <p>
+ * Only the HTTP {@code status} and a clean, user-facing {@code message} are exposed. Stack traces, exception class names and raw internal/SQL details are
+ * never serialized: they would disclose information about the server internals. Full exception details must be written to the application log only.
+ * </p>
  *
  * @author antonio
  */
 public class OHAPIError {
-    private HttpStatus status;
-    private String message;
-    private String debugMessage;
-    private String stackTrace;
-    private LocalDateTime timestamp;
-    private ErrorDescription description;
 
-    public OHAPIError(HttpStatus status, OHServiceException ex) {
-        this.timestamp = LocalDateTime.now();
-        this.status = status;
-        this.message = ex.getMessages().get(0).getMessage();
-        this.debugMessage = ex.getMessages()
-                .stream()
-                .map(em -> em.getMessage())
-                .collect(Collectors.joining(","));
-        StringWriter sw = new StringWriter();
-        ex.printStackTrace(new PrintWriter(sw));
-        this.stackTrace = sw.toString();
-        this.description = ex.getMessages().get(0).getDescription();
-    }
+	private HttpStatus status;
+	private String message;
+	private LocalDateTime timestamp;
+	private ErrorDescription description;
+
+	public OHAPIError(HttpStatus status, OHServiceException ex) {
+		this.timestamp = LocalDateTime.now();
+		this.status = status;
+		this.message = ex.getMessages().get(0).getMessage();
+		this.description = ex.getMessages().get(0).getDescription();
+	}
+
+	public OHAPIError(HttpStatus status, String message) {
+		this.timestamp = LocalDateTime.now();
+		this.status = status;
+		this.message = message;
+	}
 
 	public HttpStatus getStatus() {
 		return this.status;
@@ -63,14 +63,6 @@ public class OHAPIError {
 
 	public String getMessage() {
 		return this.message;
-	}
-
-	public String getDebugMessage() {
-		return this.debugMessage;
-	}
-
-	public String getStackTrace() {
-		return this.stackTrace;
 	}
 
 	public LocalDateTime getTimestamp() {
@@ -85,14 +77,6 @@ public class OHAPIError {
 		this.message = message;
 	}
 
-	public void setDebugMessage(String debugMessage) {
-		this.debugMessage = debugMessage;
-	}
-
-	public void setStackTrace(String stackTrace) {
-		this.stackTrace = stackTrace;
-	}
-
 	public void setTimestamp(LocalDateTime timestamp) {
 		this.timestamp = timestamp;
 	}
@@ -104,5 +88,5 @@ public class OHAPIError {
 	public void setDescription(ErrorDescription description) {
 		this.description = description;
 	}
-	
+
 }

--- a/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
+++ b/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
+++ b/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
@@ -32,6 +32,8 @@ import org.isf.utils.exception.OHInvalidSQLException;
 import org.isf.utils.exception.OHOperationNotAllowedException;
 import org.isf.utils.exception.OHReportException;
 import org.isf.utils.exception.OHServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -43,6 +45,10 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice
 public class OHResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OHResponseEntityExceptionHandler.class);
+
+    private static final String GENERIC_ERROR_MESSAGE = "An internal error occurred";
 
     @ExceptionHandler(value = {OHDataValidationException.class})
     protected ResponseEntity<Object> handleOHServiceValidationException(OHServiceException ex) {
@@ -92,6 +98,16 @@ public class OHResponseEntityExceptionHandler extends ResponseEntityExceptionHan
     @ExceptionHandler(value = {OHAPIException.class})
     protected ResponseEntity<Object> handleOHAPIException(OHAPIException ex) {
         return buildResponseEntity(new OHAPIError(ex.getStatus(), ex));
+    }
+
+    /**
+     * Catch-all handler for any unhandled exception. The full exception (including stack trace) is logged at error level for diagnostics, while the response
+     * body only exposes a generic message and the HTTP status, so that no stack trace, exception class name or internal/SQL detail is disclosed to the client.
+     */
+    @ExceptionHandler(value = {Exception.class})
+    protected ResponseEntity<Object> handleUnexpectedException(Exception ex) {
+        LOGGER.error("Unhandled exception while processing request", ex);
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, GENERIC_ERROR_MESSAGE));
     }
 
     private ResponseEntity<Object> buildResponseEntity(OHAPIError apiError) {

--- a/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.shared.exceptions;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Verifies that the controller advice masks internal error details (stack traces, exception class names, raw/SQL messages) and only returns a clean,
+ * user-facing message to the client.
+ */
+class OHResponseEntityExceptionHandlerTest {
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setup() {
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new FailingController())
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+	}
+
+	@Test
+	void unhandledRuntimeExceptionReturnsGenericMessageWithoutDetails() throws Exception {
+		this.mockMvc
+			.perform(get("/test/runtime-exception").accept(MediaType.APPLICATION_JSON))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.message").value("An internal error occurred"))
+			.andExpect(content().string(not(containsString("stackTrace"))))
+			.andExpect(content().string(not(containsString("debugMessage"))))
+			.andExpect(content().string(not(containsString("NullPointerException"))))
+			.andExpect(content().string(not(containsString("super secret SQL detail"))));
+	}
+
+	@Test
+	void ohServiceExceptionReturnsUserFacingMessageWithoutDetails() throws Exception {
+		this.mockMvc
+			.perform(get("/test/service-exception").accept(MediaType.APPLICATION_JSON))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.message").value("A user-facing message"))
+			.andExpect(content().string(not(containsString("stackTrace"))))
+			.andExpect(content().string(not(containsString("debugMessage"))))
+			.andExpect(content().string(not(containsString("OHServiceException"))));
+	}
+
+	@RestController
+	private static class FailingController {
+
+		@GetMapping("/test/runtime-exception")
+		public ResponseEntity<String> throwRuntimeException() {
+			throw new NullPointerException("super secret SQL detail near 'table users'");
+		}
+
+		@GetMapping("/test/service-exception")
+		public ResponseEntity<String> throwServiceException() throws OHServiceException {
+			throw new OHServiceException(new OHExceptionMessage("A user-facing message"));
+		}
+	}
+}


### PR DESCRIPTION
## OP-891 — Information Disclosure 2/2: Errors masking (I04) — API part

### Problem
`OHAPIError` serialized a **full Java stack trace** (`stackTrace`) and the raw exception messages (`debugMessage`) in **every** error response body, leaking exception class names, internal paths and SQL details to clients. (OP-890's `server.error.*` props don't help — the API serializes errors through this custom advice, bypassing Spring's error path.)

### Fix
- **`OHAPIError`**: drop `stackTrace` and `debugMessage`; expose only `status` + a clean user-facing `message` (plus `timestamp`/`description`). Add a `(HttpStatus, String)` constructor.
- **`OHResponseEntityExceptionHandler`**: add a catch-all `@ExceptionHandler(Exception.class)` → HTTP 500 `{"message":"An internal error occurred"}`, logging the full exception (with trace) to the application log only. Existing specific handlers (validation/404/OHServiceException) still win and keep their user-facing messages.
- New `OHResponseEntityExceptionHandlerTest` asserting error bodies never contain stack traces, exception class names or internal/SQL details (plants a fake SQL secret and asserts its absence).

### ⚠️ API response-contract change
The `stackTrace` and `debugMessage` JSON fields are **no longer returned** in error responses (intentional — this is the disclosure fix). No API-side or UI consumer reads them (only MSW mock fixtures referenced `debugMessage`).

### Verification
- Full API suite **229** green + new advice test (2). OpenAPI spec (`oh.yaml`) byte-equal (`OHAPIError` isn't in the spec).
- Live e2e: an OH-level error now returns `{status, message, timestamp, description}` only — no `stackTrace`/`debugMessage`.

GUI was reviewed and is **already compliant** (0 `printStackTrace`, errors funnel through localized `OHServiceExceptionUtil`) → no GUI change. The **openhospital-ui** part (React error boundary / sanitized client errors) is deferred to a separate ticket. Doc PR: _linked in a comment_.