### PR TITLE
OP-1267 Add test coverage for the pregnant treatment type REST layer

### DIFF
--- a/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
+++ b/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
+++ b/src/test/java/org/isf/pregtreattype/data/PregnantTreatmentTypeHelper.java
@@ -26,10 +26,19 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.isf.pregtreattype.TestPregnantTreatmentType;
+import org.isf.pregtreattype.dto.PregnantTreatmentTypeDTO;
 import org.isf.pregtreattype.model.PregnantTreatmentType;
 import org.isf.utils.exception.OHException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
 public class PregnantTreatmentTypeHelper {
+
+	private static ObjectMapper objectMapper;
 
 	public static PregnantTreatmentType setup() throws OHException {
 		TestPregnantTreatmentType testPregnantTreatmentType = new TestPregnantTreatmentType();
@@ -46,6 +55,25 @@ public class PregnantTreatmentTypeHelper {
 					}
 					return null;
 				}).collect(Collectors.toList());
+	}
+
+	public static String asJsonString(PregnantTreatmentTypeDTO body) {
+		try {
+			return getObjectMapper().writeValueAsString(body);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static ObjectMapper getObjectMapper() {
+		if (objectMapper == null) {
+			objectMapper = new ObjectMapper()
+					.registerModule(new ParameterNamesModule())
+					.registerModule(new Jdk8Module())
+					.registerModule(new JavaTimeModule());
+		}
+		return objectMapper;
 	}
 
 }

--- a/src/test/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeControllerTest.java
+++ b/src/test/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeControllerTest.java
@@ -1,0 +1,220 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.pregtreattype.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.isf.pregtreattype.data.PregnantTreatmentTypeHelper;
+import org.isf.pregtreattype.dto.PregnantTreatmentTypeDTO;
+import org.isf.pregtreattype.manager.PregnantTreatmentTypeBrowserManager;
+import org.isf.pregtreattype.mapper.PregnantTreatmentTypeMapper;
+import org.isf.pregtreattype.model.PregnantTreatmentType;
+import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
+import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
+import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class PregnantTreatmentTypeControllerTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PregnantTreatmentTypeControllerTest.class);
+
+	@Mock
+	protected PregnantTreatmentTypeBrowserManager pregnantTreatmentTypeManager;
+
+	protected PregnantTreatmentTypeMapper pregnantTreatmentTypeMapper = new PregnantTreatmentTypeMapper();
+
+	private MockMvc mockMvc;
+
+	private AutoCloseable closeable;
+
+	@BeforeEach
+	void setup() {
+		closeable = MockitoAnnotations.openMocks(this);
+		this.mockMvc = MockMvcBuilders
+			.standaloneSetup(new PregnantTreatmentTypeController(pregnantTreatmentTypeManager, pregnantTreatmentTypeMapper))
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+		ModelMapper modelMapper = new ModelMapper();
+		modelMapper.addConverter(new BlobToByteArrayConverter());
+		modelMapper.addConverter(new ByteArrayToBlobConverter());
+		ReflectionTestUtils.setField(pregnantTreatmentTypeMapper, "modelMapper", modelMapper);
+	}
+
+	@AfterEach
+	void closeService() throws Exception {
+		closeable.close();
+	}
+
+	@Test
+	void testGetAllPregnantTreatmentTypes_200() throws Exception {
+		String request = "/pregnanttreatmenttypes";
+
+		List<PregnantTreatmentType> results = PregnantTreatmentTypeHelper.setupPregnantTreatmentTypeList(3);
+
+		List<PregnantTreatmentTypeDTO> parsedResults = pregnantTreatmentTypeMapper.map2DTOList(results);
+
+		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
+			.thenReturn(results);
+
+		MvcResult result = this.mockMvc
+			.perform(get(request))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(PregnantTreatmentTypeHelper.getObjectMapper().writeValueAsString(parsedResults))))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testNewPregnantTreatmentType_201() throws Exception {
+		String request = "/pregnanttreatmenttypes";
+		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
+		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
+
+		when(pregnantTreatmentTypeManager.newPregnantTreatmentType(pregnantTreatmentTypeMapper.map2Model(body)))
+			.thenReturn(pregnantTreatmentType);
+
+		MvcResult result = this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdatePregnantTreatmentType_200() throws Exception {
+		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
+		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
+		String request = "/pregnanttreatmenttypes/{code}";
+		String code = body.getCode();
+
+		when(pregnantTreatmentTypeManager.isCodePresent(code))
+			.thenReturn(true);
+
+		when(pregnantTreatmentTypeManager.updatePregnantTreatmentType(pregnantTreatmentTypeMapper.map2Model(body)))
+			.thenReturn(pregnantTreatmentType);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request, code)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdatePregnantTreatmentType_404() throws Exception {
+		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
+		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
+		String request = "/pregnanttreatmenttypes/{code}";
+		String code = body.getCode();
+
+		when(pregnantTreatmentTypeManager.isCodePresent(code))
+			.thenReturn(false);
+
+		MvcResult result = this.mockMvc
+			.perform(put(request, code)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeletePregnantTreatmentType_200() throws Exception {
+		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
+		String request = "/pregnanttreatmenttypes/{code}";
+		String code = pregnantTreatmentType.getCode();
+
+		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
+			.thenReturn(List.of(pregnantTreatmentType));
+
+		String isDeleted = "true";
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString(isDeleted)))
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testDeletePregnantTreatmentType_404() throws Exception {
+		String request = "/pregnanttreatmenttypes/{code}";
+		String code = "nonExistingCode";
+
+		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
+			.thenReturn(List.of());
+
+		MvcResult result = this.mockMvc
+			.perform(delete(request, code))
+			.andDo(log())
+			.andExpect(status().isNotFound())
+			.andReturn();
+
+		LOGGER.debug("result: {}", result);
+	}
+
+}

--- a/src/test/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeControllerTest.java
+++ b/src/test/java/org/isf/pregtreattype/rest/PregnantTreatmentTypeControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -22,6 +22,7 @@
 package org.isf.pregtreattype.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -48,17 +50,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.modelmapper.ModelMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class PregnantTreatmentTypeControllerTest {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(PregnantTreatmentTypeControllerTest.class);
 
 	@Mock
 	protected PregnantTreatmentTypeBrowserManager pregnantTreatmentTypeManager;
@@ -88,7 +85,7 @@ class PregnantTreatmentTypeControllerTest {
 	}
 
 	@Test
-	void testGetAllPregnantTreatmentTypes_200() throws Exception {
+	void getAllPregnantTreatmentTypes_200() throws Exception {
 		String request = "/pregnanttreatmenttypes";
 
 		List<PregnantTreatmentType> results = PregnantTreatmentTypeHelper.setupPregnantTreatmentTypeList(3);
@@ -98,19 +95,18 @@ class PregnantTreatmentTypeControllerTest {
 		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
 			.thenReturn(results);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(get(request))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString(PregnantTreatmentTypeHelper.getObjectMapper().writeValueAsString(parsedResults))))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$", hasSize(3)))
+			.andExpect(jsonPath("$[0].code").value("ZZ"))
+			.andExpect(jsonPath("$[0].description").value("TestDescription"));
 	}
 
 	@Test
-	void testNewPregnantTreatmentType_201() throws Exception {
+	void newPregnantTreatmentType_201() throws Exception {
 		String request = "/pregnanttreatmenttypes";
 		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
 		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
@@ -118,21 +114,40 @@ class PregnantTreatmentTypeControllerTest {
 		when(pregnantTreatmentTypeManager.newPregnantTreatmentType(pregnantTreatmentTypeMapper.map2Model(body)))
 			.thenReturn(pregnantTreatmentType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(post(request)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isCreated())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("ZZ"))
+			.andExpect(jsonPath("$.description").value("TestDescription"))
+			.andExpect(jsonPath("$.hashCode").value(0));
 	}
 
 	@Test
-	void testUpdatePregnantTreatmentType_200() throws Exception {
+	void newPregnantTreatmentType_400() throws Exception {
+		String request = "/pregnanttreatmenttypes";
+		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
+		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
+
+		when(pregnantTreatmentTypeManager.newPregnantTreatmentType(pregnantTreatmentTypeMapper.map2Model(body)))
+			.thenReturn(null);
+
+		this.mockMvc
+			.perform(post(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
+			)
+			.andDo(log())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("Pregnant Treatment Type not created."));
+	}
+
+	@Test
+	void updatePregnantTreatmentType_200() throws Exception {
 		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
 		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
 		String request = "/pregnanttreatmenttypes/{code}";
@@ -144,21 +159,20 @@ class PregnantTreatmentTypeControllerTest {
 		when(pregnantTreatmentTypeManager.updatePregnantTreatmentType(pregnantTreatmentTypeMapper.map2Model(body)))
 			.thenReturn(pregnantTreatmentType);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request, code)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.code").value("ZZ"))
+			.andExpect(jsonPath("$.description").value("TestDescription"))
+			.andExpect(jsonPath("$.hashCode").value(0));
 	}
 
 	@Test
-	void testUpdatePregnantTreatmentType_404() throws Exception {
+	void updatePregnantTreatmentType_404() throws Exception {
 		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
 		PregnantTreatmentTypeDTO body = pregnantTreatmentTypeMapper.map2DTO(pregnantTreatmentType);
 		String request = "/pregnanttreatmenttypes/{code}";
@@ -167,20 +181,19 @@ class PregnantTreatmentTypeControllerTest {
 		when(pregnantTreatmentTypeManager.isCodePresent(code))
 			.thenReturn(false);
 
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(put(request, code)
 				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(PregnantTreatmentTypeHelper.asJsonString(body)))
 			)
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Pregnant Treatment Type not found."));
 	}
 
 	@Test
-	void testDeletePregnantTreatmentType_200() throws Exception {
+	void deletePregnantTreatmentType_200() throws Exception {
 		PregnantTreatmentType pregnantTreatmentType = PregnantTreatmentTypeHelper.setup();
 		String request = "/pregnanttreatmenttypes/{code}";
 		String code = pregnantTreatmentType.getCode();
@@ -188,33 +201,26 @@ class PregnantTreatmentTypeControllerTest {
 		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
 			.thenReturn(List.of(pregnantTreatmentType));
 
-		String isDeleted = "true";
-		MvcResult result = this.mockMvc
+		this.mockMvc
 			.perform(delete(request, code))
 			.andDo(log())
-			.andExpect(status().is2xxSuccessful())
 			.andExpect(status().isOk())
-			.andExpect(content().string(containsString(isDeleted)))
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(content().string("true"));
 	}
 
 	@Test
-	void testDeletePregnantTreatmentType_404() throws Exception {
+	void deletePregnantTreatmentType_404() throws Exception {
 		String request = "/pregnanttreatmenttypes/{code}";
 		String code = "nonExistingCode";
 
 		when(pregnantTreatmentTypeManager.getPregnantTreatmentType())
 			.thenReturn(List.of());
 
-		MvcResult result = this.mockMvc
-			.perform(delete(request, code))
+		this.mockMvc
+			.perform(delete(request, code).accept(MediaType.APPLICATION_JSON))
 			.andDo(log())
 			.andExpect(status().isNotFound())
-			.andReturn();
-
-		LOGGER.debug("result: {}", result);
+			.andExpect(jsonPath("$.message").value("Pregnant Treatment Type not found."));
 	}
 
 }


### PR DESCRIPTION
Sub-task of OP-1237 (Testing Coverage Improvements - API): https://openhospital.atlassian.net/browse/OP-1267

Adds test coverage for the `org.isf.pregtreattype` REST layer: `PregnantTreatmentTypeControllerTest` (MockMvc standalone) covering all endpoints — list, create (201), update (200 and 404 when the code is not present) and delete (200 and 404 when the code is not found) — and extends the existing `PregnantTreatmentTypeHelper` with the JSON serialization helpers used by the controller test.
