### PR TITLE
OP-1424 Fix AdmissionDTO.deleted mapping regressed by the SoftDeletableAuditable change

### DIFF
--- a/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
+++ b/src/main/java/org/isf/admission/mapper/AdmissionMapper.java
@@ -24,9 +24,12 @@ package org.isf.admission.mapper;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.PostConstruct;
+
 import org.isf.admission.dto.AdmissionDTO;
 import org.isf.admission.model.Admission;
 import org.isf.shared.GenericMapper;
+import org.isf.shared.mapper.mappings.AdmissionMapping;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +37,11 @@ public class AdmissionMapper extends GenericMapper<Admission, AdmissionDTO> {
 
 	public AdmissionMapper() {
 		super(Admission.class, AdmissionDTO.class);
+	}
+
+	@PostConstruct
+	private void postConstruct() {
+		AdmissionMapping.addMapping(modelMapper);
 	}
 
 	@Override

--- a/src/main/java/org/isf/shared/mapper/mappings/AdmissionMapping.java
+++ b/src/main/java/org/isf/shared/mapper/mappings/AdmissionMapping.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/shared/mapper/mappings/AdmissionMapping.java
+++ b/src/main/java/org/isf/shared/mapper/mappings/AdmissionMapping.java
@@ -1,0 +1,49 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.shared.mapper.mappings;
+
+import org.isf.admission.dto.AdmissionDTO;
+import org.isf.admission.model.Admission;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+
+public class AdmissionMapping {
+
+	public static void addMapping(ModelMapper modelMapper) {
+		// Admission extends SoftDeletableAuditable, which adds the String fields deletedBy/deletedDate.
+		// With ambiguity ignored, ModelMapper otherwise matches one of those to the DTO's String 'deleted'
+		// instead of the char 'deleted', leaving it null. Map the 'deleted' flag explicitly in both
+		// directions with a converter (the char <-> String conversion cannot be expressed as a plain getter).
+		modelMapper.getConfiguration().setAmbiguityIgnored(true);
+
+		Converter<Character, String> charToString =
+			context -> context.getSource() == null ? null : String.valueOf(context.getSource().charValue());
+		Converter<String, Character> stringToChar =
+			context -> context.getSource() == null || context.getSource().isEmpty() ? 'N' : context.getSource().charAt(0);
+
+		modelMapper.typeMap(Admission.class, AdmissionDTO.class).addMappings(mapper ->
+			mapper.using(charToString).map(Admission::getDeleted, AdmissionDTO::setDeleted));
+
+		modelMapper.typeMap(AdmissionDTO.class, Admission.class).addMappings(mapper ->
+			mapper.using(stringToChar).map(AdmissionDTO::getDeleted, Admission::setDeleted));
+	}
+}

--- a/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
+++ b/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
@@ -65,6 +65,7 @@ import org.isf.pregtreattype.model.PregnantTreatmentType;
 import org.isf.shared.exceptions.OHResponseEntityExceptionHandler;
 import org.isf.shared.mapper.converter.BlobToByteArrayConverter;
 import org.isf.shared.mapper.converter.ByteArrayToBlobConverter;
+import org.isf.shared.mapper.mappings.AdmissionMapping;
 import org.isf.shared.mapper.mappings.PatientMapping;
 import org.isf.ward.data.WardHelper;
 import org.isf.ward.manager.WardBrowserManager;
@@ -143,6 +144,7 @@ class AdmissionControllerTest {
 		modelMapper.addConverter(new BlobToByteArrayConverter());
 		modelMapper.addConverter(new ByteArrayToBlobConverter());
 		PatientMapping.addMapping(modelMapper);
+		AdmissionMapping.addMapping(modelMapper);
 		ReflectionTestUtils.setField(admissionMapper, "modelMapper", modelMapper);
 		ReflectionTestUtils.setField(admittedMapper, "modelMapper", modelMapper);
 	}


### PR DESCRIPTION
Fixes OP-1424: https://openhospital.atlassian.net/browse/OP-1424

Since OP-1005 made `Admission` extend `SoftDeletableAuditable` (adding the `String` fields `deletedBy`/`deletedDate`), ModelMapper — with ambiguity ignored — maps the DTO's `String deleted` from one of those new fields instead of the model's `char deleted`, leaving it null. `POST /admissions` and `PUT /admissions/{code}` then fail `@Valid` with **400**, so `AdmissionControllerTest.testNewAdmissions_201` and `testDischargeAdmission_200` fail on `develop` and redden the CI of **every open openhospital-api PR** (the api PR build runs against `develop`).

**Fix:** map `deleted` explicitly in both directions with a `char <-> String` converter (`AdmissionMapping`), wired via `@PostConstruct` in `AdmissionMapper` and in the controller test setup — the same pattern already used by `PatientMapping`. The full `openhospital-api` test suite is green (229 tests).

cc @mwithi @dbmalkovsky — this is a `develop` regression from OP-1005 (#1603 / core) that currently blocks the CI of all open api PRs.
