### PR TITLE
OP-1430 Expose the password policy via GET /auth/password-policy

### DIFF
--- a/openapi/oh.yaml
+++ b/openapi/oh.yaml
@@ -5785,6 +5785,20 @@ paths:
                   $ref: "#/components/schemas/BillItemsDTO"
       security:
       - bearerAuth: []
+  /auth/password-policy:
+    get:
+      tags:
+      - Login
+      operationId: getPasswordPolicy
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PasswordPolicyDTO"
+      security:
+      - bearerAuth: []
   /agetypes/{index}:
     get:
       tags:
@@ -8431,6 +8445,26 @@ components:
             $ref: "#/components/schemas/PatientExaminationDTO"
         pageInfo:
           $ref: "#/components/schemas/PageInfoDTO"
+    PasswordPolicyDTO:
+      type: object
+      description: "The password policy enforced by the server, so clients can validate\
+        \ passwords consistently"
+      properties:
+        strongPasswordEnabled:
+          type: boolean
+          description: Whether the strong-password policy (character requirements)
+            is enforced
+          example: true
+        minLength:
+          type: integer
+          format: int32
+          description: "The minimum password length, or 0 when no minimum-length policy\
+            \ is enforced"
+          example: 6
+        regex:
+          type: string
+          description: The regular expression a password must match when the strong-password
+            policy is enabled
     PageAdmissionDTO:
       type: object
       properties:

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -107,7 +107,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable()) // Disable CSRF protection
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/healthcheck").permitAll()
-				.requestMatchers("/auth/login", "/auth/refresh-token").permitAll()
+				.requestMatchers("/auth/login", "/auth/refresh-token", "/auth/password-policy").permitAll()
 				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
 				// admissions
 				.requestMatchers(HttpMethod.POST, "/admissions/**").hasAuthority("admissions.create")

--- a/src/main/java/org/isf/login/dto/PasswordPolicyDTO.java
+++ b/src/main/java/org/isf/login/dto/PasswordPolicyDTO.java
@@ -1,0 +1,71 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "The password policy enforced by the server, so clients can validate passwords consistently")
+public class PasswordPolicyDTO {
+
+	@Schema(description = "Whether the strong-password policy (character requirements) is enforced", example = "true")
+	private boolean strongPasswordEnabled;
+
+	@Schema(description = "The minimum password length, or 0 when no minimum-length policy is enforced", example = "6")
+	private int minLength;
+
+	@Schema(description = "The regular expression a password must match when the strong-password policy is enabled")
+	private String regex;
+
+	public PasswordPolicyDTO() {
+	}
+
+	public PasswordPolicyDTO(boolean strongPasswordEnabled, int minLength, String regex) {
+		this.strongPasswordEnabled = strongPasswordEnabled;
+		this.minLength = minLength;
+		this.regex = regex;
+	}
+
+	public boolean isStrongPasswordEnabled() {
+		return strongPasswordEnabled;
+	}
+
+	public void setStrongPasswordEnabled(boolean strongPasswordEnabled) {
+		this.strongPasswordEnabled = strongPasswordEnabled;
+	}
+
+	public int getMinLength() {
+		return minLength;
+	}
+
+	public void setMinLength(int minLength) {
+		this.minLength = minLength;
+	}
+
+	public String getRegex() {
+		return regex;
+	}
+
+	public void setRegex(String regex) {
+		this.regex = regex;
+	}
+
+}

--- a/src/main/java/org/isf/login/rest/LoginController.java
+++ b/src/main/java/org/isf/login/rest/LoginController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/login/rest/LoginController.java
+++ b/src/main/java/org/isf/login/rest/LoginController.java
@@ -28,6 +28,7 @@ import jakarta.validation.Valid;
 
 import org.isf.login.dto.LoginRequest;
 import org.isf.login.dto.LoginResponse;
+import org.isf.login.dto.PasswordPolicyDTO;
 import org.isf.login.dto.TokenRefreshRequest;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
@@ -46,6 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -155,6 +157,17 @@ public class LoginController {
 		} catch (JwtException e) {
 			throw new OHAPIException(new OHExceptionMessage("Refresh token expired or invalid"));
 		}
+	}
+
+	/**
+	 * Exposes the server-side password policy so that clients can validate passwords consistently with the backend,
+	 * instead of hardcoding their own rules. Public, because a client may need it before it has a valid session
+	 * (for example on a forced change-password screen reached with a stale token).
+	 */
+	@GetMapping("/auth/password-policy")
+	public PasswordPolicyDTO getPasswordPolicy() {
+		return new PasswordPolicyDTO(userManager.isStrongPasswordEnabled(), userManager.getPasswordMinLength(),
+			userManager.getPasswordStrengthRegex());
 	}
 
 	private boolean mustChangePassword(User user, boolean passwordExpired) {

--- a/src/main/java/org/isf/security/jwt/MustChangePasswordFilter.java
+++ b/src/main/java/org/isf/security/jwt/MustChangePasswordFilter.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/security/jwt/MustChangePasswordFilter.java
+++ b/src/main/java/org/isf/security/jwt/MustChangePasswordFilter.java
@@ -58,6 +58,8 @@ public class MustChangePasswordFilter extends GenericFilterBean {
 		// normally consumed by Spring's LogoutFilter before this filter runs, kept as belt-and-braces
 		{ "POST", "/auth/logout" },
 		{ "POST", "/auth/refresh-token" },
+		// the password policy is public configuration the client may need before it can present a valid session
+		{ "GET", "/auth/password-policy" },
 		// the healthcheck must never require any authentication state
 		{ "GET", "/healthcheck" }
 	};

--- a/src/test/java/org/isf/login/rest/LoginControllerTest.java
+++ b/src/test/java/org/isf/login/rest/LoginControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,6 +39,7 @@ import jakarta.servlet.http.HttpSession;
 import org.isf.OpenHospitalApiApplication;
 import org.isf.login.dto.LoginRequest;
 import org.isf.login.dto.LoginResponse;
+import org.isf.login.dto.PasswordPolicyDTO;
 import org.isf.login.dto.TokenRefreshRequest;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
@@ -137,6 +139,21 @@ class LoginControllerTest {
 		mvc.perform(post("/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(UserHelper.asJsonString(loginRequest))))
+			.andExpect(status().isOk())
+			.andExpect(content().string(Objects.requireNonNull(expectedJson)))
+			.andReturn();
+	}
+
+	@Test
+	void testGetPasswordPolicy() throws Exception {
+		when(userManager.isStrongPasswordEnabled()).thenReturn(true);
+		when(userManager.getPasswordMinLength()).thenReturn(6);
+		when(userManager.getPasswordStrengthRegex()).thenReturn("^(?=.*[0-9]).+$");
+
+		PasswordPolicyDTO expected = new PasswordPolicyDTO(true, 6, "^(?=.*[0-9]).+$");
+		String expectedJson = UserHelper.asJsonString(expected);
+
+		mvc.perform(get("/auth/password-policy"))
 			.andExpect(status().isOk())
 			.andExpect(content().string(Objects.requireNonNull(expectedJson)))
 			.andReturn();

--- a/src/test/java/org/isf/login/rest/LoginControllerTest.java
+++ b/src/test/java/org/isf/login/rest/LoginControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2024 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *


### PR DESCRIPTION
Part of OP-1430: https://openhospital.atlassian.net/browse/OP-1430

Adds a public `GET /auth/password-policy` on `LoginController` returning a `PasswordPolicyDTO` (`strongPasswordEnabled`, `minLength`, `regex`) built from the core accessors, so clients can validate passwords consistently with the backend instead of hardcoding their own rules. Whitelisted in `SecurityConfig` **and** in `MustChangePasswordFilter.ALLOWED_ENDPOINTS` (a client still holding a must-change-password token must not get a 403 for this public, session-independent config). `openapi/oh.yaml` is regenerated with the new path + schema; a controller test is added.

The API-side strength/length enforcement already landed with OP-896 (`UserController.validatePasswordStrength` → core `isPasswordValid`); this PR only exposes the policy so clients can mirror it.

Companion PRs: core informatici/openhospital-core#1647 · ui informatici/openhospital-ui#783
Depends on the core PR (new accessors).
