### PR TITLE
OP-1245 Improve test coverage for org.isf.disease.rest

### DIFF
--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -381,14 +382,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseOpd())
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request))
+		this.mockMvc
+			.perform(get(request).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting OPD diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting OPD diseases."));
 	}
 
 	@Test
@@ -400,14 +398,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseOpd(typeCode))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
+		this.mockMvc
+			.perform(get(request, typeCode).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting OPD diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting OPD diseases."));
 	}
 
 	@Test
@@ -417,14 +412,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut())
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request))
+		this.mockMvc
+			.perform(get(request).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting IPD out diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting IPD out diseases."));
 	}
 
 	@Test
@@ -436,14 +428,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut(typeCode))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
+		this.mockMvc
+			.perform(get(request, typeCode).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting IPD out diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting IPD out diseases."));
 	}
 
 	@Test
@@ -453,14 +442,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseIpdIn())
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request))
+		this.mockMvc
+			.perform(get(request).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting IPD-in diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting IPD-in diseases."));
 	}
 
 	@Test
@@ -472,14 +458,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseIpdIn(typeCode))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
+		this.mockMvc
+			.perform(get(request, typeCode).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting IPD-in diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting IPD-in diseases."));
 	}
 
 	@Test
@@ -489,14 +472,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDisease())
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request))
+		this.mockMvc
+			.perform(get(request).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting diseases."));
 	}
 
 	@Test
@@ -508,14 +488,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDisease(typeCode))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, typeCode))
+		this.mockMvc
+			.perform(get(request, typeCode).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting diseases by type code.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting diseases by type code."));
 	}
 
 	@Test
@@ -525,14 +502,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseAll())
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request))
+		this.mockMvc
+			.perform(get(request).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Error getting all diseases.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Error getting all diseases."));
 	}
 
 	@Test
@@ -544,14 +518,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(get(request, code))
+		this.mockMvc
+			.perform(get(request, code).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("No disease found with the specified code.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("No disease found with the specified code."));
 	}
 
 	@Test
@@ -564,17 +535,15 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
 			.thenReturn(true);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("Duplicated disease code.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Duplicated disease code."));
 	}
 
 	@Test
@@ -590,17 +559,15 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.descriptionControl(disease.getDescription(), disease.getType().getCode()))
 			.thenReturn(true);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("Duplicated disease description for the same disease type.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Duplicated disease description for the same disease type."));
 	}
 
 	@Test
@@ -619,17 +586,15 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.newDisease(any(Disease.class)))
 			.thenThrow(new OHServiceException(new OHExceptionMessage("Failure")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Disease not created.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Disease not created."));
 	}
 
 	@Test
@@ -642,17 +607,15 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
 			.thenReturn(false);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("Disease not found.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Disease not found."));
 	}
 
 	@Test
@@ -668,17 +631,15 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.updateDisease(any(Disease.class)))
 			.thenThrow(new OHServiceException(new OHExceptionMessage("Failure")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Disease not updated.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Disease not updated."));
 	}
 
 	@Test
@@ -690,14 +651,11 @@ class DiseaseControllerTest {
 		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
+		this.mockMvc
+			.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("No disease found with the specified code.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("No disease found with the specified code."));
 	}
 
 	@Test
@@ -713,15 +671,11 @@ class DiseaseControllerTest {
 		doThrow(new OHServiceException(new OHExceptionMessage("Failure")))
 			.when(diseaseBrowserManagerMock).deleteDisease(any(Disease.class));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("false")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("false"));
 	}
 
 }

--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -22,6 +22,8 @@
 package org.isf.disease.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -42,6 +44,8 @@ import org.isf.disease.model.Disease;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -188,12 +192,12 @@ class DiseaseControllerTest {
 
 	@Test
 	void testGetDiseasesIpdInByCode_200() throws Exception {
-		String request = "/diseases/ipd/out/{typecode}";
+		String request = "/diseases/ipd/in/{typecode}";
 
 		String typeCode = "1";
 
 		List<Disease> diseases = DiseaseHelper.setupDiseaseList(3);
-		when(diseaseBrowserManagerMock.getDiseaseIpdOut(typeCode))
+		when(diseaseBrowserManagerMock.getDiseaseIpdIn(typeCode))
 			.thenReturn(diseases);
 
 		MvcResult result = this.mockMvc
@@ -365,6 +369,356 @@ class DiseaseControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString("true")))
 
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesOpd_500() throws Exception {
+		String request = "/diseases/opd";
+
+		when(diseaseBrowserManagerMock.getDiseaseOpd())
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting OPD diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesOpdByCode_500() throws Exception {
+		String request = "/diseases/opd/{typecode}";
+
+		String typeCode = "1";
+
+		when(diseaseBrowserManagerMock.getDiseaseOpd(typeCode))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, typeCode))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting OPD diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesIpdOut_500() throws Exception {
+		String request = "/diseases/ipd/out";
+
+		when(diseaseBrowserManagerMock.getDiseaseIpdOut())
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting IPD out diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesIpdOutByCode_500() throws Exception {
+		String request = "/diseases/ipd/out/{typecode}";
+
+		String typeCode = "1";
+
+		when(diseaseBrowserManagerMock.getDiseaseIpdOut(typeCode))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, typeCode))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting IPD out diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesIpdIn_500() throws Exception {
+		String request = "/diseases/ipd/in";
+
+		when(diseaseBrowserManagerMock.getDiseaseIpdIn())
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting IPD-in diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesIpdInByCode_500() throws Exception {
+		String request = "/diseases/ipd/in/{typecode}";
+
+		String typeCode = "1";
+
+		when(diseaseBrowserManagerMock.getDiseaseIpdIn(typeCode))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, typeCode))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting IPD-in diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseases_500() throws Exception {
+		String request = "/diseases/both";
+
+		when(diseaseBrowserManagerMock.getDisease())
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseasesString_500() throws Exception {
+		String request = "/diseases/both/{typecode}";
+
+		String typeCode = "1";
+
+		when(diseaseBrowserManagerMock.getDisease(typeCode))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, typeCode))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting diseases by type code.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetAllDiseases_500() throws Exception {
+		String request = "/diseases/all";
+
+		when(diseaseBrowserManagerMock.getDiseaseAll())
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Error getting all diseases.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetDiseaseByCode_404() throws Exception {
+		String request = "/diseases/{code}";
+
+		String code = "999";
+
+		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, code))
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("No disease found with the specified code.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewDisease_duplicatedCode_400() throws Exception {
+		String request = "/diseases";
+
+		Disease disease = DiseaseHelper.setup();
+		DiseaseDTO body = diseaseMapper.map2DTO(disease);
+
+		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
+			.thenReturn(true);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("Duplicated disease code.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewDisease_duplicatedDescription_400() throws Exception {
+		String request = "/diseases";
+
+		Disease disease = DiseaseHelper.setup();
+		DiseaseDTO body = diseaseMapper.map2DTO(disease);
+
+		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
+			.thenReturn(false);
+
+		when(diseaseBrowserManagerMock.descriptionControl(disease.getDescription(), disease.getType().getCode()))
+			.thenReturn(true);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("Duplicated disease description for the same disease type.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewDisease_notCreated_500() throws Exception {
+		String request = "/diseases";
+
+		Disease disease = DiseaseHelper.setup();
+		DiseaseDTO body = diseaseMapper.map2DTO(disease);
+
+		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
+			.thenReturn(false);
+
+		when(diseaseBrowserManagerMock.descriptionControl(disease.getDescription(), disease.getType().getCode()))
+			.thenReturn(false);
+
+		when(diseaseBrowserManagerMock.newDisease(any(Disease.class)))
+			.thenThrow(new OHServiceException(new OHExceptionMessage("Failure")));
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Disease not created.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateDisease_404() throws Exception {
+		String request = "/diseases";
+
+		Disease disease = DiseaseHelper.setup();
+		DiseaseDTO body = diseaseMapper.map2DTO(disease);
+
+		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
+			.thenReturn(false);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("Disease not found.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateDisease_notUpdated_500() throws Exception {
+		String request = "/diseases";
+
+		Disease disease = DiseaseHelper.setup();
+		DiseaseDTO body = diseaseMapper.map2DTO(disease);
+
+		when(diseaseBrowserManagerMock.isCodePresent(disease.getCode()))
+			.thenReturn(true);
+
+		when(diseaseBrowserManagerMock.updateDisease(any(Disease.class)))
+			.thenThrow(new OHServiceException(new OHExceptionMessage("Failure")));
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Disease not updated.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteDisease_404() throws Exception {
+		String request = "/diseases/{code}";
+
+		String code = "999";
+
+		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("No disease found with the specified code.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteDisease_notDeleted_200() throws Exception {
+		String request = "/diseases/{code}";
+
+		String code = "999";
+
+		Disease disease = DiseaseHelper.setup();
+		when(diseaseBrowserManagerMock.getDiseaseByCode(code))
+			.thenReturn(disease);
+
+		doThrow(new OHServiceException(new OHExceptionMessage("Failure")))
+			.when(diseaseBrowserManagerMock).deleteDisease(any(Disease.class));
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("false")))
 			.andReturn();
 
 		LOGGER.debug("result: {}", result);

--- a/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
+++ b/src/test/java/org/isf/disease/rest/DiseaseControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -375,7 +375,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesOpd_500() throws Exception {
+	void getDiseasesOpd_500() throws Exception {
 		String request = "/diseases/opd";
 
 		when(diseaseBrowserManagerMock.getDiseaseOpd())
@@ -392,7 +392,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesOpdByCode_500() throws Exception {
+	void getDiseasesOpdByCode_500() throws Exception {
 		String request = "/diseases/opd/{typecode}";
 
 		String typeCode = "1";
@@ -411,7 +411,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesIpdOut_500() throws Exception {
+	void getDiseasesIpdOut_500() throws Exception {
 		String request = "/diseases/ipd/out";
 
 		when(diseaseBrowserManagerMock.getDiseaseIpdOut())
@@ -428,7 +428,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesIpdOutByCode_500() throws Exception {
+	void getDiseasesIpdOutByCode_500() throws Exception {
 		String request = "/diseases/ipd/out/{typecode}";
 
 		String typeCode = "1";
@@ -447,7 +447,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesIpdIn_500() throws Exception {
+	void getDiseasesIpdIn_500() throws Exception {
 		String request = "/diseases/ipd/in";
 
 		when(diseaseBrowserManagerMock.getDiseaseIpdIn())
@@ -464,7 +464,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesIpdInByCode_500() throws Exception {
+	void getDiseasesIpdInByCode_500() throws Exception {
 		String request = "/diseases/ipd/in/{typecode}";
 
 		String typeCode = "1";
@@ -483,7 +483,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseases_500() throws Exception {
+	void getDiseases_500() throws Exception {
 		String request = "/diseases/both";
 
 		when(diseaseBrowserManagerMock.getDisease())
@@ -500,7 +500,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseasesString_500() throws Exception {
+	void getDiseasesString_500() throws Exception {
 		String request = "/diseases/both/{typecode}";
 
 		String typeCode = "1";
@@ -519,7 +519,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetAllDiseases_500() throws Exception {
+	void getAllDiseases_500() throws Exception {
 		String request = "/diseases/all";
 
 		when(diseaseBrowserManagerMock.getDiseaseAll())
@@ -536,7 +536,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testGetDiseaseByCode_404() throws Exception {
+	void getDiseaseByCode_404() throws Exception {
 		String request = "/diseases/{code}";
 
 		String code = "999";
@@ -555,7 +555,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testNewDisease_duplicatedCode_400() throws Exception {
+	void newDisease_duplicatedCode_400() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();
@@ -578,7 +578,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testNewDisease_duplicatedDescription_400() throws Exception {
+	void newDisease_duplicatedDescription_400() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();
@@ -604,7 +604,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testNewDisease_notCreated_500() throws Exception {
+	void newDisease_notCreated_500() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();
@@ -633,7 +633,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testUpdateDisease_404() throws Exception {
+	void updateDisease_404() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();
@@ -656,7 +656,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testUpdateDisease_notUpdated_500() throws Exception {
+	void updateDisease_notUpdated_500() throws Exception {
 		String request = "/diseases";
 
 		Disease disease = DiseaseHelper.setup();
@@ -682,7 +682,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testDeleteDisease_404() throws Exception {
+	void deleteDisease_404() throws Exception {
 		String request = "/diseases/{code}";
 
 		String code = "999";
@@ -701,7 +701,7 @@ class DiseaseControllerTest {
 	}
 
 	@Test
-	void testDeleteDisease_notDeleted_200() throws Exception {
+	void deleteDisease_notDeleted_200() throws Exception {
 		String request = "/diseases/{code}";
 
 		String code = "999";


### PR DESCRIPTION
See [OP-1245](https://openhospital.atlassian.net/browse/OP-1245) (parent OP-1237: bring each listed package to at least 80% line coverage).

Improves line coverage of `org.isf.disease.rest` from **68.8% to 100%** (branches 28/28, jacoco 0.8.12) by adding 17 tests to the existing `DiseaseControllerTest`: OHServiceException → 500 paths for all nine GET endpoints, 404 paths for get-by-code/update/delete, duplicate-code and duplicate-description → 400 plus not-created → 500 for POST, not-updated → 500 for PUT, and the delete-returns-false path. Every test asserts both the HTTP status and the OHAPIError message.

Also fixes a pre-existing copy-paste bug in `testGetDiseasesIpdInByCode_200`, which was hitting `/diseases/ipd/out/{typecode}` and mocking `getDiseaseIpdOut` instead of the ipd/in endpoint — this is why the ipd/in success path was uncovered; the fix is intentional, not scope creep.

Note: the delete-failure test pins the controller's current behavior of returning 200 with body `false` instead of an error status — documented as existing behavior. Only the test file is touched; 30/30 tests green.


[OP-1245]: https://openhospital.atlassian.net/browse/OP-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ