### PR TITLE
OP-1063 Insert laboratory exam via newLaboratory2 in LaboratoryController

### DIFF
--- a/src/main/java/org/isf/lab/rest/LaboratoryController.java
+++ b/src/main/java/org/isf/lab/rest/LaboratoryController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/lab/rest/LaboratoryController.java
+++ b/src/main/java/org/isf/lab/rest/LaboratoryController.java
@@ -140,12 +140,14 @@ public class LaboratoryController {
 		labToInsert.setPatient(patient);
 		labToInsert.setLock(0);
 		labToInsert.setInOutPatient(laboratoryDTO.getInOutPatient().toString());
-		List<String> labRows = new ArrayList<>();
+		List<LaboratoryRow> labRows = new ArrayList<>();
 		if (labRow != null) {
-			labRows = new ArrayList<>(labRow);
+			for (String rowDescription : labRow) {
+				labRows.add(new LaboratoryRow(labToInsert, rowDescription));
+			}
 		}
 		try {
-			laboratoryManager.newLaboratory(labToInsert, labRows);
+			laboratoryManager.newLaboratory2(labToInsert, labRows);
 		} catch (OHServiceException serviceException) {
 			throw new OHAPIException(new OHExceptionMessage("Laboratory not created."));
 		}

--- a/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
+++ b/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
+++ b/src/test/java/org/isf/lab/rest/LaboratoryControllerTest.java
@@ -125,7 +125,7 @@ class LaboratoryControllerTest {
 		labWithRowsDTO.setLaboratoryDTO(body);
 		labWithRowsDTO.setLaboratoryRowList(labRows);
 
-		when(laboratoryManager.newLaboratory(any(Laboratory.class), anyList())).thenReturn(lab);
+		when(laboratoryManager.newLaboratory2(any(Laboratory.class), anyList())).thenReturn(lab);
 		when(patientBrowserManager.getPatientById(anyInt())).thenReturn(patient);
 		when(examManager.getExams()).thenReturn(Collections.singletonList(lab.getExam()));
 
@@ -162,7 +162,7 @@ class LaboratoryControllerTest {
 		labWithRowsDTO.setLaboratoryDTO(body);
 		labWithRowsDTO.setLaboratoryRowList(labRows);
 
-		when(laboratoryManager.newLaboratory(any(Laboratory.class), anyList())).thenReturn(lab);
+		when(laboratoryManager.newLaboratory2(any(Laboratory.class), anyList())).thenReturn(lab);
 		when(laboratoryManager.getLaboratory(anyInt())).thenReturn(Optional.of(lab));
 		when(patientBrowserManager.getPatientById(anyInt())).thenReturn(patient);
 		when(examManager.getExams()).thenReturn(Collections.singletonList(lab.getExam()));
@@ -201,7 +201,7 @@ class LaboratoryControllerTest {
 		labWithRowsDTO.setLaboratoryDTO(body);
 		labWithRowsDTO.setLaboratoryRowList(labRows);
 
-		when(laboratoryManager.newLaboratory(any(Laboratory.class), anyList())).thenReturn(lab);
+		when(laboratoryManager.newLaboratory2(any(Laboratory.class), anyList())).thenReturn(lab);
 		when(laboratoryManager.getLaboratory(anyInt())).thenReturn(Optional.of(lab));
 		when(laboratoryManager.getLaboratory(any(Patient.class))).thenReturn(Collections.singletonList(lab));
 		when(patientBrowserManager.getPatientById(anyInt())).thenReturn(patient);


### PR DESCRIPTION
Part of OP-1063 (**core + GUI + API**). Since core removes the deprecated v1 String-based `LabManager.newLaboratory(...)` (keeping the `LaboratoryRow`-based v2), `POST /laboratories` converts the request's result descriptions into `LaboratoryRow` objects and calls `newLaboratory2`, mirroring the existing batch `newLaboratory2` endpoint.

Same branch name as the core PR so CI cross-builds the core fork branch. `LaboratoryControllerTest` updated; full API test suite green. Sibling PRs linked in a comment.
