### PR TITLE
OP-1358 Expose the ward/supplier virtual flag in the REST API

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -6289,6 +6289,8 @@ components:
           type: boolean
         pharmacy:
           type: boolean
+        virtual:
+          type: boolean
       required:
       - beds
       - description
@@ -6707,6 +6709,8 @@ components:
           type: string
           description: The supplier's notes
           maxLength: 200
+        virtual:
+          type: boolean
         lock:
           type: integer
           format: int32

--- a/src/main/java/org/isf/supplier/dto/SupplierDTO.java
+++ b/src/main/java/org/isf/supplier/dto/SupplierDTO.java
@@ -52,6 +52,8 @@ public class SupplierDTO {
 	@Schema(description = "The supplier's notes", example = "", maxLength = 200)
 	private String supNote;
 
+	private boolean isVirtual;
+
 	@Schema(description = "Lock", example = "0")
 	private int lock;
 
@@ -102,6 +104,10 @@ public class SupplierDTO {
 		return this.supNote;
 	}
 
+	public boolean isVirtual() {
+		return this.isVirtual;
+	}
+
 	public void setSupId(Integer supId) {
 		this.supId = supId;
 	}
@@ -132,6 +138,10 @@ public class SupplierDTO {
 
 	public void setSupNote(String supNote) {
 		this.supNote = supNote;
+	}
+
+	public void setVirtual(boolean isVirtual) {
+		this.isVirtual = isVirtual;
 	}
 
 	public int getLock() {

--- a/src/main/java/org/isf/supplier/dto/SupplierDTO.java
+++ b/src/main/java/org/isf/supplier/dto/SupplierDTO.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/ward/dto/WardDTO.java
+++ b/src/main/java/org/isf/ward/dto/WardDTO.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/ward/dto/WardDTO.java
+++ b/src/main/java/org/isf/ward/dto/WardDTO.java
@@ -56,6 +56,9 @@ public class WardDTO {
 	private boolean isPharmacy;
 
 	@NotNull
+	private boolean isVirtual;
+
+	@NotNull
 	private boolean isMale;
 
 	@NotNull
@@ -103,6 +106,10 @@ public class WardDTO {
 
 	public boolean isPharmacy() {
 		return this.isPharmacy;
+	}
+
+	public boolean isVirtual() {
+		return this.isVirtual;
 	}
 
 	public boolean isMale() {
@@ -155,6 +162,10 @@ public class WardDTO {
 
 	public void setPharmacy(boolean isPharmacy) {
 		this.isPharmacy = isPharmacy;
+	}
+
+	public void setVirtual(boolean isVirtual) {
+		this.isVirtual = isVirtual;
 	}
 
 	public void setMale(boolean isMale) {


### PR DESCRIPTION
## OP-1358 — Define virtual supplier and virtual wards (Phase 1) — API

Depends on core PR informatici/openhospital-core#1615.

Adds the `virtual` boolean to `WardDTO` and `SupplierDTO` (auto-mapped by ModelMapper) and updates `openapi/oh.yaml`.

### Verified
ward/supplier controller tests green; OpenAPI check replicated locally (committed `oh.yaml` byte-equal to the spec generated from the running app).

Companion PRs: core informatici/openhospital-core#1615 · gui informatici/openhospital-gui#2218