### PR TITLE
OP-886 Add DELETE /patients/{code}/personal-data for GDPR erasure

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -6459,6 +6459,10 @@ components:
           type: string
           description: Current anamnesis
           maxLength: 255
+        anonymized:
+          type: boolean
+          description: Whether the patient has been anonymized (GDPR right to erasure)
+          readOnly: true
         status:
           type: string
           description: Status

--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -6075,6 +6075,29 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /patients/{code}/personal-data:
+    delete:
+      tags:
+      - Patients
+      summary: GDPR Art. 17 — Right to erasure. Irreversibly anonymize a patient's
+        personal data.
+      operationId: anonymizePatient
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+      security:
+      - bearerAuth: []
   /operations/rows/{code}:
     delete:
       tags:

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -232,6 +232,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.PUT, "/patientconsensus/**").hasAuthority("patientconsensus.update")
 				.requestMatchers(HttpMethod.DELETE, "/patientconsensus/**").hasAuthority("patientconsensus.delete")
 				// patients
+				.requestMatchers(HttpMethod.DELETE, "/patients/{code}/personal-data").hasAuthority("patient.anonymize")
 				.requestMatchers(HttpMethod.POST, "/patients/**").hasAuthority("patients.create")
 				.requestMatchers(HttpMethod.GET, "/patients/**").hasAuthority("patients.read")
 				.requestMatchers(HttpMethod.PUT, "/patients/**").hasAuthority("patients.update")

--- a/src/main/java/org/isf/patient/dto/PatientDTO.java
+++ b/src/main/java/org/isf/patient/dto/PatientDTO.java
@@ -120,6 +120,9 @@ public class PatientDTO {
 	@Schema(description = "Current anamnesis", maxLength = 255)
 	private String anamnesis;
 
+	@Schema(description = "Whether the patient has been anonymized (GDPR right to erasure)", accessMode = AccessMode.READ_ONLY)
+	private boolean anonymized;
+
 	@Schema(description = "Status", example = "I")
 	private PatientSTATUS status;
 
@@ -183,6 +186,14 @@ public class PatientDTO {
 	@Schema(accessMode = AccessMode.READ_ONLY)
 	public int getHashCode() {
 		return hashCode;
+	}
+
+	public boolean isAnonymized() {
+		return anonymized;
+	}
+
+	public void setAnonymized(boolean anonymized) {
+		this.anonymized = anonymized;
 	}
 
 	public String getFirstName() {

--- a/src/main/java/org/isf/patient/rest/PatientController.java
+++ b/src/main/java/org/isf/patient/rest/PatientController.java
@@ -57,6 +57,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -251,6 +252,29 @@ public class PatientController {
 		} catch (OHServiceException serviceException) {
 			throw new OHAPIException(new OHExceptionMessage("Patient not deleted."));
 		}
+	}
+
+	/**
+	 * Irreversibly anonymize the personal identification data of a {@link Patient} (GDPR Art. 17 — Right to
+	 * erasure). The clinical records are preserved for statistical use. Requires the {@code patient.anonymize}
+	 * permission.
+	 *
+	 * @param code the code of the patient to anonymize.
+	 * @return {@code true} if the patient has been anonymized.
+	 * @throws OHServiceException When failed to anonymize the patient.
+	 */
+	@DeleteMapping(value = "/patients/{code}/personal-data")
+	@Operation(summary = "GDPR Art. 17 — Right to erasure. Irreversibly anonymize a patient's personal data.")
+	public boolean anonymizePatient(@PathVariable int code) throws OHServiceException {
+		LOGGER.info("Anonymize personal data of patient code: '{}'.", code);
+		Patient patient = patientManager.getPatientById(code);
+
+		if (patient == null) {
+			throw new OHAPIException(new OHExceptionMessage("Patient not found."), HttpStatus.NOT_FOUND);
+		}
+
+		patientManager.anonymizePatient(code);
+		return true;
 	}
 
 	@GetMapping(value = "/patients/merge")

--- a/src/test/java/org/isf/patient/rest/PatientControllerTest.java
+++ b/src/test/java/org/isf/patient/rest/PatientControllerTest.java
@@ -617,4 +617,29 @@ class PatientControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().string(containsString(PatientHelper.asJsonString(patientMapper.map2DTOList(patientList)))));
     }
+
+	@Test
+	void when_delete_personal_data_with_existent_code_then_anonymized_OK() throws Exception {
+		int code = 123;
+		Patient patient = new Patient();
+		when(patientBrowserManagerMock.getPatientById(code)).thenReturn(patient);
+		when(patientBrowserManagerMock.anonymizePatient(code)).thenReturn(patient);
+
+		this.mockMvc
+			.perform(delete("/patients/{code}/personal-data", code))
+			.andDo(log())
+			.andExpect(status().isOk())
+			.andExpect(content().string("true"));
+	}
+
+	@Test
+	void when_delete_personal_data_with_unexistent_code_then_NotFound() throws Exception {
+		int code = 123;
+		when(patientBrowserManagerMock.getPatientById(code)).thenReturn(null);
+
+		this.mockMvc
+			.perform(delete("/patients/{code}/personal-data", code))
+			.andDo(log())
+			.andExpect(status().isNotFound());
+	}
 }


### PR DESCRIPTION
API part of **OP-886 – GDPR 1/4 Oblivion (Art. 17, right to erasure)**.

### Changes
- `DELETE /patients/{code}/personal-data` in `PatientController` (`anonymizePatient`), returning `404` for an unknown patient; delegates to `PatientBrowserManager.anonymizePatient()`.
- Guarded by the new `patient.anonymize` authority in `SecurityConfig` (matched before the generic `/patients/**` rules).
- `openapi/oh.yaml` regenerated to include the new path.
- Controller tests for the OK and not-found cases.

Depends on **core informatici/openhospital-core#1641** (needs `PatientBrowserManager.anonymizePatient` + the `patient.anonymize` permission seed). Merge order: core first.

Verified end-to-end against a running API + MariaDB 10.6 demo DB (anonymization returns 200, permission enforced).
