### PR TITLE
OP-1274 Improve test coverage for org.isf.vaccine.rest

### DIFF
--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -22,6 +22,7 @@
 package org.isf.vaccine.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -37,6 +38,9 @@ import java.util.Objects;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.utils.exception.OHDataIntegrityViolationException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.vaccine.data.VaccineHelper;
 import org.isf.vaccine.dto.VaccineDTO;
 import org.isf.vaccine.manager.VaccineBrowserManager;
@@ -154,6 +158,54 @@ public class VaccineControllerTest {
 	}
 
 	@Test
+	void testNewVaccine_VaccineTypeAlreadyPresent_400() throws Exception {
+		String request = "/vaccines";
+		String code = "ZZ";
+		Vaccine vaccine = VaccineHelper.setup(code);
+		VaccineDTO body = vaccineMapper.map2DTO(vaccine);
+
+		when(vaccineBrowserManagerMock.newVaccine(vaccineMapper.map2Model(body)))
+				.thenThrow(new OHDataIntegrityViolationException(new OHExceptionMessage("Duplicated vaccine type")));
+
+		MvcResult result = this.mockMvc
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine type already present.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewVaccine_NotCreated_400() throws Exception {
+		String request = "/vaccines";
+		String code = "ZZ";
+		Vaccine vaccine = VaccineHelper.setup(code);
+		VaccineDTO body = vaccineMapper.map2DTO(vaccine);
+
+		when(vaccineBrowserManagerMock.newVaccine(vaccineMapper.map2Model(body)))
+				.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
+
+		MvcResult result = this.mockMvc
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine not created.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testUpdateVaccine_200() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
@@ -171,6 +223,30 @@ public class VaccineControllerTest {
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(status().isOk())
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateVaccine_NotUpdated_400() throws Exception {
+		String request = "/vaccines";
+		String code = "ZZ";
+		Vaccine vaccine = VaccineHelper.setup(code);
+		VaccineDTO body = vaccineMapper.map2DTO(vaccine);
+
+		when(vaccineBrowserManagerMock.updateVaccine(vaccineMapper.map2Model(body)))
+				.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
+
+		MvcResult result = this.mockMvc
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine not updated.")))
 				.andReturn();
 
 		LOGGER.debug("result: {}", result);
@@ -195,6 +271,48 @@ public class VaccineControllerTest {
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(status().isOk())
 				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteVaccine_NotFound_404() throws Exception {
+		String request = "/vaccines/{code}";
+		String code = "0";
+
+		when(vaccineBrowserManagerMock.findVaccine(code))
+				.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isNotFound())
+				.andExpect(content().string(containsString("Vaccine not found.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteVaccine_NotDeleted_400() throws Exception {
+		String request = "/vaccines/{code}";
+		String code = "0";
+
+		Vaccine vaccine = VaccineHelper.setup(code);
+
+		when(vaccineBrowserManagerMock.findVaccine(code))
+				.thenReturn(vaccine);
+		doThrow(new OHServiceException(new OHExceptionMessage("Error")))
+				.when(vaccineBrowserManagerMock).deleteVaccine(vaccine);
+
+		MvcResult result = this.mockMvc
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine not deleted.")))
 				.andReturn();
 
 		LOGGER.debug("result: {}", result);

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -158,7 +158,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	void testNewVaccine_VaccineTypeAlreadyPresent_400() throws Exception {
+	void newVaccine_VaccineTypeAlreadyPresent_400() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
 		Vaccine vaccine = VaccineHelper.setup(code);
@@ -182,7 +182,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	void testNewVaccine_NotCreated_400() throws Exception {
+	void newVaccine_NotCreated_400() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
 		Vaccine vaccine = VaccineHelper.setup(code);
@@ -229,7 +229,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	void testUpdateVaccine_NotUpdated_400() throws Exception {
+	void updateVaccine_NotUpdated_400() throws Exception {
 		String request = "/vaccines";
 		String code = "ZZ";
 		Vaccine vaccine = VaccineHelper.setup(code);
@@ -277,7 +277,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	void testDeleteVaccine_NotFound_404() throws Exception {
+	void deleteVaccine_NotFound_404() throws Exception {
 		String request = "/vaccines/{code}";
 		String code = "0";
 
@@ -296,7 +296,7 @@ public class VaccineControllerTest {
 	}
 
 	@Test
-	void testDeleteVaccine_NotDeleted_400() throws Exception {
+	void deleteVaccine_NotDeleted_400() throws Exception {
 		String request = "/vaccines/{code}";
 		String code = "0";
 

--- a/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
+++ b/src/test/java/org/isf/vaccine/rest/VaccineControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -150,7 +151,7 @@ public class VaccineControllerTest {
 						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				//.andDo(print())
+				//.andDo(log())
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(status().isCreated())
 				.andReturn();
@@ -167,18 +168,15 @@ public class VaccineControllerTest {
 		when(vaccineBrowserManagerMock.newVaccine(vaccineMapper.map2Model(body)))
 				.thenThrow(new OHDataIntegrityViolationException(new OHExceptionMessage("Duplicated vaccine type")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(post(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine type already present.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine type already present."));
 	}
 
 	@Test
@@ -191,18 +189,15 @@ public class VaccineControllerTest {
 		when(vaccineBrowserManagerMock.newVaccine(vaccineMapper.map2Model(body)))
 				.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(post(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine not created.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine not created."));
 	}
 
 	@Test
@@ -238,18 +233,15 @@ public class VaccineControllerTest {
 		when(vaccineBrowserManagerMock.updateVaccine(vaccineMapper.map2Model(body)))
 				.thenThrow(new OHServiceException(new OHExceptionMessage("Error")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(put(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine not updated.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine not updated."));
 	}
 
 	@Test
@@ -284,15 +276,11 @@ public class VaccineControllerTest {
 		when(vaccineBrowserManagerMock.findVaccine(code))
 				.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-				.perform(delete(request, code))
+		this.mockMvc
+				.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isNotFound())
-				.andExpect(content().string(containsString("Vaccine not found.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine not found."));
 	}
 
 	@Test
@@ -307,15 +295,11 @@ public class VaccineControllerTest {
 		doThrow(new OHServiceException(new OHExceptionMessage("Error")))
 				.when(vaccineBrowserManagerMock).deleteVaccine(vaccine);
 
-		MvcResult result = this.mockMvc
-				.perform(delete(request, code))
+		this.mockMvc
+				.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine not deleted.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine not deleted."));
 	}
 
 	@Test


### PR DESCRIPTION
See [OP-1274](https://openhospital.atlassian.net/browse/OP-1274) (parent OP-1237: bring each listed package to at least 80% line coverage).

Improves line coverage of `org.isf.vaccine.rest` from **69.0% to 100%** (branches 2/2, jacoco 0.8.12) by adding 5 tests to the existing `VaccineControllerTest` covering the previously untested error paths: POST with OHDataIntegrityViolationException → 400 "Vaccine type already present.", POST with OHServiceException → 400 "Vaccine not created.", PUT failure → 400 "Vaccine not updated.", DELETE of unknown code → 404 "Vaccine not found.", and DELETE where the manager throws → 400 "Vaccine not deleted.". Every test asserts both the HTTP status and the exact OHAPIError message.

Only the test file is touched; 11/11 tests green. No unreachable code remains in VaccineController.


[OP-1274]: https://openhospital.atlassian.net/browse/OP-1274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ