### PR TITLE
OP-887 Add GET /patients/{code}/export for GDPR data portability

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -767,6 +767,31 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /patients/{code}/export:
+    get:
+      tags:
+      - Patients
+      description: GDPR Art. 20 - Right to data portability
+      operationId: exportPatientData
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PatientExportDTO"
+            text/csv:
+              schema:
+                type: string
+      security:
+      - bearerAuth: []
   /patientconsensus/{patientId}:
     get:
       tags:
@@ -6315,6 +6340,64 @@ components:
       - docs
       - nurs
       - visitDuration
+    PatientExportDTO:
+      type: object
+      description: "Aggregate of a patient record and all the records connected to\
+        \ it, for GDPR Art. 20 (right to data portability) exports"
+      properties:
+        patient:
+          $ref: "#/components/schemas/PatientDTO"
+          description: The patient record
+        admissions:
+          type: array
+          description: The admissions of the patient
+          items:
+            $ref: "#/components/schemas/AdmissionDTO"
+        opds:
+          type: array
+          description: The OPD episodes of the patient
+          items:
+            $ref: "#/components/schemas/OpdDTO"
+        laboratories:
+          type: array
+          description: The laboratory exams of the patient
+          items:
+            $ref: "#/components/schemas/LaboratoryDTO"
+        therapies:
+          type: array
+          description: The therapies of the patient
+          items:
+            $ref: "#/components/schemas/TherapyRowDTO"
+        operations:
+          type: array
+          description: The operations of the patient
+          items:
+            $ref: "#/components/schemas/OperationRowDTO"
+        vaccines:
+          type: array
+          description: The vaccines of the patient
+          items:
+            $ref: "#/components/schemas/PatientVaccineDTO"
+        examinations:
+          type: array
+          description: The examinations of the patient
+          items:
+            $ref: "#/components/schemas/PatientExaminationDTO"
+        bills:
+          type: array
+          description: The bills of the patient
+          items:
+            $ref: "#/components/schemas/BillDTO"
+        billItems:
+          type: array
+          description: The items of the patient's bills
+          items:
+            $ref: "#/components/schemas/BillItemsDTO"
+        billPayments:
+          type: array
+          description: The payments of the patient's bills
+          items:
+            $ref: "#/components/schemas/BillPaymentsDTO"
     PatientDTO:
       type: object
       description: Class representing a patient

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -233,6 +233,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
 				// patients
 				.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
+				.requestMatchers(HttpMethod.GET, "/patients/{code}/export").hasAuthority("patient.export")
 				.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
 				.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")
 				.requestMatchers(HttpMethod.DELETE, "/patients/**").hasAuthority("patients.delete")

--- a/src/main/java/org/isf/patient/dto/PatientExportDTO.java
+++ b/src/main/java/org/isf/patient/dto/PatientExportDTO.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/patient/dto/PatientExportDTO.java
+++ b/src/main/java/org/isf/patient/dto/PatientExportDTO.java
@@ -1,0 +1,162 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.dto;
+
+import java.util.List;
+
+import org.isf.accounting.dto.BillDTO;
+import org.isf.accounting.dto.BillItemsDTO;
+import org.isf.accounting.dto.BillPaymentsDTO;
+import org.isf.admission.dto.AdmissionDTO;
+import org.isf.examination.dto.PatientExaminationDTO;
+import org.isf.lab.dto.LaboratoryDTO;
+import org.isf.opd.dto.OpdDTO;
+import org.isf.operation.dto.OperationRowDTO;
+import org.isf.patvac.dto.PatientVaccineDTO;
+import org.isf.therapy.dto.TherapyRowDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Aggregate of a patient record and all the records connected to it, for GDPR Art. 20 (right to data portability) exports")
+public class PatientExportDTO {
+
+	@Schema(description = "The patient record")
+	private PatientDTO patient;
+
+	@Schema(description = "The admissions of the patient")
+	private List<AdmissionDTO> admissions;
+
+	@Schema(description = "The OPD episodes of the patient")
+	private List<OpdDTO> opds;
+
+	@Schema(description = "The laboratory exams of the patient")
+	private List<LaboratoryDTO> laboratories;
+
+	@Schema(description = "The therapies of the patient")
+	private List<TherapyRowDTO> therapies;
+
+	@Schema(description = "The operations of the patient")
+	private List<OperationRowDTO> operations;
+
+	@Schema(description = "The vaccines of the patient")
+	private List<PatientVaccineDTO> vaccines;
+
+	@Schema(description = "The examinations of the patient")
+	private List<PatientExaminationDTO> examinations;
+
+	@Schema(description = "The bills of the patient")
+	private List<BillDTO> bills;
+
+	@Schema(description = "The items of the patient's bills")
+	private List<BillItemsDTO> billItems;
+
+	@Schema(description = "The payments of the patient's bills")
+	private List<BillPaymentsDTO> billPayments;
+
+	public PatientDTO getPatient() {
+		return patient;
+	}
+
+	public void setPatient(PatientDTO patient) {
+		this.patient = patient;
+	}
+
+	public List<AdmissionDTO> getAdmissions() {
+		return admissions;
+	}
+
+	public void setAdmissions(List<AdmissionDTO> admissions) {
+		this.admissions = admissions;
+	}
+
+	public List<OpdDTO> getOpds() {
+		return opds;
+	}
+
+	public void setOpds(List<OpdDTO> opds) {
+		this.opds = opds;
+	}
+
+	public List<LaboratoryDTO> getLaboratories() {
+		return laboratories;
+	}
+
+	public void setLaboratories(List<LaboratoryDTO> laboratories) {
+		this.laboratories = laboratories;
+	}
+
+	public List<TherapyRowDTO> getTherapies() {
+		return therapies;
+	}
+
+	public void setTherapies(List<TherapyRowDTO> therapies) {
+		this.therapies = therapies;
+	}
+
+	public List<OperationRowDTO> getOperations() {
+		return operations;
+	}
+
+	public void setOperations(List<OperationRowDTO> operations) {
+		this.operations = operations;
+	}
+
+	public List<PatientVaccineDTO> getVaccines() {
+		return vaccines;
+	}
+
+	public void setVaccines(List<PatientVaccineDTO> vaccines) {
+		this.vaccines = vaccines;
+	}
+
+	public List<PatientExaminationDTO> getExaminations() {
+		return examinations;
+	}
+
+	public void setExaminations(List<PatientExaminationDTO> examinations) {
+		this.examinations = examinations;
+	}
+
+	public List<BillDTO> getBills() {
+		return bills;
+	}
+
+	public void setBills(List<BillDTO> bills) {
+		this.bills = bills;
+	}
+
+	public List<BillItemsDTO> getBillItems() {
+		return billItems;
+	}
+
+	public void setBillItems(List<BillItemsDTO> billItems) {
+		this.billItems = billItems;
+	}
+
+	public List<BillPaymentsDTO> getBillPayments() {
+		return billPayments;
+	}
+
+	public void setBillPayments(List<BillPaymentsDTO> billPayments) {
+		this.billPayments = billPayments;
+	}
+}

--- a/src/main/java/org/isf/patient/mapper/PatientExportMapper.java
+++ b/src/main/java/org/isf/patient/mapper/PatientExportMapper.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/patient/mapper/PatientExportMapper.java
+++ b/src/main/java/org/isf/patient/mapper/PatientExportMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.mapper;
+
+import org.isf.accounting.mapper.BillItemsMapper;
+import org.isf.accounting.mapper.BillMapper;
+import org.isf.accounting.mapper.BillPaymentsMapper;
+import org.isf.admission.mapper.AdmissionMapper;
+import org.isf.examination.mapper.PatientExaminationMapper;
+import org.isf.lab.mapper.LaboratoryMapper;
+import org.isf.opd.mapper.OpdMapper;
+import org.isf.operation.mapper.OperationRowMapper;
+import org.isf.patient.dto.PatientDTO;
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.dto.PatientExportDTO;
+import org.isf.patvac.mapper.PatVacMapper;
+import org.isf.therapy.mapper.TherapyRowMapper;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assembles a {@link PatientExportDTO} out of a {@link PatientExport} aggregate, delegating each
+ * entity group to its existing mapper.
+ */
+@Component
+public class PatientExportMapper {
+
+	private final PatientMapper patientMapper;
+
+	private final AdmissionMapper admissionMapper;
+
+	private final OpdMapper opdMapper;
+
+	private final LaboratoryMapper laboratoryMapper;
+
+	private final TherapyRowMapper therapyRowMapper;
+
+	private final OperationRowMapper operationRowMapper;
+
+	private final PatVacMapper patVacMapper;
+
+	private final PatientExaminationMapper patientExaminationMapper;
+
+	private final BillMapper billMapper;
+
+	private final BillItemsMapper billItemsMapper;
+
+	private final BillPaymentsMapper billPaymentsMapper;
+
+	public PatientExportMapper(PatientMapper patientMapper, AdmissionMapper admissionMapper, OpdMapper opdMapper, LaboratoryMapper laboratoryMapper,
+		TherapyRowMapper therapyRowMapper, OperationRowMapper operationRowMapper, PatVacMapper patVacMapper,
+		PatientExaminationMapper patientExaminationMapper, BillMapper billMapper, BillItemsMapper billItemsMapper, BillPaymentsMapper billPaymentsMapper) {
+		this.patientMapper = patientMapper;
+		this.admissionMapper = admissionMapper;
+		this.opdMapper = opdMapper;
+		this.laboratoryMapper = laboratoryMapper;
+		this.therapyRowMapper = therapyRowMapper;
+		this.operationRowMapper = operationRowMapper;
+		this.patVacMapper = patVacMapper;
+		this.patientExaminationMapper = patientExaminationMapper;
+		this.billMapper = billMapper;
+		this.billItemsMapper = billItemsMapper;
+		this.billPaymentsMapper = billPaymentsMapper;
+	}
+
+	public PatientExportDTO map2DTO(PatientExport export) {
+		PatientExportDTO dto = new PatientExportDTO();
+		dto.setPatient(stripPhoto(patientMapper.map2DTO(export.getPatient())));
+		dto.setAdmissions(admissionMapper.map2DTOList(export.getAdmissions()));
+		dto.getAdmissions().forEach(admission -> stripPhoto(admission.getPatient()));
+		dto.setOpds(opdMapper.map2DTOList(export.getOpds()));
+		dto.setLaboratories(laboratoryMapper.map2DTOList(export.getLaboratories()));
+		dto.setTherapies(therapyRowMapper.map2DTOList(export.getTherapies()));
+		dto.getTherapies().forEach(therapy -> stripPhoto(therapy.getPatID()));
+		dto.setOperations(operationRowMapper.map2DTOList(export.getOperations()));
+		dto.getOperations().forEach(operation -> {
+			if (operation.getAdmission() != null) {
+				stripPhoto(operation.getAdmission().getPatient());
+			}
+			if (operation.getBill() != null) {
+				stripPhoto(operation.getBill().getPatient());
+			}
+		});
+		dto.setVaccines(patVacMapper.map2DTOList(export.getVaccines()));
+		dto.getVaccines().forEach(vaccine -> stripPhoto(vaccine.getPatient()));
+		dto.setExaminations(patientExaminationMapper.map2DTOList(export.getExaminations()));
+		dto.setBills(billMapper.map2DTOList(export.getBills()));
+		dto.getBills().forEach(bill -> stripPhoto(bill.getPatient()));
+		dto.setBillItems(billItemsMapper.map2DTOList(export.getBillItems()));
+		dto.setBillPayments(billPaymentsMapper.map2DTOList(export.getBillPayments()));
+		return dto;
+	}
+
+	/**
+	 * The profile photo is intentionally not part of the export (see AdminManual, GDPR - Data Portability).
+	 */
+	private PatientDTO stripPhoto(PatientDTO patientDTO) {
+		if (patientDTO != null) {
+			patientDTO.setBlobPhoto(null);
+		}
+		return patientDTO;
+	}
+}

--- a/src/main/java/org/isf/patient/rest/PatientExportController.java
+++ b/src/main/java/org/isf/patient/rest/PatientExportController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/patient/rest/PatientExportController.java
+++ b/src/main/java/org/isf/patient/rest/PatientExportController.java
@@ -1,0 +1,139 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.rest;
+
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.dto.PatientExportDTO;
+import org.isf.patient.manager.PatientExportManager;
+import org.isf.patient.mapper.PatientExportMapper;
+import org.isf.shared.exceptions.OHAPIException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "Patients")
+@SecurityRequirement(name = "bearerAuth")
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+public class PatientExportController {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PatientExportController.class);
+
+	private static final MediaType TEXT_CSV = MediaType.parseMediaType("text/csv");
+
+	private final PatientExportManager patientExportManager;
+
+	private final PatientExportMapper patientExportMapper;
+
+	private final PatientExportCsv patientExportCsv;
+
+	public PatientExportController(PatientExportManager patientExportManager, PatientExportMapper patientExportMapper, PatientExportCsv patientExportCsv) {
+		this.patientExportManager = patientExportManager;
+		this.patientExportMapper = patientExportMapper;
+		this.patientExportCsv = patientExportCsv;
+	}
+
+	/**
+	 * Export the {@link org.isf.patient.model.Patient} record and all the records connected to it, in an open
+	 * format: JSON by default, CSV when the {@code Accept} header asks for {@code text/csv}.
+	 *
+	 * @param code the code of the patient to export
+	 * @param accept the {@code Accept} header of the request
+	 * @return the {@link PatientExportDTO} as JSON, or its CSV rendering
+	 * @throws OHServiceException When failed to export the patient data
+	 */
+	@GetMapping(value = "/patients/{code}/export", produces = { MediaType.APPLICATION_JSON_VALUE, "text/csv" })
+	@Operation(description = "GDPR Art. 20 - Right to data portability")
+	@ApiResponse(responseCode = "200", content = {
+		@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PatientExportDTO.class)),
+		@Content(mediaType = "text/csv", schema = @Schema(type = "string"))
+	})
+	public ResponseEntity<?> exportPatientData(
+		@PathVariable("code") int code,
+		@Parameter(hidden = true) @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept
+	) throws OHServiceException {
+		LOGGER.info("Export patient data for code: '{}'.", code);
+		PatientExport export = patientExportManager.exportPatientData(code);
+		if (export == null) {
+			throw new OHAPIException(new OHExceptionMessage("Patient not found."), HttpStatus.NOT_FOUND);
+		}
+		PatientExportDTO exportDTO = patientExportMapper.map2DTO(export);
+		if (isCsvRequested(accept)) {
+			String csv;
+			try {
+				csv = patientExportCsv.toCsv(exportDTO);
+			} catch (JsonProcessingException jsonProcessingException) {
+				LOGGER.error("Export patient data for code '{}' failed.", code, jsonProcessingException);
+				throw new OHAPIException(new OHExceptionMessage("Patient data not exported."));
+			}
+			return ResponseEntity.ok()
+				.contentType(TEXT_CSV)
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"patient_" + code + "_export.csv\"")
+				.body(csv);
+		}
+		return ResponseEntity.ok(exportDTO);
+	}
+
+	/**
+	 * Whether the {@code Accept} header asks for CSV. Media types are evaluated in header order:
+	 * JSON (the default, also chosen for {@code Accept: *&#47;*} or no header) wins over a later CSV entry.
+	 */
+	private boolean isCsvRequested(String accept) {
+		if (accept == null || accept.isBlank()) {
+			return false;
+		}
+		try {
+			for (MediaType mediaType : MediaType.parseMediaTypes(accept)) {
+				if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+					return false;
+				}
+				if (mediaType.isCompatibleWith(TEXT_CSV)) {
+					return true;
+				}
+			}
+		} catch (InvalidMediaTypeException invalidMediaTypeException) {
+			return false;
+		}
+		return false;
+	}
+}

--- a/src/main/java/org/isf/patient/rest/PatientExportCsv.java
+++ b/src/main/java/org/isf/patient/rest/PatientExportCsv.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/patient/rest/PatientExportCsv.java
+++ b/src/main/java/org/isf/patient/rest/PatientExportCsv.java
@@ -1,0 +1,116 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.isf.patient.dto.PatientExportDTO;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Renders a {@link PatientExportDTO} as CSV (RFC 4180 quoting rules). The output contains one section per
+ * entity group: a {@code # <group>} marker line, a header row with the union of the keys of the group rows
+ * (in first-occurrence order), one data row per record and a blank line between sections. Nested objects and
+ * lists are serialized as compact JSON inside the field.
+ */
+@Component
+public class PatientExportCsv {
+
+	private static final String CRLF = "\r\n";
+
+	private final ObjectMapper objectMapper;
+
+	public PatientExportCsv(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	public String toCsv(PatientExportDTO export) throws JsonProcessingException {
+		StringBuilder csv = new StringBuilder();
+		writeSection(csv, "patient", export.getPatient() == null ? List.of() : List.of(export.getPatient()));
+		writeSection(csv, "admissions", export.getAdmissions());
+		writeSection(csv, "opds", export.getOpds());
+		writeSection(csv, "laboratories", export.getLaboratories());
+		writeSection(csv, "therapies", export.getTherapies());
+		writeSection(csv, "operations", export.getOperations());
+		writeSection(csv, "vaccines", export.getVaccines());
+		writeSection(csv, "examinations", export.getExaminations());
+		writeSection(csv, "bills", export.getBills());
+		writeSection(csv, "billItems", export.getBillItems());
+		writeSection(csv, "billPayments", export.getBillPayments());
+		return csv.toString();
+	}
+
+	private void writeSection(StringBuilder csv, String group, List<?> rows) throws JsonProcessingException {
+		if (csv.length() > 0) {
+			csv.append(CRLF);
+		}
+		csv.append("# ").append(group).append(CRLF);
+		List<Map<String, Object>> flatRows = new ArrayList<>();
+		Set<String> keys = new LinkedHashSet<>();
+		if (rows != null) {
+			for (Object row : rows) {
+				Map<String, Object> flatRow = objectMapper.convertValue(row, new TypeReference<LinkedHashMap<String, Object>>() {
+				});
+				keys.addAll(flatRow.keySet());
+				flatRows.add(flatRow);
+			}
+		}
+		if (keys.isEmpty()) {
+			return;
+		}
+		csv.append(String.join(",", keys.stream().map(this::escape).toList())).append(CRLF);
+		for (Map<String, Object> flatRow : flatRows) {
+			List<String> values = new ArrayList<>();
+			for (String key : keys) {
+				values.add(escape(render(flatRow.get(key))));
+			}
+			csv.append(String.join(",", values)).append(CRLF);
+		}
+	}
+
+	private String render(Object value) throws JsonProcessingException {
+		if (value == null) {
+			return "";
+		}
+		if (value instanceof Map || value instanceof Collection) {
+			return objectMapper.writeValueAsString(value);
+		}
+		return String.valueOf(value);
+	}
+
+	private String escape(String value) {
+		if (value.contains(",") || value.contains("\"") || value.contains("\r") || value.contains("\n")) {
+			return '"' + value.replace("\"", "\"\"") + '"';
+		}
+		return value;
+	}
+}

--- a/src/main/java/org/isf/patient/rest/PatientExportCsv.java
+++ b/src/main/java/org/isf/patient/rest/PatientExportCsv.java
@@ -108,9 +108,15 @@ public class PatientExportCsv {
 	}
 
 	private String escape(String value) {
-		if (value.contains(",") || value.contains("\"") || value.contains("\r") || value.contains("\n")) {
-			return '"' + value.replace("\"", "\"\"") + '"';
+		String sanitized = value;
+		// Neutralize CSV formula injection: spreadsheet applications interpret a cell starting with =, +, -,
+		// @, tab or carriage return as a formula, so such values are prefixed with a single quote.
+		if (!sanitized.isEmpty() && "=+-@\t\r".indexOf(sanitized.charAt(0)) >= 0) {
+			sanitized = "'" + sanitized;
 		}
-		return value;
+		if (sanitized.contains(",") || sanitized.contains("\"") || sanitized.contains("\r") || sanitized.contains("\n")) {
+			return '"' + sanitized.replace("\"", "\"\"") + '"';
+		}
+		return sanitized;
 	}
 }

--- a/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
+++ b/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2023 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
+++ b/src/main/java/org/isf/patvac/mapper/PatVacMapper.java
@@ -21,6 +21,8 @@
  */
 package org.isf.patvac.mapper;
 
+import jakarta.annotation.PostConstruct;
+
 import org.isf.patvac.dto.PatientVaccineDTO;
 import org.isf.patvac.model.PatientVaccine;
 import org.isf.shared.GenericMapper;
@@ -30,5 +32,13 @@ import org.springframework.stereotype.Component;
 public class PatVacMapper extends GenericMapper<PatientVaccine, PatientVaccineDTO> {
 	public PatVacMapper() {
 		super(PatientVaccine.class, PatientVaccineDTO.class);
+	}
+
+	@PostConstruct
+	private void postConstruct() {
+		// pin the mapping of the "vaccine" property: implicit matching resolves it to the
+		// LocalDateTime "vaccineDate" property and fails at map time
+		modelMapper.typeMap(PatientVaccine.class, PatientVaccineDTO.class)
+			.addMappings(mapper -> mapper.map(PatientVaccine::getVaccine, PatientVaccineDTO::setVaccine));
 	}
 }

--- a/src/test/java/org/isf/patient/rest/PatientExportControllerTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientExportControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/patient/rest/PatientExportControllerTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientExportControllerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.isf.OpenHospitalApiApplication;
+import org.isf.accounting.TestBillItems;
+import org.isf.accounting.TestBillPayments;
+import org.isf.accounting.data.BillHelper;
+import org.isf.accounting.model.Bill;
+import org.isf.admission.data.AdmissionHelper;
+import org.isf.examination.TestPatientExamination;
+import org.isf.lab.data.LaboratoryHelper;
+import org.isf.medicals.TestMedical;
+import org.isf.medicals.model.Medical;
+import org.isf.medtype.TestMedicalType;
+import org.isf.opd.data.OpdHelper;
+import org.isf.operation.TestOperationRow;
+import org.isf.operation.data.OperationHelper;
+import org.isf.patient.data.PatientHelper;
+import org.isf.patient.dto.PatientExport;
+import org.isf.patient.manager.PatientExportManager;
+import org.isf.patient.mapper.PatientExportMapper;
+import org.isf.patient.model.Patient;
+import org.isf.patvac.TestPatientVaccine;
+import org.isf.therapy.TestTherapy;
+import org.isf.utils.exception.OHException;
+import org.isf.vaccine.TestVaccine;
+import org.isf.vaccine.model.Vaccine;
+import org.isf.vactype.TestVaccineType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest(classes = OpenHospitalApiApplication.class)
+@AutoConfigureMockMvc
+class PatientExportControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PatientExportControllerTest.class);
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PatientExportMapper patientExportMapper;
+
+	@MockitoBean
+	private PatientExportManager patientExportManager;
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patient.export" })
+	@DisplayName("Export patient data as JSON")
+	void exportPatientDataAsJson() throws Exception {
+		PatientExport export = setupPatientExport();
+
+		when(patientExportManager.exportPatientData(anyInt())).thenReturn(export);
+
+		var result = mvc.perform(
+				get("/patients/{code}/export", 1))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(content().json(objectMapper.writeValueAsString(patientExportMapper.map2DTO(export))))
+			.andExpect(jsonPath("$.patient").exists())
+			.andExpect(jsonPath("$.patient.blobPhoto").isEmpty())
+			.andExpect(jsonPath("$.admissions").isNotEmpty())
+			.andExpect(jsonPath("$.opds").isNotEmpty())
+			.andExpect(jsonPath("$.laboratories").isNotEmpty())
+			.andExpect(jsonPath("$.therapies").isNotEmpty())
+			.andExpect(jsonPath("$.operations").isNotEmpty())
+			.andExpect(jsonPath("$.vaccines").isNotEmpty())
+			.andExpect(jsonPath("$.vaccines[0].vaccine").exists())
+			.andExpect(jsonPath("$.examinations").isNotEmpty())
+			.andExpect(jsonPath("$.bills").isNotEmpty())
+			.andExpect(jsonPath("$.billItems").isNotEmpty())
+			.andExpect(jsonPath("$.billPayments").isNotEmpty())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patient.export" })
+	@DisplayName("Export patient data as JSON when the Accept header allows any media type")
+	void exportPatientDataAsJsonWhenAcceptingAnyMediaType() throws Exception {
+		when(patientExportManager.exportPatientData(anyInt())).thenReturn(setupPatientExport());
+
+		mvc.perform(
+				get("/patients/{code}/export", 1).header(HttpHeaders.ACCEPT, MediaType.ALL_VALUE))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patient.export" })
+	@DisplayName("Export patient data as CSV")
+	void exportPatientDataAsCsv() throws Exception {
+		when(patientExportManager.exportPatientData(anyInt())).thenReturn(setupPatientExport());
+
+		var result = mvc.perform(
+				get("/patients/{code}/export", 1).header(HttpHeaders.ACCEPT, "text/csv"))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith("text/csv"))
+			.andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"patient_1_export.csv\""))
+			.andExpect(content().string(containsString("# patient")))
+			.andExpect(content().string(containsString("# admissions")))
+			.andExpect(content().string(containsString("# opds")))
+			.andExpect(content().string(containsString("# laboratories")))
+			.andExpect(content().string(containsString("# therapies")))
+			.andExpect(content().string(containsString("# operations")))
+			.andExpect(content().string(containsString("# vaccines")))
+			.andExpect(content().string(containsString("# examinations")))
+			.andExpect(content().string(containsString("# bills")))
+			.andExpect(content().string(containsString("# billItems")))
+			.andExpect(content().string(containsString("# billPayments")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patient.export" })
+	@DisplayName("Export patient data as CSV when the Accept header carries media type parameters")
+	void exportPatientDataAsCsvWithMediaTypeParameters() throws Exception {
+		when(patientExportManager.exportPatientData(anyInt())).thenReturn(setupPatientExport());
+
+		mvc.perform(
+				get("/patients/{code}/export", 1).header(HttpHeaders.ACCEPT, "text/csv;q=0.9"))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith("text/csv"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patients.read" })
+	@DisplayName("Should fail to export patient data without the patient.export permission")
+	void shouldFailToExportPatientDataWithoutPermission() throws Exception {
+		mvc.perform(
+				get("/patients/{code}/export", 1))
+			.andDo(log())
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "patient.export" })
+	@DisplayName("Should fail to export patient data when the patient is not found")
+	void shouldFailToExportPatientDataWhenPatientNotFound() throws Exception {
+		when(patientExportManager.exportPatientData(anyInt())).thenReturn(null);
+
+		mvc.perform(
+				get("/patients/{code}/export", 1))
+			.andDo(log())
+			.andExpect(status().isNotFound());
+	}
+
+	private PatientExport setupPatientExport() throws OHException {
+		Patient patient = PatientHelper.setup();
+		patient.setCode(1);
+		PatientExport export = new PatientExport();
+		export.setPatient(patient);
+		export.setAdmissions(List.of(AdmissionHelper.setup()));
+		export.setOpds(List.of(OpdHelper.setup()));
+		export.setLaboratories(List.of(LaboratoryHelper.setup()));
+		Medical medical = new TestMedical().setup(new TestMedicalType().setup(false), false);
+		medical.setCode(1);
+		export.setTherapies(List.of(new TestTherapy().setup(patient, medical, true)));
+		export.setOperations(List.of(new TestOperationRow().setup(OperationHelper.setup(), true)));
+		Vaccine vaccine = new TestVaccine().setup(new TestVaccineType().setup(false), false);
+		export.setVaccines(List.of(new TestPatientVaccine().setup(patient, vaccine, true)));
+		export.setExaminations(List.of(new TestPatientExamination().setup(patient, true)));
+		Bill bill = BillHelper.setup(1);
+		export.setBills(List.of(bill));
+		export.setBillItems(List.of(new TestBillItems().setup(bill, true)));
+		export.setBillPayments(List.of(new TestBillPayments().setup(bill, true)));
+		return export;
+	}
+}

--- a/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
@@ -69,4 +69,18 @@ class PatientExportCsvTest {
 		assertThat(csv).contains("# billItems");
 		assertThat(csv).contains("# billPayments");
 	}
+
+	@Test
+	void neutralizesCsvFormulaInjection() throws Exception {
+		PatientDTO patientDTO = new PatientDTO();
+		patientDTO.setFirstName("=1+2");
+		patientDTO.setSecondName("+SUM(A1)");
+		PatientExportDTO export = new PatientExportDTO();
+		export.setPatient(patientDTO);
+
+		String csv = patientExportCsv.toCsv(export);
+
+		assertThat(csv).contains("'=1+2");
+		assertThat(csv).contains("'+SUM(A1)");
+	}
 }

--- a/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientExportCsvTest.java
@@ -1,0 +1,72 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.patient.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.isf.patient.dto.PatientDTO;
+import org.isf.patient.dto.PatientExportDTO;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class PatientExportCsvTest {
+
+	private final PatientExportCsv patientExportCsv = new PatientExportCsv(new ObjectMapper());
+
+	@Test
+	void quotesFieldsContainingSeparatorsQuotesAndNewlines() throws Exception {
+		PatientDTO patientDTO = new PatientDTO();
+		patientDTO.setFirstName("John, \"JJ\"\nJunior");
+		patientDTO.setSecondName("Doe");
+		PatientExportDTO export = new PatientExportDTO();
+		export.setPatient(patientDTO);
+
+		String csv = patientExportCsv.toCsv(export);
+
+		assertThat(csv).contains("\"John, \"\"JJ\"\"\nJunior\"");
+		assertThat(csv).contains("Doe");
+	}
+
+	@Test
+	void writesOneSectionPerEntityGroup() throws Exception {
+		PatientExportDTO export = new PatientExportDTO();
+		export.setPatient(new PatientDTO());
+		export.setAdmissions(List.of());
+
+		String csv = patientExportCsv.toCsv(export);
+
+		assertThat(csv).contains("# patient");
+		assertThat(csv).contains("# admissions");
+		assertThat(csv).contains("# opds");
+		assertThat(csv).contains("# laboratories");
+		assertThat(csv).contains("# therapies");
+		assertThat(csv).contains("# operations");
+		assertThat(csv).contains("# vaccines");
+		assertThat(csv).contains("# examinations");
+		assertThat(csv).contains("# bills");
+		assertThat(csv).contains("# billItems");
+		assertThat(csv).contains("# billPayments");
+	}
+}


### PR DESCRIPTION
See [OP-887](https://openhospital.atlassian.net/browse/OP-887). Depends on informatici/openhospital-core#1633 (same branch name, so this PR's CI cross-builds against that core branch).

`GET /patients/{code}/export` returns the full patient aggregate as JSON; with `Accept: text/csv` it returns a CSV rendering — one RFC-4180 section per entity group with `# <group>` marker lines, CRLF, and an attachment `Content-Disposition` (`patient_<code>_export.csv`). Media types are evaluated in header order, JSON winning when both are acceptable (q-values are not weighted; documented in the javadoc). The endpoint requires the new `patient.export` authority: the SecurityConfig rule is placed before the generic `GET /patients/**` matcher. `@Operation(description = "GDPR Art. 20 - Right to data portability")` per the ticket.

`openapi/oh.yaml` was regenerated and verified byte-identical (sorted-JSON compare) to the springdoc output of the running application.

This PR also fixes a pre-existing production bug surfaced while wiring the mapper: the shared ModelMapper mis-resolved `PatientVaccine.vaccine` onto `vaccineDate`, so `GET/POST/PUT /patientvaccines` failed with a MappingException for any record with a non-null vaccine date. Pinned with an explicit typeMap in `PatVacMapper`; an audit of other implicit GenericMapper matches may be worth a follow-up ticket.

Verified: controller and CSV tests green, full suite green (237 tests); live end-to-end on the demo database — 200 JSON with all entity groups populated (vaccines included, per the ticket's note), 200 CSV, 404 for an unknown patient, 403 for a user whose group lacks the permission.


[OP-887]: https://openhospital.atlassian.net/browse/OP-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ