### PR TITLE
OP-892 Preserve the admission sex/age snapshot on update

### DIFF
--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/main/java/org/isf/admission/rest/AdmissionController.java
+++ b/src/main/java/org/isf/admission/rest/AdmissionController.java
@@ -548,6 +548,11 @@ public class AdmissionController {
 
 		Admission updateAdmission = admissionMapper.map2Model(updateAdmissionDTO);
 
+		// OP-892: the sex/age snapshot is taken at insertion and is not part of the DTO, so carry it
+		// over from the stored admission or the mapped entity would overwrite it with null on update
+		updateAdmission.setSex(old.getSex());
+		updateAdmission.setAge(old.getAge());
+
 		if (updateAdmissionDTO.getWard() != null && updateAdmissionDTO.getWard().getCode() != null
 			&& !updateAdmissionDTO.getWard().getCode().trim().isEmpty()) {
 			List<Ward> wards = wardManager.getWards().stream()

--- a/src/main/java/org/isf/examination/rest/ExaminationController.java
+++ b/src/main/java/org/isf/examination/rest/ExaminationController.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -105,7 +105,8 @@ public class ExaminationController {
 		if (dto.getPex_ID() != id) {
 			throw new OHAPIException(new OHExceptionMessage("Patient examination id mismatch."));
 		}
-		if (examinationBrowserManager.getByID(id) == null) {
+		PatientExamination old = examinationBrowserManager.getByID(id);
+		if (old == null) {
 			throw new OHAPIException(new OHExceptionMessage("Patient examination not found."), HttpStatus.NOT_FOUND);
 		}
 
@@ -118,6 +119,10 @@ public class ExaminationController {
 		PatientExamination patientExamination = patientExaminationMapper.map2Model(dto);
 		patientExamination.setPatient(patient);
 		patientExamination.setPex_date(dto.getPex_date());
+		// OP-892: the sex/age snapshot is taken at insertion and is not part of the DTO, so carry it over
+		// from the stored examination or the mapped entity would overwrite it with null on update
+		patientExamination.setSex(old.getSex());
+		patientExamination.setAge(old.getAge());
 
 		return patientExaminationMapper.map2DTO(examinationBrowserManager.saveOrUpdate(patientExamination));
 	}

--- a/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
+++ b/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *

--- a/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
+++ b/src/test/java/org/isf/admission/rest/AdmissionControllerTest.java
@@ -22,6 +22,7 @@
 package org.isf.admission.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -73,6 +74,7 @@ import org.isf.ward.model.Ward;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.modelmapper.ModelMapper;
@@ -484,6 +486,66 @@ class AdmissionControllerTest {
 			.andReturn();
 
 		LOGGER.debug("result: {}", result);
+	}
+
+	@Test
+	void testUpdateAdmissionsPreservesSexAgeSnapshot() throws Exception {
+		String request = "/admissions";
+
+		AdmissionDTO body = AdmissionHelper.setup(admissionMapper);
+		Integer code = 10;
+		body.getPatient().setCode(code);
+
+		// the stored admission carries the OP-892 sex/age snapshot, which is not part of the DTO
+		Admission old = admissionMapper.map2Model(body);
+		old.setSex("F");
+		old.setAge(34);
+
+		when(admissionManagerMock.getAdmission(body.getId()))
+			.thenReturn(old);
+
+		List<Ward> wardList = WardHelper.setupWardList(2);
+		when(wardManagerMock.getWards())
+			.thenReturn(wardList);
+
+		List<AdmissionType> admissionTypeList = AdmissionTypeDTOHelper.setupAdmissionTypeList(3);
+		when(admissionManagerMock.getAdmissionType())
+			.thenReturn(admissionTypeList);
+
+		Patient patient = PatientHelper.setup();
+		patient.setCode(code);
+		when(patientManagerMock.getPatientById(body.getPatient().getCode()))
+			.thenReturn(patient);
+
+		List<Disease> diseaseList = DiseaseHelper.setupDiseaseList(3);
+		when(diseaseManagerMock.getDiseaseAll())
+			.thenReturn(diseaseList);
+
+		List<Operation> operationsList = OperationHelper.setupOperationList(3);
+		when(operationManagerMock.getOperation())
+			.thenReturn(operationsList);
+
+		List<DischargeType> disTypes = DischargeTypeHelper.setupDischargeTypeList(3);
+		when(admissionManagerMock.getDischargeType())
+			.thenReturn(disTypes);
+
+		List<PregnantTreatmentType> pregnancyTreatmentTypes = PregnantTreatmentTypeHelper.setupPregnantTreatmentTypeList(3);
+		when(pregnancyTreatmentTypeManagerMock.getPregnantTreatmentType())
+			.thenReturn(pregnancyTreatmentTypes);
+
+		ArgumentCaptor<Admission> savedAdmission = ArgumentCaptor.forClass(Admission.class);
+		when(admissionManagerMock.updateAdmission(savedAdmission.capture()))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		this.mockMvc
+			.perform(put(request)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(AdmissionHelper.asJsonString(body))))
+			.andDo(log())
+			.andExpect(status().isOk());
+
+		assertThat(savedAdmission.getValue().getSex()).isEqualTo("F");
+		assertThat(savedAdmission.getValue().getAge()).isEqualTo(34);
 	}
 
 }

--- a/src/test/java/org/isf/examination/rest/ExaminationControllerTest.java
+++ b/src/test/java/org/isf/examination/rest/ExaminationControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -21,6 +21,7 @@
  */
 package org.isf.examination.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -47,6 +48,7 @@ import org.isf.patient.manager.PatientBrowserManager;
 import org.isf.patient.model.Patient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -250,6 +252,35 @@ class ExaminationControllerTest {
 			.andDo(log())
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString(objectMapper.writeValueAsString(patientExaminationDTO))));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = {"examinations.update"})
+	@DisplayName("Should preserve the sex/age snapshot on update")
+	void testUpdateExaminationPreservesSexAgeSnapshot() throws Exception {
+		Patient patient = PatientHelper.setup();
+		patient.setCode(2);
+		// the stored examination carries the OP-892 sex/age snapshot, which is not part of the DTO
+		PatientExamination stored = new TestPatientExamination().setup(patient, false);
+		stored.setPex_ID(1);
+		stored.setPex_sat(100.0);
+		stored.setSex("F");
+		stored.setAge(34);
+		PatientExaminationDTO dto = mapper.map2DTO(stored);
+		dto.setPatientCode(patient.getCode());
+
+		when(manager.getByID(anyInt())).thenReturn(stored);
+		when(patientBrowserManager.getPatientById(anyInt())).thenReturn(patient);
+		ArgumentCaptor<PatientExamination> saved = ArgumentCaptor.forClass(PatientExamination.class);
+		when(manager.saveOrUpdate(saved.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		mvc.perform(put("/examinations/{id}", "1")
+				.content(objectMapper.writeValueAsString(dto))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+
+		assertThat(saved.getValue().getSex()).isEqualTo("F");
+		assertThat(saved.getValue().getAge()).isEqualTo(34);
 	}
 
 	@Test


### PR DESCRIPTION
## What

`PUT /admissions` maps the incoming DTO onto a new `Admission` entity; the OP-892 sex/age snapshot (`ADM_SEX`/`ADM_AGE`, taken at insertion and intentionally not part of the DTO) was therefore overwritten with `null` on every update. The controller now carries the snapshot over from the stored admission. Controller test pinning the behaviour.

## Why

The snapshot exists so aggregate statistics can be produced without joining the patient table (informatici/openhospital-core#1602). Without this carry-over, any admission update through the REST API silently erases it.

## Notes

- Depends on openhospital-core#1602 (the `Admission` sex/age fields): CI stays red until that PR is merged.
- No OpenAPI change: the snapshot is intentionally not exposed in `AdmissionDTO`.
- The Swing GUI does not need an equivalent fix: it updates the entity loaded from the database, so the snapshot is preserved there.

Related PRs: openhospital-core#1602 · openhospital-doc#283 · openhospital-gui#2237

Jira: OP-892
