### PR TITLE
OP-1275 Improve test coverage for org.isf.vactype.rest

### DIFF
--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -137,7 +137,7 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
-	void testNewVaccineTypeAlreadyPresent_400() throws Exception {
+	void newVaccineTypeAlreadyPresent_400() throws Exception {
 		String request = "/vaccinetypes";
 		String code = "ZZ";
 		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
@@ -160,7 +160,7 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
-	void testNewVaccineTypeNotCreated_400() throws Exception {
+	void newVaccineTypeNotCreated_400() throws Exception {
 		String request = "/vaccinetypes";
 		String code = "ZZ";
 		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
@@ -206,7 +206,7 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateVaccineTypeNotUpdated_400() throws Exception {
+	void updateVaccineTypeNotUpdated_400() throws Exception {
 		String request = "/vaccinetypes";
 		String code = "ZZ";
 		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
@@ -253,7 +253,7 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteVaccineTypeNotFound_404() throws Exception {
+	void deleteVaccineTypeNotFound_404() throws Exception {
 		String request = "/vaccinetypes/{code}";
 		String code = "0";
 
@@ -272,7 +272,7 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteVaccineTypeNotDeleted_400() throws Exception {
+	void deleteVaccineTypeNotDeleted_400() throws Exception {
 		String request = "/vaccinetypes/{code}";
 		String code = "0";
 

--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -145,18 +146,15 @@ class VaccineTypeControllerTest {
 		when(vaccineTypeBrowserManagerMock.newVaccineType(vaccineTypeMapper.map2Model(body)))
 				.thenThrow(new OHDataIntegrityViolationException(new OHExceptionMessage("Duplicated key.")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(post(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine Type already present.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine Type already present."));
 	}
 
 	@Test
@@ -168,18 +166,15 @@ class VaccineTypeControllerTest {
 		when(vaccineTypeBrowserManagerMock.newVaccineType(vaccineTypeMapper.map2Model(body)))
 				.thenThrow(new OHServiceException(new OHExceptionMessage("Validation failed.")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(post(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine Type not created.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine Type not created."));
 	}
 
 	@Test
@@ -214,18 +209,15 @@ class VaccineTypeControllerTest {
 		when(vaccineTypeBrowserManagerMock.updateVaccineType(vaccineTypeMapper.map2Model(body)))
 				.thenThrow(new OHServiceException(new OHExceptionMessage("Validation failed.")));
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 				.perform(put(request)
 						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
 						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
 				)
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine Type not updated.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine Type not updated."));
 	}
 
 	@Test
@@ -260,15 +252,11 @@ class VaccineTypeControllerTest {
 		when(vaccineTypeBrowserManagerMock.findVaccineType(code))
 				.thenReturn(null);
 
-		MvcResult result = this.mockMvc
-				.perform(delete(request, code))
+		this.mockMvc
+				.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isNotFound())
-				.andExpect(content().string(containsString("Vaccine Type not found.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine Type not found."));
 	}
 
 	@Test
@@ -283,15 +271,11 @@ class VaccineTypeControllerTest {
 		doThrow(new OHServiceException(new OHExceptionMessage("Delete failed.")))
 				.when(vaccineTypeBrowserManagerMock).deleteVaccineType(vaccineType);
 
-		MvcResult result = this.mockMvc
-				.perform(delete(request, code))
+		this.mockMvc
+				.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 				.andDo(log())
-				.andExpect(status().is4xxClientError())
 				.andExpect(status().isBadRequest())
-				.andExpect(content().string(containsString("Vaccine Type not deleted.")))
-				.andReturn();
-
-		LOGGER.debug("result: {}", result);
+				.andExpect(jsonPath("$.message").value("Vaccine Type not deleted."));
 	}
 
 	@Test

--- a/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
+++ b/src/test/java/org/isf/vactype/rest/VaccineTypeControllerTest.java
@@ -22,6 +22,7 @@
 package org.isf.vactype.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -37,6 +38,9 @@ import java.util.Objects;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.utils.exception.OHDataIntegrityViolationException;
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
 import org.isf.vactype.data.VaccineTypeHelper;
 import org.isf.vactype.dto.VaccineTypeDTO;
 import org.isf.vactype.manager.VaccineTypeBrowserManager;
@@ -133,6 +137,52 @@ class VaccineTypeControllerTest {
 	}
 
 	@Test
+	void testNewVaccineTypeAlreadyPresent_400() throws Exception {
+		String request = "/vaccinetypes";
+		String code = "ZZ";
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
+
+		when(vaccineTypeBrowserManagerMock.newVaccineType(vaccineTypeMapper.map2Model(body)))
+				.thenThrow(new OHDataIntegrityViolationException(new OHExceptionMessage("Duplicated key.")));
+
+		MvcResult result = this.mockMvc
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine Type already present.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewVaccineTypeNotCreated_400() throws Exception {
+		String request = "/vaccinetypes";
+		String code = "ZZ";
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
+
+		when(vaccineTypeBrowserManagerMock.newVaccineType(vaccineTypeMapper.map2Model(body)))
+				.thenThrow(new OHServiceException(new OHExceptionMessage("Validation failed.")));
+
+		MvcResult result = this.mockMvc
+				.perform(post(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine Type not created.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
 	void testUpdateVaccineType_200() throws Exception {
 		String request = "/vaccinetypes";
 		String code = "ZZ";
@@ -150,6 +200,29 @@ class VaccineTypeControllerTest {
 				.andDo(log())
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(status().isOk())
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateVaccineTypeNotUpdated_400() throws Exception {
+		String request = "/vaccinetypes";
+		String code = "ZZ";
+		VaccineTypeDTO body = vaccineTypeMapper.map2DTO(VaccineTypeHelper.setup(code));
+
+		when(vaccineTypeBrowserManagerMock.updateVaccineType(vaccineTypeMapper.map2Model(body)))
+				.thenThrow(new OHServiceException(new OHExceptionMessage("Validation failed.")));
+
+		MvcResult result = this.mockMvc
+				.perform(put(request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(Objects.requireNonNull(VaccineTypeHelper.asJsonString(body)))
+				)
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine Type not updated.")))
 				.andReturn();
 
 		LOGGER.debug("result: {}", result);
@@ -174,6 +247,48 @@ class VaccineTypeControllerTest {
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(status().isOk())
 				.andExpect(content().string(containsString(isDeleted)))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteVaccineTypeNotFound_404() throws Exception {
+		String request = "/vaccinetypes/{code}";
+		String code = "0";
+
+		when(vaccineTypeBrowserManagerMock.findVaccineType(code))
+				.thenReturn(null);
+
+		MvcResult result = this.mockMvc
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isNotFound())
+				.andExpect(content().string(containsString("Vaccine Type not found.")))
+				.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteVaccineTypeNotDeleted_400() throws Exception {
+		String request = "/vaccinetypes/{code}";
+		String code = "0";
+
+		VaccineType vaccineType = VaccineTypeHelper.setup(code);
+
+		when(vaccineTypeBrowserManagerMock.findVaccineType(code))
+				.thenReturn(vaccineType);
+		doThrow(new OHServiceException(new OHExceptionMessage("Delete failed.")))
+				.when(vaccineTypeBrowserManagerMock).deleteVaccineType(vaccineType);
+
+		MvcResult result = this.mockMvc
+				.perform(delete(request, code))
+				.andDo(log())
+				.andExpect(status().is4xxClientError())
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(containsString("Vaccine Type not deleted.")))
 				.andReturn();
 
 		LOGGER.debug("result: {}", result);


### PR DESCRIPTION
See [OP-1275](https://openhospital.atlassian.net/browse/OP-1275) (parent OP-1237: bring each listed package to at least 80% line coverage).

Improves line coverage of `org.isf.vactype.rest` from **66.7% to 100%** (branches 2/2, jacoco 0.8.12) by adding 5 tests to the existing `VaccineTypeControllerTest` covering the untested error paths: POST with OHDataIntegrityViolationException → 400 "Vaccine Type already present.", POST with OHServiceException → 400 "Vaccine Type not created.", PUT failure → 400 "Vaccine Type not updated.", DELETE of unknown code → 404 "Vaccine Type not found.", and DELETE where the manager throws → 400 "Vaccine Type not deleted.". Every test asserts both the HTTP status and the exact OHAPIError message.

Only the test file is touched; 10/10 tests green. No unreachable code remains in VaccineTypeController.


[OP-1275]: https://openhospital.atlassian.net/browse/OP-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ