### PR TITLE
OP-1258 Add test coverage for the medical type REST layer

### DIFF
--- a/src/test/java/org/isf/medtype/data/MedicalTypeHelper.java
+++ b/src/test/java/org/isf/medtype/data/MedicalTypeHelper.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/medtype/data/MedicalTypeHelper.java
+++ b/src/test/java/org/isf/medtype/data/MedicalTypeHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.medtype.data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.isf.medtype.TestMedicalType;
+import org.isf.medtype.dto.MedicalTypeDTO;
+import org.isf.medtype.model.MedicalType;
+import org.isf.utils.exception.OHException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+public class MedicalTypeHelper {
+
+	private static ObjectMapper objectMapper;
+
+	public static MedicalType setup(int i) throws OHException {
+		TestMedicalType testMedicalType = new TestMedicalType();
+		MedicalType medicalType = testMedicalType.setup(false);
+		medicalType.setCode(medicalType.getCode() + i);
+		return medicalType;
+	}
+
+	public static List<MedicalType> setupMedicalTypeList(int size) {
+		return IntStream.range(0, size)
+				.mapToObj(i -> {
+					try {
+						return MedicalTypeHelper.setup(i);
+					} catch (OHException e) {
+						e.printStackTrace();
+					}
+					return null;
+				}).collect(Collectors.toList());
+	}
+
+	public static String asJsonString(MedicalTypeDTO body) {
+		try {
+			return getObjectMapper().writeValueAsString(body);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static ObjectMapper getObjectMapper() {
+		if (objectMapper == null) {
+			objectMapper = new ObjectMapper()
+					.registerModule(new ParameterNamesModule())
+					.registerModule(new Jdk8Module())
+					.registerModule(new JavaTimeModule());
+		}
+		return objectMapper;
+	}
+
+}

--- a/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
+++ b/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -88,7 +88,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testGetAllMedicalTypes_200() throws Exception {
+	void getAllMedicalTypes_200() throws Exception {
 		String request = "/medicaltypes";
 
 		List<MedicalType> results = MedicalTypeHelper.setupMedicalTypeList(3);
@@ -110,7 +110,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testNewMedicalType_201() throws Exception {
+	void newMedicalType_201() throws Exception {
 		String request = "/medicaltypes";
 		MedicalType medicalType = MedicalTypeHelper.setup(1);
 		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
@@ -132,7 +132,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateMedicalType_200() throws Exception {
+	void updateMedicalType_200() throws Exception {
 		String request = "/medicaltypes";
 		MedicalType medicalType = MedicalTypeHelper.setup(2);
 		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
@@ -157,7 +157,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testUpdateMedicalType_404() throws Exception {
+	void updateMedicalType_404() throws Exception {
 		String request = "/medicaltypes";
 		MedicalType medicalType = MedicalTypeHelper.setup(3);
 		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
@@ -178,7 +178,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testIsCodeUsed_200() throws Exception {
+	void isCodeUsed_200() throws Exception {
 		String request = "/medicaltypes/check/{code}";
 		MedicalType medicalType = MedicalTypeHelper.setup(4);
 		String code = medicalType.getCode();
@@ -198,7 +198,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteMedicalType_200() throws Exception {
+	void deleteMedicalType_200() throws Exception {
 		String request = "/medicaltypes/{code}";
 		MedicalType medicalType = MedicalTypeHelper.setup(5);
 		String code = medicalType.getCode();
@@ -219,7 +219,7 @@ class MedicalTypeControllerTest {
 	}
 
 	@Test
-	void testDeleteMedicalType_404() throws Exception {
+	void deleteMedicalType_404() throws Exception {
 		String request = "/medicaltypes/{code}";
 		MedicalType medicalType = MedicalTypeHelper.setup(6);
 		String code = medicalType.getCode();

--- a/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
+++ b/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
@@ -1,0 +1,239 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.medtype.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.isf.medtype.data.MedicalTypeHelper;
+import org.isf.medtype.dto.MedicalTypeDTO;
+import org.isf.medtype.manager.MedicalTypeBrowserManager;
+import org.isf.medtype.mapper.MedicalTypeMapper;
+import org.isf.medtype.model.MedicalType;
+import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
+import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
+import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class MedicalTypeControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MedicalTypeControllerTest.class);
+
+	@Mock
+	protected MedicalTypeBrowserManager medicalTypeBrowserManager;
+
+	protected MedicalTypeMapper medicalTypeMapper = new MedicalTypeMapper();
+
+	private MockMvc mockMvc;
+
+	private AutoCloseable closeable;
+
+	@BeforeEach
+	void setup() {
+		closeable = MockitoAnnotations.openMocks(this);
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new MedicalTypeController(medicalTypeBrowserManager, medicalTypeMapper))
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+		ModelMapper modelMapper = new ModelMapper();
+		modelMapper.addConverter(new BlobToByteArrayConverter());
+		modelMapper.addConverter(new ByteArrayToBlobConverter());
+		ReflectionTestUtils.setField(medicalTypeMapper, "modelMapper", modelMapper);
+	}
+
+	@AfterEach
+	void closeService() throws Exception {
+		closeable.close();
+	}
+
+	@Test
+	void testGetAllMedicalTypes_200() throws Exception {
+		String request = "/medicaltypes";
+
+		List<MedicalType> results = MedicalTypeHelper.setupMedicalTypeList(3);
+
+		List<MedicalTypeDTO> parsedResults = medicalTypeMapper.map2DTOList(results);
+
+		when(medicalTypeBrowserManager.getMedicalType())
+			.thenReturn(results);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(MedicalTypeHelper.getObjectMapper().writeValueAsString(parsedResults))))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewMedicalType_201() throws Exception {
+		String request = "/medicaltypes";
+		MedicalType medicalType = MedicalTypeHelper.setup(1);
+		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
+
+		when(medicalTypeBrowserManager.newMedicalType(medicalTypeMapper.map2Model(body)))
+			.thenReturn(medicalType);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateMedicalType_200() throws Exception {
+		String request = "/medicaltypes";
+		MedicalType medicalType = MedicalTypeHelper.setup(2);
+		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
+
+		when(medicalTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(true);
+
+		when(medicalTypeBrowserManager.updateMedicalType(medicalTypeMapper.map2Model(body)))
+			.thenReturn(medicalType);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateMedicalType_404() throws Exception {
+		String request = "/medicaltypes";
+		MedicalType medicalType = MedicalTypeHelper.setup(3);
+		MedicalTypeDTO body = medicalTypeMapper.map2DTO(medicalType);
+
+		when(medicalTypeBrowserManager.isCodePresent(body.getCode()))
+			.thenReturn(false);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testIsCodeUsed_200() throws Exception {
+		String request = "/medicaltypes/check/{code}";
+		MedicalType medicalType = MedicalTypeHelper.setup(4);
+		String code = medicalType.getCode();
+
+		when(medicalTypeBrowserManager.isCodePresent(code))
+			.thenReturn(true);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("true")))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteMedicalType_200() throws Exception {
+		String request = "/medicaltypes/{code}";
+		MedicalType medicalType = MedicalTypeHelper.setup(5);
+		String code = medicalType.getCode();
+
+		when(medicalTypeBrowserManager.getMedicalType())
+			.thenReturn(List.of(medicalType));
+
+		String isDeleted = "true";
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(isDeleted)))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeleteMedicalType_404() throws Exception {
+		String request = "/medicaltypes/{code}";
+		MedicalType medicalType = MedicalTypeHelper.setup(6);
+		String code = medicalType.getCode();
+
+		when(medicalTypeBrowserManager.getMedicalType())
+			.thenReturn(List.of(MedicalTypeHelper.setup(7)));
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+}

--- a/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
+++ b/src/test/java/org/isf/medtype/rest/MedicalTypeControllerTest.java
@@ -21,7 +21,7 @@
  */
 package org.isf.medtype.rest;
 
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -48,17 +49,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.modelmapper.ModelMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class MedicalTypeControllerTest {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(MedicalTypeControllerTest.class);
 
 	@Mock
 	protected MedicalTypeBrowserManager medicalTypeBrowserManager;
@@ -93,20 +89,16 @@ class MedicalTypeControllerTest {
 
 		List<MedicalType> results = MedicalTypeHelper.setupMedicalTypeList(3);
 
-		List<MedicalTypeDTO> parsedResults = medicalTypeMapper.map2DTOList(results);
-
 		when(medicalTypeBrowserManager.getMedicalType())
 			.thenReturn(results);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(get(request))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(MedicalTypeHelper.getObjectMapper().writeValueAsString(parsedResults))))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$", hasSize(3)))
+			.andExpect(jsonPath("$[0].code").value("Z0"))
+			.andExpect(jsonPath("$[0].description").value("TestDescription"));
 	}
 
 	@Test
@@ -118,17 +110,15 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.newMedicalType(medicalTypeMapper.map2Model(body)))
 			.thenReturn(medicalType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isCreated())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("Z1"))
+			.andExpect(jsonPath("$.description").value("TestDescription"));
 	}
 
 	@Test
@@ -143,17 +133,15 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.updateMedicalType(medicalTypeMapper.map2Model(body)))
 			.thenReturn(medicalType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("Z2"))
+			.andExpect(jsonPath("$.description").value("TestDescription"));
 	}
 
 	@Test
@@ -165,16 +153,15 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.isCodePresent(body.getCode()))
 			.thenReturn(false);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(MedicalTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Medical type not found."));
 	}
 
 	@Test
@@ -186,15 +173,11 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.isCodePresent(code))
 			.thenReturn(true);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(get(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("true")))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("true"));
 	}
 
 	@Test
@@ -206,16 +189,11 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.getMedicalType())
 			.thenReturn(List.of(medicalType));
 
-		String isDeleted = "true";
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("true"));
 	}
 
 	@Test
@@ -227,13 +205,11 @@ class MedicalTypeControllerTest {
 		when(medicalTypeBrowserManager.getMedicalType())
 			.thenReturn(List.of(MedicalTypeHelper.setup(7)));
 
-		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
+		this.mockMvc
+			.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Medical type not found."));
 	}
 
 }


### PR DESCRIPTION
Sub-task of OP-1237 (Testing Coverage Improvements - API): https://openhospital.atlassian.net/browse/OP-1258

Adds test coverage for the `org.isf.medtype` REST layer: `MedicalTypeControllerTest` (MockMvc standalone) covering all `MedicalTypeController` endpoints — list, create (201), update (200 and 404 when the code is missing), code check, and delete (200 and 404 when the code is not found) — plus a `MedicalTypeHelper` for the test data, following the existing `*TypeControllerTest` convention.
