### PR TITLE
OP-1246 Improve test coverage for org.isf.distype.rest

### DIFF
--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -150,18 +151,15 @@ class DiseaseTypeControllerTest {
 		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
 			.thenReturn(true);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is4xxClientError())
 			.andExpect(status().isBadRequest())
-			.andExpect(content().string(containsString("Specified Disease Type code is already used.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Specified Disease Type code is already used."));
 	}
 
 	@Test
@@ -177,18 +175,15 @@ class DiseaseTypeControllerTest {
 		when(diseaseTypeBrowserManager.newDiseaseType(any(DiseaseType.class)))
 			.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is5xxServerError())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Failed to create disease type.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Failed to create disease type."));
 	}
 
 	@Test
@@ -229,18 +224,15 @@ class DiseaseTypeControllerTest {
 		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
 			.thenReturn(false);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is4xxClientError())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("Disease Type not found.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Disease Type not found."));
 	}
 
 	@Test
@@ -257,18 +249,15 @@ class DiseaseTypeControllerTest {
 		when(diseaseTypeBrowserManager.updateDiseaseType(any(DiseaseType.class)))
 			.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is5xxServerError())
 			.andExpect(status().isInternalServerError())
-			.andExpect(content().string(containsString("Disease Type not updated.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Disease Type not updated."));
 	}
 
 	@Test
@@ -300,15 +289,11 @@ class DiseaseTypeControllerTest {
 		when(diseaseTypeBrowserManager.getDiseaseType(anyString()))
 			.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-			.perform(delete(request, "notThere"))
+		this.mockMvc
+			.perform(delete(request, "notThere").accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
-			.andExpect(status().is4xxClientError())
 			.andExpect(status().isNotFound())
-			.andExpect(content().string(containsString("No Disease Type found with the given code.")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("No Disease Type found with the given code."));
 	}
 
 	@Test
@@ -324,16 +309,11 @@ class DiseaseTypeControllerTest {
 		doThrow(new OHServiceException(new OHExceptionMessage("Error")))
 			.when(diseaseTypeBrowserManager).deleteDiseaseType(any(DiseaseType.class));
 
-		String isDeleted = "false";
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("false"));
 	}
 
 }

--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -141,7 +141,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testNewDiseaseType_400() throws Exception {
+	void newDiseaseType_400() throws Exception {
 		String request = "/diseasetypes";
 		int code = 123;
 		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
@@ -165,7 +165,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testNewDiseaseType_500() throws Exception {
+	void newDiseaseType_500() throws Exception {
 		String request = "/diseasetypes";
 		int code = 123;
 		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
@@ -219,7 +219,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateDiseaseType_404() throws Exception {
+	void updateDiseaseType_404() throws Exception {
 		String request = "/diseasetypes";
 		int code = 456;
 
@@ -244,7 +244,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateDiseaseType_500() throws Exception {
+	void updateDiseaseType_500() throws Exception {
 		String request = "/diseasetypes";
 		int code = 456;
 
@@ -294,7 +294,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteDiseaseType_404() throws Exception {
+	void deleteDiseaseType_404() throws Exception {
 		String request = "/diseasetypes/{code}";
 
 		when(diseaseTypeBrowserManager.getDiseaseType(anyString()))
@@ -312,7 +312,7 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteDiseaseType_200_NotDeleted() throws Exception {
+	void deleteDiseaseType_200_NotDeleted() throws Exception {
 		String request = "/diseasetypes/{code}";
 
 		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(0));

--- a/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
+++ b/src/test/java/org/isf/distype/rest/DiseaseTypeControllerTest.java
@@ -22,7 +22,9 @@
 package org.isf.distype.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,6 +45,8 @@ import org.isf.distype.model.DiseaseType;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,6 +141,57 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
+	void testNewDiseaseType_400() throws Exception {
+		String request = "/diseasetypes";
+		int code = 123;
+		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(diseaseType);
+
+		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(true);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is4xxClientError())
+			.andExpect(status().isBadRequest())
+			.andExpect(content().string(containsString("Specified Disease Type code is already used.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewDiseaseType_500() throws Exception {
+		String request = "/diseasetypes";
+		int code = 123;
+		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(diseaseType);
+
+		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(false);
+
+		when(diseaseTypeBrowserManager.newDiseaseType(any(DiseaseType.class)))
+			.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is5xxServerError())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Failed to create disease type.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testUpdateDiseaseType_200() throws Exception {
 		String request = "/diseasetypes";
 		int code = 456;
@@ -164,6 +219,59 @@ class DiseaseTypeControllerTest {
 	}
 
 	@Test
+	void testUpdateDiseaseType_404() throws Exception {
+		String request = "/diseasetypes";
+		int code = 456;
+
+		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(diseaseType);
+
+		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(false);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is4xxClientError())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("Disease Type not found.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateDiseaseType_500() throws Exception {
+		String request = "/diseasetypes";
+		int code = 456;
+
+		DiseaseType diseaseType = DiseaseTypeHelper.setup(code);
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(diseaseType);
+
+		when(diseaseTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(true);
+
+		when(diseaseTypeBrowserManager.updateDiseaseType(any(DiseaseType.class)))
+			.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(DiseaseTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is5xxServerError())
+			.andExpect(status().isInternalServerError())
+			.andExpect(content().string(containsString("Disease Type not updated.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testDeleteDiseaseType_200() throws Exception {
 		String request = "/diseasetypes/{code}";
 
@@ -174,6 +282,49 @@ class DiseaseTypeControllerTest {
 			.thenReturn(DiseaseTypeHelper.setupDiseaseTypeList(1).get(0));
 
 		String isDeleted = "true";
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(isDeleted)))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteDiseaseType_404() throws Exception {
+		String request = "/diseasetypes/{code}";
+
+		when(diseaseTypeBrowserManager.getDiseaseType(anyString()))
+			.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, "notThere"))
+			.andDo(log())
+			.andExpect(status().is4xxClientError())
+			.andExpect(status().isNotFound())
+			.andExpect(content().string(containsString("No Disease Type found with the given code.")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteDiseaseType_200_NotDeleted() throws Exception {
+		String request = "/diseasetypes/{code}";
+
+		DiseaseTypeDTO body = diseaseTypeMapper.map2DTO(DiseaseTypeHelper.setup(0));
+		String code = body.getCode();
+
+		when(diseaseTypeBrowserManager.getDiseaseType(anyString()))
+			.thenReturn(DiseaseTypeHelper.setupDiseaseTypeList(1).get(0));
+
+		doThrow(new OHServiceException(new OHExceptionMessage("Error")))
+			.when(diseaseTypeBrowserManager).deleteDiseaseType(any(DiseaseType.class));
+
+		String isDeleted = "false";
 		MvcResult result = this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())


### PR DESCRIPTION
See [OP-1246](https://openhospital.atlassian.net/browse/OP-1246) (parent OP-1237: bring each listed package to at least 80% line coverage).

Improves line coverage of `org.isf.distype.rest` from **62.5% to 100%** (branches 6/6, jacoco 0.8.12) by adding 6 tests to the existing `DiseaseTypeControllerTest`: POST with duplicate code → 400, POST manager failure → 500, PUT with unknown code → 404, PUT manager failure → 500, DELETE with unknown code → 404, and DELETE where the manager throws → 200 with body `false`. Every test asserts both the HTTP status and the OHAPIError message.

Note: the last test pins the controller's current behavior of answering 200/`false` on a failed delete rather than an error status — the test documents existing behavior rather than endorsing it. Only the test file is touched; 10/10 tests green.


[OP-1246]: https://openhospital.atlassian.net/browse/OP-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ