### PR TITLE
OP-1431 Reject reusing the current password on a self password change

### DIFF
--- a/src/main/java/org/isf/users/rest/UserController.java
+++ b/src/main/java/org/isf/users/rest/UserController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/users/rest/UserController.java
+++ b/src/main/java/org/isf/users/rest/UserController.java
@@ -248,6 +248,8 @@ public class UserController {
 			throw new OHAPIException(new OHExceptionMessage("The password must be changed before updating the profile."), HttpStatus.FORBIDDEN);
 		}
 		validatePasswordStrength(userDTO.getPasswd());
+		// OP-1431: a forced/self password change must not reuse the current password
+		validatePasswordNotReused(entity, userDTO.getPasswd());
 		User user = userMapper.map2Model(userDTO);
 		user.setUserGroupName(entity.getUserGroupName());
 		User updatedUser;
@@ -276,6 +278,20 @@ public class UserController {
 	private void validatePasswordStrength(String password) throws OHAPIException {
 		if (password != null && !password.isEmpty() && !userManager.isPasswordValid(password)) {
 			throw new OHAPIException(new OHExceptionMessage("The password does not meet the strength requirements."), HttpStatus.BAD_REQUEST);
+		}
+	}
+
+	/**
+	 * Rejects a new password that is the same as the user's current one (OP-1431). No-op when no password is
+	 * provided, so that requests that only update other user fields are not affected.
+	 *
+	 * @param currentUser the user whose current password to compare against
+	 * @param newPassword the plain-text candidate password (may be {@code null} or empty)
+	 * @throws OHAPIException if the new password matches the user's current one
+	 */
+	private void validatePasswordNotReused(User currentUser, String newPassword) throws OHAPIException {
+		if (newPassword != null && !newPassword.isEmpty() && userManager.isSameAsCurrentPassword(currentUser, newPassword)) {
+			throw new OHAPIException(new OHExceptionMessage("The new password must be different from the current one."), HttpStatus.BAD_REQUEST);
 		}
 	}
 

--- a/src/test/java/org/isf/users/rest/UserControllerTest.java
+++ b/src/test/java/org/isf/users/rest/UserControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/users/rest/UserControllerTest.java
+++ b/src/test/java/org/isf/users/rest/UserControllerTest.java
@@ -630,6 +630,24 @@ class UserControllerTest {
 		}
 
 		@Test
+		@DisplayName("Should reject reusing the current password on profile update")
+		@WithMockUser(username = "doctor")
+		void shouldRejectReusingCurrentPassword() throws Exception {
+			var user = new User("doctor", new UserGroup("doctor", "Doctor group"), "SamePass1@", "Simple user");
+
+			when(userManager.getUserByName(any())).thenReturn(user);
+			when(userManager.isSameAsCurrentPassword(any(), any())).thenReturn(true);
+
+			mvc.perform(
+					put("/users/me").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(userMapper.map2DTO(user))))
+				.andDo(log())
+				.andExpect(status().isBadRequest())
+				.andReturn();
+
+			verify(userManager, never()).updatePassword(any());
+		}
+
+		@Test
 		@DisplayName("Should update user without updating password")
 		@WithMockUser(username = "doctor")
 		void shouldUpdateUserWithoutUpdatingPassword() throws Exception {


### PR DESCRIPTION
## What

The self change-password endpoint (`PUT /users/me`) now rejects a new password equal to the current one, returning `400`. A new private `validatePasswordNotReused` mirrors the existing `validatePasswordStrength` and delegates to the core `UserBrowsingManager.isSameAsCurrentPassword`.

## Why

Follow-up to the password-policy work (OP-896 / OP-1430): a user renewing their own password must not be allowed to reuse the current one. The administrator reset path (`PUT /users/{username}`) is intentionally left unchanged, since an administrator does not know the target user's current password.

## Notes

- No change to the OpenAPI contract: no new endpoint or schema, only an added validation on an existing, already 400-capable endpoint.
- Controller test `shouldRejectReusingCurrentPassword`.

Depends on openhospital-core: OP-1431 (`isSameAsCurrentPassword`).

Jira: OP-1431

---
Related PRs: openhospital-core #1648 · openhospital-api #608 · openhospital-gui #2236
