### PR TITLE
OP-1244 Improve test coverage for org.isf.agetype.rest

### DIFF
--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -139,7 +139,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateAgeType_nullCode_400() throws Exception {
+	void updateAgeType_nullCode_400() throws Exception {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
@@ -159,7 +159,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateAgeType_emptyCode_400() throws Exception {
+	void updateAgeType_emptyCode_400() throws Exception {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
@@ -179,7 +179,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateAgeType_unknownCode_400() throws Exception {
+	void updateAgeType_unknownCode_400() throws Exception {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
@@ -200,7 +200,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateAgeType_getTypeByCodeFails_500() throws Exception {
+	void updateAgeType_getTypeByCodeFails_500() throws Exception {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
@@ -221,7 +221,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateAgeType_500() throws Exception {
+	void updateAgeType_500() throws Exception {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(3);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
@@ -265,7 +265,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testGetAgeTypeCodeByAge_200_noMatchingCode() throws Exception {
+	void getAgeTypeCodeByAge_200_noMatchingCode() throws Exception {
 
 		String request = "/agetypes/code?age={age}";
 		int age = 200;
@@ -306,7 +306,7 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
-	void testGetAgeTypeByIndex_404() throws Exception {
+	void getAgeTypeByIndex_404() throws Exception {
 		String request = "/agetypes/{index}";
 		int index = 25;
 

--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -145,17 +146,15 @@ class AgeTypeControllerTest {
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
 		body.get(0).setCode(null);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("The age type with code null is not valid.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("The age type with code null is not valid."));
 	}
 
 	@Test
@@ -163,19 +162,18 @@ class AgeTypeControllerTest {
 		String request = "/agetypes";
 		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
 		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
-		body.get(0).setCode("   ");
+		String code = "   ";
+		body.get(0).setCode(code);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("is not valid.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("The age type with code " + code + " is not valid."));
 	}
 
 	@Test
@@ -186,17 +184,15 @@ class AgeTypeControllerTest {
 
 		when(ageTypeManagerMock.getTypeByCode(anyString())).thenReturn(null);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("is not valid.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("The age type with code " + body.get(0).getCode() + " is not valid."));
 	}
 
 	@Test
@@ -207,17 +203,15 @@ class AgeTypeControllerTest {
 
 		when(ageTypeManagerMock.getTypeByCode(anyString())).thenThrow(new OHServiceException(new OHExceptionMessage("Unable to get age type")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Unable to get age type")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Unable to get age type"));
 	}
 
 	@Test
@@ -229,17 +223,15 @@ class AgeTypeControllerTest {
 		when(ageTypeManagerMock.getTypeByCode(anyString())).thenReturn(ageTypes.get(0));
 		when(ageTypeManagerMock.updateAgeType(anyList())).thenThrow(new OHServiceException(new OHExceptionMessage("Update failed")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Unable to update age types")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Unable to update age types. Please check that you've correctly set values"));
 	}
 
 	@Test
@@ -273,15 +265,11 @@ class AgeTypeControllerTest {
 		when(ageTypeManagerMock.getTypeByAge(age))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(get(request, age))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().json("{}"))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("{}"));
 	}
 
 	@Test
@@ -313,14 +301,11 @@ class AgeTypeControllerTest {
 		when(ageTypeManagerMock.getTypeByCode(index))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, index))
+		this.mockMvc
+			.perform(get(request, index).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("Age type not found with index :" + index)))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Age type not found with index :" + index));
 	}
 
 }

--- a/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
+++ b/src/test/java/org/isf/agetype/rest/AgeTypeControllerTest.java
@@ -23,6 +23,7 @@ package org.isf.agetype.rest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -42,6 +43,8 @@ import org.isf.agetype.model.AgeType;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -136,6 +139,110 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
+	void testUpdateAgeType_nullCode_400() throws Exception {
+		String request = "/agetypes";
+		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
+		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
+		body.get(0).setCode(null);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("The age type with code null is not valid.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateAgeType_emptyCode_400() throws Exception {
+		String request = "/agetypes";
+		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
+		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
+		body.get(0).setCode("   ");
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("is not valid.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateAgeType_unknownCode_400() throws Exception {
+		String request = "/agetypes";
+		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
+		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
+
+		when(ageTypeManagerMock.getTypeByCode(anyString())).thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("is not valid.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateAgeType_getTypeByCodeFails_500() throws Exception {
+		String request = "/agetypes";
+		List<AgeType> ageTypes = AgeTypeHelper.genList(1);
+		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
+
+		when(ageTypeManagerMock.getTypeByCode(anyString())).thenThrow(new OHServiceException(new OHExceptionMessage("Unable to get age type")));
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Unable to get age type")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateAgeType_500() throws Exception {
+		String request = "/agetypes";
+		List<AgeType> ageTypes = AgeTypeHelper.genList(3);
+		List<AgeTypeDTO> body = ageTypeMapper.map2DTOList(ageTypes);
+
+		when(ageTypeManagerMock.getTypeByCode(anyString())).thenReturn(ageTypes.get(0));
+		when(ageTypeManagerMock.updateAgeType(anyList())).thenThrow(new OHServiceException(new OHExceptionMessage("Update failed")));
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(objectMapper.writeValueAsString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Unable to update age types")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testGetAgeTypeCodeByAge_200() throws Exception {
 
 		String request = "/agetypes/code?age={age}";
@@ -158,6 +265,26 @@ class AgeTypeControllerTest {
 	}
 
 	@Test
+	void testGetAgeTypeCodeByAge_200_noMatchingCode() throws Exception {
+
+		String request = "/agetypes/code?age={age}";
+		int age = 200;
+
+		when(ageTypeManagerMock.getTypeByAge(age))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, age))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().json("{}"))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testGetAgeTypeByIndex_200() throws Exception {
 		String request = "/agetypes/{index}";
 		int index = 10;
@@ -173,6 +300,24 @@ class AgeTypeControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString(AgeTypeHelper.getObjectMapper().writeValueAsString(ageTypeDTO))))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetAgeTypeByIndex_404() throws Exception {
+		String request = "/agetypes/{index}";
+		int index = 25;
+
+		when(ageTypeManagerMock.getTypeByCode(index))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, index))
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("Age type not found with index :" + index)))
 			.andReturn();
 
 		LOGGER.debug("result: {}", result);


### PR DESCRIPTION
See [OP-1244](https://openhospital.atlassian.net/browse/OP-1244) (parent OP-1237: bring each listed package to at least 80% line coverage).

Improves line coverage of `org.isf.agetype.rest` from **70.6% to 100%** (branches 10/10, measured with jacoco 0.8.12) by extending the existing `AgeTypeControllerTest` with 7 tests covering the previously untested error paths of `PUT /agetypes` (null/empty/unknown code → 400, lookup failure and manager update failure → 500) and the miss branches of the age-code lookups (`GET /agetypes/code` returning no match, GET by index returning null → 404).

Note: the no-matching-age test pins the controller's current behavior of returning 200 with an empty JSON body rather than 404 — the test documents existing behavior rather than endorsing it. Only the test file is touched; 11/11 tests green.


[OP-1244]: https://openhospital.atlassian.net/browse/OP-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ