### PR TITLE
OP-1262 Improve test coverage for org.isf.opetype

### DIFF
--- a/src/test/java/org/isf/opetype/data/OperationTypeDTOHelper.java
+++ b/src/test/java/org/isf/opetype/data/OperationTypeDTOHelper.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/opetype/data/OperationTypeDTOHelper.java
+++ b/src/test/java/org/isf/opetype/data/OperationTypeDTOHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.opetype.data;
+
+import org.isf.opetype.TestOperationType;
+import org.isf.opetype.dto.OperationTypeDTO;
+import org.isf.opetype.mapper.OperationTypeMapper;
+import org.isf.utils.exception.OHException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+public class OperationTypeDTOHelper {
+
+	private static ObjectMapper objectMapper;
+
+	public static OperationTypeDTO setup(OperationTypeMapper operationTypeMapper) throws OHException {
+		TestOperationType testOperationType = new TestOperationType();
+		return operationTypeMapper.map2DTO(testOperationType.setup(false));
+	}
+
+	public static String asJsonString(OperationTypeDTO operationTypeDTO) {
+		try {
+			return getObjectMapper().writeValueAsString(operationTypeDTO);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static ObjectMapper getObjectMapper() {
+		if (objectMapper == null) {
+			objectMapper = new ObjectMapper()
+					.registerModule(new ParameterNamesModule())
+					.registerModule(new Jdk8Module())
+					.registerModule(new JavaTimeModule());
+		}
+		return objectMapper;
+	}
+
+}

--- a/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
+++ b/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
@@ -1,0 +1,180 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.opetype.rest;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.isf.opetype.data.OperationTypeDTOHelper;
+import org.isf.opetype.dto.OperationTypeDTO;
+import org.isf.opetype.manager.OperationTypeBrowserManager;
+import org.isf.opetype.mapper.OperationTypeMapper;
+import org.isf.opetype.model.OperationType;
+import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
+import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
+import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class OperationTypeControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OperationTypeControllerTest.class);
+
+	@Mock
+	protected OperationTypeBrowserManager operationTypeManagerMock;
+
+	protected OperationTypeMapper operationTypemapper = new OperationTypeMapper();
+
+	private MockMvc mockMvc;
+
+	private AutoCloseable closeable;
+
+	@BeforeEach
+	void setup() {
+		closeable = MockitoAnnotations.openMocks(this);
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new OperationTypeController(operationTypeManagerMock, operationTypemapper))
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+		ModelMapper modelMapper = new ModelMapper();
+		modelMapper.addConverter(new BlobToByteArrayConverter());
+		modelMapper.addConverter(new ByteArrayToBlobConverter());
+		ReflectionTestUtils.setField(operationTypemapper, "modelMapper", modelMapper);
+	}
+
+	@AfterEach
+	void closeService() throws Exception {
+		closeable.close();
+	}
+
+	@Test
+	void testNewOperationType_201() throws Exception {
+		String request = "/operationtypes";
+		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
+
+		OperationType operationType = new OperationType("ZZ", "TestDescription");
+
+		when(operationTypeManagerMock.newOperationType(operationType))
+			.thenReturn(operationType);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(OperationTypeDTOHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateOperationType_200() throws Exception {
+		String request = "/operationtypes/{code}";
+		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
+		String code = body.getCode();
+		OperationType operationType = new OperationType("ZZ", "TestDescription");
+
+		when(operationTypeManagerMock.isCodePresent(code))
+			.thenReturn(true);
+
+		when(operationTypeManagerMock.updateOperationType(operationType))
+			.thenReturn(operationType);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request, code)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(OperationTypeDTOHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testGetOperationTypes_200() throws Exception {
+		String request = "/operationtypes";
+
+		OperationType operationType = new OperationType("ZZ", "TestDescription");
+		List<OperationType> operationTypesFound = new ArrayList<>();
+		operationTypesFound.add(operationType);
+		when(operationTypeManagerMock.getOperationType())
+			.thenReturn(operationTypesFound);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteOperationType_200() throws Exception {
+		String request = "/operationtypes/{code}";
+		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
+		String code = body.getCode();
+
+		OperationType operationType = new OperationType("ZZ", "TestDescription");
+		ArrayList<OperationType> operationTypesFound = new ArrayList<>();
+		operationTypesFound.add(operationType);
+		when(operationTypeManagerMock.getOperationType())
+			.thenReturn(operationTypesFound);
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+}

--- a/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
+++ b/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
@@ -21,12 +21,15 @@
  */
 package org.isf.opetype.rest;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
@@ -47,17 +50,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.modelmapper.ModelMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class OperationTypeControllerTest {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(OperationTypeControllerTest.class);
 
 	@Mock
 	protected OperationTypeBrowserManager operationTypeManagerMock;
@@ -96,17 +94,15 @@ class OperationTypeControllerTest {
 		when(operationTypeManagerMock.newOperationType(operationType))
 			.thenReturn(operationType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(OperationTypeDTOHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isCreated())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("ZZ"))
+			.andExpect(jsonPath("$.description").value("TestDescription"));
 	}
 
 	@Test
@@ -122,17 +118,15 @@ class OperationTypeControllerTest {
 		when(operationTypeManagerMock.updateOperationType(operationType))
 			.thenReturn(operationType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request, code)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(OperationTypeDTOHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("ZZ"))
+			.andExpect(jsonPath("$.description").value("TestDescription"));
 	}
 
 	@Test
@@ -145,14 +139,13 @@ class OperationTypeControllerTest {
 		when(operationTypeManagerMock.getOperationType())
 			.thenReturn(operationTypesFound);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(get(request))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$", hasSize(1)))
+			.andExpect(jsonPath("$[0].code").value("ZZ"))
+			.andExpect(jsonPath("$[0].description").value("TestDescription"));
 	}
 
 	@Test
@@ -167,14 +160,11 @@ class OperationTypeControllerTest {
 		when(operationTypeManagerMock.getOperationType())
 			.thenReturn(operationTypesFound);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("true"));
 	}
 
 }

--- a/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
+++ b/src/test/java/org/isf/opetype/rest/OperationTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -87,7 +87,7 @@ class OperationTypeControllerTest {
 	}
 
 	@Test
-	void testNewOperationType_201() throws Exception {
+	void newOperationType_201() throws Exception {
 		String request = "/operationtypes";
 		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
 
@@ -110,7 +110,7 @@ class OperationTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateOperationType_200() throws Exception {
+	void updateOperationType_200() throws Exception {
 		String request = "/operationtypes/{code}";
 		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
 		String code = body.getCode();
@@ -136,7 +136,7 @@ class OperationTypeControllerTest {
 	}
 
 	@Test
-	void testGetOperationTypes_200() throws Exception {
+	void getOperationTypes_200() throws Exception {
 		String request = "/operationtypes";
 
 		OperationType operationType = new OperationType("ZZ", "TestDescription");
@@ -156,7 +156,7 @@ class OperationTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteOperationType_200() throws Exception {
+	void deleteOperationType_200() throws Exception {
 		String request = "/operationtypes/{code}";
 		OperationTypeDTO body = OperationTypeDTOHelper.setup(operationTypemapper);
 		String code = body.getCode();


### PR DESCRIPTION
## OP-1262 — Improve test coverage for `org.isf.opetype`

Adds a `MockMvc` standalone test for `OperationTypeController`, following the pattern of the existing type-controller tests (`AdmissionTypeControllerTest`, `AgeTypeControllerTest`, `DiseaseTypeControllerTest`, …).

- **`OperationTypeControllerTest`** — covers all four endpoints:
  - `POST /operationtypes` → 201
  - `PUT /operationtypes/{code}` → 200
  - `GET /operationtypes` → 200
  - `DELETE /operationtypes/{code}` → 200
- **`OperationTypeDTOHelper`** — test-data helper built on the core `TestOperationType` fixture, mirroring the existing `*DTOHelper` classes.

The test wires the **real** `OperationTypeMapper` (not a mock) into the controller, so it exercises `org.isf.opetype.mapper` as well as `org.isf.opetype.rest`.

Jira: https://openhospital.atlassian.net/browse/OP-1262
