### PR TITLE
OP-1242 Add REST resource for patient professions

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -514,6 +514,60 @@ paths:
                 $ref: "#/components/schemas/SupplierDTO"
       security:
       - bearerAuth: []
+  /professions:
+    get:
+      tags:
+      - Professions
+      operationId: getProfessions
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProfessionDTO"
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - Professions
+      operationId: updateProfession
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfessionDTO"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfessionDTO"
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - Professions
+      operationId: newProfession
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfessionDTO"
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfessionDTO"
+      security:
+      - bearerAuth: []
   /pricesothers/{id}:
     put:
       tags:
@@ -6075,6 +6129,26 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /professions/{code}:
+    delete:
+      tags:
+      - Professions
+      operationId: deleteProfession
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+      security:
+      - bearerAuth: []
   /operations/rows/{code}:
     delete:
       tags:
@@ -6281,13 +6355,13 @@ components:
           format: int32
           description: lock
           example: 0
-        female:
-          type: boolean
-        male:
+        pharmacy:
           type: boolean
         opd:
           type: boolean
-        pharmacy:
+        female:
+          type: boolean
+        male:
           type: boolean
       required:
       - beds
@@ -6715,6 +6789,21 @@ components:
       required:
       - supId
       - supName
+    ProfessionDTO:
+      type: object
+      description: Class representing a profession
+      properties:
+        code:
+          type: string
+          description: Profession code
+          maxLength: 50
+        description:
+          type: string
+          description: Profession description
+          maxLength: 50
+      required:
+      - code
+      - description
     PricesOthersDTO:
       type: object
       description: Class representing a price others

--- a/src/main/java/org/isf/profession/dto/ProfessionDTO.java
+++ b/src/main/java/org/isf/profession/dto/ProfessionDTO.java
@@ -1,0 +1,54 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Class representing a profession")
+public class ProfessionDTO {
+
+	@NotNull
+	@Schema(description = "Profession code", maxLength = 50)
+	private String code;
+
+	@NotNull
+	@Schema(description = "Profession description", maxLength = 50)
+	private String description;
+
+	public String getCode() {
+		return this.code;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/org/isf/profession/mapper/ProfessionMapper.java
+++ b/src/main/java/org/isf/profession/mapper/ProfessionMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.mapper;
+
+import org.isf.profession.dto.ProfessionDTO;
+import org.isf.profession.model.Profession;
+import org.isf.shared.GenericMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfessionMapper extends GenericMapper<Profession, ProfessionDTO> {
+	public ProfessionMapper() {
+		super(Profession.class, ProfessionDTO.class);
+	}
+}

--- a/src/main/java/org/isf/profession/rest/ProfessionController.java
+++ b/src/main/java/org/isf/profession/rest/ProfessionController.java
@@ -1,0 +1,138 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.rest;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.isf.profession.dto.ProfessionDTO;
+import org.isf.profession.manager.ProfessionBrowserManager;
+import org.isf.profession.mapper.ProfessionMapper;
+import org.isf.profession.model.Profession;
+import org.isf.shared.exceptions.OHAPIException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "Professions")
+@SecurityRequirement(name = "bearerAuth")
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+public class ProfessionController {
+
+	private final ProfessionBrowserManager professionManager;
+
+	private final ProfessionMapper mapper;
+
+	public ProfessionController(ProfessionBrowserManager professionManager, ProfessionMapper professionMapper) {
+		this.professionManager = professionManager;
+		this.mapper = professionMapper;
+	}
+
+	/**
+	 * Returns all the stored {@link Profession}s.
+	 * @return a list of professions.
+	 * @throws OHServiceException When failed to get professions
+	 */
+	@GetMapping(value = "/professions")
+	public List<ProfessionDTO> getProfessions() throws OHServiceException {
+		return mapper.map2DTOList(professionManager.getProfessions());
+	}
+
+	/**
+	 * Create a new {@link Profession}.
+	 * @param professionDTO Profession payload
+	 * @return the profession created
+	 * @throws OHServiceException - in case of duplicated code or in case of error
+	 */
+	@PostMapping(value = "/professions")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ProfessionDTO newProfession(
+		@Valid @RequestBody ProfessionDTO professionDTO
+	) throws OHServiceException {
+		Profession profession = mapper.map2Model(professionDTO);
+		if (professionManager.isCodePresent(profession.getCode())) {
+			throw new OHAPIException(new OHExceptionMessage("Specified Profession code is already used."));
+		}
+
+		try {
+			return mapper.map2DTO(professionManager.newProfession(profession));
+		} catch (OHServiceException serviceException) {
+			throw new OHAPIException(new OHExceptionMessage("Failed to create profession."), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Updates the specified {@link Profession}.
+	 * @param professionDTO - the profession to update.
+	 * @return the updated profession
+	 * @throws OHServiceException When failed to update profession
+	 */
+	@PutMapping(value = "/professions")
+	public ProfessionDTO updateProfession(@Valid @RequestBody ProfessionDTO professionDTO) throws OHServiceException {
+		Profession profession = mapper.map2Model(professionDTO);
+		if (!professionManager.isCodePresent(profession.getCode())) {
+			throw new OHAPIException(new OHExceptionMessage("Profession not found."), HttpStatus.NOT_FOUND);
+		}
+
+		try {
+			return mapper.map2DTO(professionManager.updateProfession(profession));
+		} catch (OHServiceException serviceException) {
+			throw new OHAPIException(new OHExceptionMessage("Profession not updated."), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Deletes the specified {@link Profession}.
+	 * @param code - the code of the profession to remove.
+	 * @return {@code true} if the profession has been removed, {@code false} otherwise.
+	 * @throws OHServiceException When failed to delete profession
+	 */
+	@DeleteMapping(value = "/professions/{code}")
+	public boolean deleteProfession(@PathVariable String code) throws OHServiceException {
+		Profession profession = professionManager.getProfession(code);
+		if (profession == null) {
+			throw new OHAPIException(new OHExceptionMessage("No Profession found with the given code."), HttpStatus.NOT_FOUND);
+		}
+
+		try {
+			professionManager.deleteProfession(profession);
+			return true;
+		} catch (OHServiceException e) {
+			return false;
+		}
+	}
+}

--- a/src/test/java/org/isf/profession/data/ProfessionHelper.java
+++ b/src/test/java/org/isf/profession/data/ProfessionHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.isf.profession.TestProfession;
+import org.isf.profession.dto.ProfessionDTO;
+import org.isf.profession.model.Profession;
+import org.isf.utils.exception.OHException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+public class ProfessionHelper {
+
+	private static ObjectMapper objectMapper;
+
+	public static Profession setup(int i) throws OHException {
+		TestProfession testProfession = new TestProfession();
+		Profession profession = testProfession.setup(false);
+		profession.setCode(profession.getCode() + i);
+		return profession;
+	}
+
+	public static List<Profession> setupProfessionList(int size) {
+		return IntStream.range(0, size)
+				.mapToObj(i -> {
+					try {
+						return ProfessionHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
+	}
+
+	public static String asJsonString(ProfessionDTO body) {
+		try {
+			return getObjectMapper().writeValueAsString(body);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static ObjectMapper getObjectMapper() {
+		if (objectMapper == null) {
+			objectMapper = new ObjectMapper()
+					.registerModule(new ParameterNamesModule())
+					.registerModule(new Jdk8Module())
+					.registerModule(new JavaTimeModule());
+		}
+		return objectMapper;
+	}
+
+}

--- a/src/test/java/org/isf/profession/rest/ProfessionControllerTest.java
+++ b/src/test/java/org/isf/profession/rest/ProfessionControllerTest.java
@@ -1,0 +1,188 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.profession.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.isf.profession.data.ProfessionHelper;
+import org.isf.profession.dto.ProfessionDTO;
+import org.isf.profession.manager.ProfessionBrowserManager;
+import org.isf.profession.mapper.ProfessionMapper;
+import org.isf.profession.model.Profession;
+import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
+import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
+import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class ProfessionControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProfessionControllerTest.class);
+
+	@Mock
+	protected ProfessionBrowserManager professionBrowserManager;
+
+	protected ProfessionMapper professionMapper = new ProfessionMapper();
+
+	private MockMvc mockMvc;
+
+	private AutoCloseable closeable;
+
+	@BeforeEach
+	void setup() {
+		closeable = MockitoAnnotations.openMocks(this);
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new ProfessionController(professionBrowserManager, professionMapper))
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+		ModelMapper modelMapper = new ModelMapper();
+		modelMapper.addConverter(new BlobToByteArrayConverter());
+		modelMapper.addConverter(new ByteArrayToBlobConverter());
+		ReflectionTestUtils.setField(professionMapper, "modelMapper", modelMapper);
+	}
+
+	@AfterEach
+	void closeService() throws Exception {
+		closeable.close();
+	}
+
+	@Test
+	void testGetProfessions_200() throws Exception {
+		String request = "/professions";
+
+		List<Profession> results = ProfessionHelper.setupProfessionList(3);
+
+		List<ProfessionDTO> parsedResults = professionMapper.map2DTOList(results);
+
+		when(professionBrowserManager.getProfessions())
+			.thenReturn(results);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(ProfessionHelper.getObjectMapper().writeValueAsString(parsedResults))))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewProfession_201() throws Exception {
+		String request = "/professions";
+		int code = 123;
+		Profession profession = ProfessionHelper.setup(code);
+		ProfessionDTO body = professionMapper.map2DTO(profession);
+
+		when(professionBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(false);
+
+		when(professionBrowserManager.newProfession(professionMapper.map2Model(body)))
+			.thenReturn(profession);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(ProfessionHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateProfession_200() throws Exception {
+		int code = 456;
+
+		Profession profession = ProfessionHelper.setup(code);
+		ProfessionDTO body = professionMapper.map2DTO(profession);
+		String request = "/professions";
+
+		when(professionBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(true);
+
+		when(professionBrowserManager.updateProfession(professionMapper.map2Model(body)))
+			.thenReturn(profession);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(ProfessionHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteProfession_200() throws Exception {
+		String request = "/professions/{code}";
+
+		ProfessionDTO body = professionMapper.map2DTO(ProfessionHelper.setup(0));
+		String code = body.getCode();
+
+		when(professionBrowserManager.getProfession(anyString()))
+			.thenReturn(ProfessionHelper.setupProfessionList(1).get(0));
+
+		String isDeleted = "true";
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(isDeleted)))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+}


### PR DESCRIPTION
## What changed

Expose the new Profession lookup table through a REST controller, mirroring the DiseaseType resource.

- Add `ProfessionController` (`/professions`: GET list, POST, PUT `/{code}`, DELETE) with `ProfessionDTO` and `ProfessionMapper`.
- Add `ProfessionControllerTest` and test helper.
- Regenerate `openapi/oh.yaml`.

## Tests

`ProfessionControllerTest` 4/4.

## Notes

Depends on informatici/openhospital-core#1616 (the Profession entity/manager) being merged first.