### PR TITLE
OP-1434 Require operation-specific authorities on /bills and /stockmovements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the API project of [Open Hospital][openhospital]: it exposes a REST API 
 
 ## Summary
 
+  * [Authorization model](#authorization-model)
   * [How to build [WIP]](#how-to-build-wip)
     + [Using Swagger-UI](#using-swagger-ui)
     + [Using Postman](#using-postman)
@@ -19,6 +20,22 @@ This is the API project of [Open Hospital][openhospital]: it exposes a REST API 
 
 <small>Table of contents generated with <i><a href='http://ecotrust-canada.github.io/markdown-toc/'>markdown-toc</a></i></small>
 
+
+## Authorization model
+
+> **Experimental API.** This REST API is experimental and is not yet an officially supported, production-ready interface. Endpoints, payloads and the authorization rules described here may still change.
+
+Every request must be authenticated with a valid JWT (obtained from `/auth/login`), except the public endpoints: `/`, `/healthcheck`, `/auth/login`, `/auth/refresh-token` and the Swagger UI / OpenAPI documents.
+
+Beyond authentication, each endpoint namespace requires an operation-specific **authority** named `<namespace>.<action>`, where the action is one of `create`, `read`, `update` or `delete`, mapped respectively to the `POST`, `GET`, `PUT` and `DELETE` methods. For example `/patients` requires `patients.read` to list and `patients.create` to create; `/bills` requires the `bills.*` authorities; `/stockmovements` requires the `stockmovements.*` authorities. A few read operations are exposed over `POST` because they take a request body (for example the `/bills/search/**` endpoints); these require the corresponding `read` authority.
+
+A user's authorities come from the permissions granted to the user's group. The `admin` group is granted every permission by default; other groups must be configured with the permissions they need.
+
+The API answers:
+
+* `401 Unauthorized` when the request is not authenticated (missing or invalid token);
+* `403 Forbidden` when the user is authenticated but lacks the required authority;
+* the endpoint's normal response when the user holds the required authority.
 
 ## How to build [WIP]
 

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -309,7 +309,10 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
 				.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
 				.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
-				// stockmovements
+				// stockmovements: StockMovementController currently exposes only POST (charge/discharge) and GET, but the
+				// update/delete rules are declared on purpose (defense in depth) so that any mutating endpoint added under
+				// /stockmovements later is protected by default instead of silently falling through to
+				// anyRequest().authenticated() — which is exactly the gap this change fixes.
 				.requestMatchers(HttpMethod.POST, "/stockmovements/**").hasAuthority("stockmovements.create")
 				.requestMatchers(HttpMethod.GET, "/stockmovements/**").hasAuthority("stockmovements.read")
 				.requestMatchers(HttpMethod.PUT, "/stockmovements/**").hasAuthority("stockmovements.update")

--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 /*
  * Open Hospital (www.open-hospital.org)
- * Copyright © 2006-2025 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
  *
  * Open Hospital is a free and open source software for healthcare data management.
  *
@@ -122,6 +122,12 @@ public class SecurityConfig {
 				// age types
 				.requestMatchers(HttpMethod.GET, "/agetypes/**").hasAnyAuthority("agetypes.read")
 				.requestMatchers(HttpMethod.PUT, "/agetypes/**").hasAuthority("agetypes.update")
+				// bills (the search endpoints use POST but are read operations, so they require the read authority)
+				.requestMatchers(HttpMethod.POST, "/bills/search/**").hasAuthority("bills.read")
+				.requestMatchers(HttpMethod.POST, "/bills/**").hasAuthority("bills.create")
+				.requestMatchers(HttpMethod.GET, "/bills/**").hasAuthority("bills.read")
+				.requestMatchers(HttpMethod.PUT, "/bills/**").hasAuthority("bills.update")
+				.requestMatchers(HttpMethod.DELETE, "/bills/**").hasAuthority("bills.delete")
 				// dischargetypes
 				.requestMatchers(HttpMethod.POST, "/dischargetypes/**").hasAuthority("dischargetypes.create")
 				.requestMatchers(HttpMethod.GET, "/dischargetypes/**").hasAnyAuthority("dischargetypes.read")
@@ -303,6 +309,11 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/sms/**").hasAnyAuthority("sms.read")
 				.requestMatchers(HttpMethod.PUT, "/sms/**").hasAuthority("sms.update")
 				.requestMatchers(HttpMethod.DELETE, "/sms/**").hasAuthority("sms.delete")
+				// stockmovements
+				.requestMatchers(HttpMethod.POST, "/stockmovements/**").hasAuthority("stockmovements.create")
+				.requestMatchers(HttpMethod.GET, "/stockmovements/**").hasAuthority("stockmovements.read")
+				.requestMatchers(HttpMethod.PUT, "/stockmovements/**").hasAuthority("stockmovements.update")
+				.requestMatchers(HttpMethod.DELETE, "/stockmovements/**").hasAuthority("stockmovements.delete")
 				// suppliers
 				.requestMatchers(HttpMethod.POST, "/suppliers/**").hasAuthority("suppliers.create")
 				.requestMatchers(HttpMethod.GET, "/suppliers/**").hasAnyAuthority("suppliers.read")
@@ -333,6 +344,8 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/wards/**").hasAnyAuthority("wards.read")
 				.requestMatchers(HttpMethod.PUT, "/wards/**").hasAuthority("wards.update")
 				.requestMatchers(HttpMethod.DELETE, "/wards/**").hasAuthority("wards.delete")
+				// wardsNoMaternity is a wards read endpoint that does not match /wards/** and otherwise falls through
+				.requestMatchers(HttpMethod.GET, "/wardsNoMaternity").hasAuthority("wards.read")
 
 				.anyRequest().authenticated()
 

--- a/src/test/java/org/isf/security/BillAndStockMovementAuthorizationTest.java
+++ b/src/test/java/org/isf/security/BillAndStockMovementAuthorizationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * Open Hospital is a free and open source software for healthcare data management.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.isf.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+
+import org.isf.OpenHospitalApiApplication;
+import org.isf.accounting.manager.BillBrowserManager;
+import org.isf.medicalstock.manager.MovBrowserManager;
+import org.isf.ward.manager.WardBrowserManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+
+/**
+ * Verifies the authorization rules added for the billing (/bills) and stock movement (/stockmovements)
+ * endpoints, which previously fell through to anyRequest().authenticated(), plus the /wardsNoMaternity
+ * endpoint uncovered by the fall-through audit. Only the authorization outcome is asserted: a request that
+ * is not stopped with 401/403 has passed the filter chain and reached the controller.
+ */
+@SpringBootTest(classes = OpenHospitalApiApplication.class)
+@AutoConfigureMockMvc
+class BillAndStockMovementAuthorizationTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@MockitoBean
+	private BillBrowserManager billManager;
+
+	@MockitoBean
+	private MovBrowserManager movManager;
+
+	@MockitoBean
+	private WardBrowserManager wardManager;
+
+	private void assertReachedController(RequestBuilder request) throws Exception {
+		try {
+			int status = mvc.perform(request).andReturn().getResponse().getStatus();
+			assertThat(status).isNotIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value());
+		} catch (ServletException e) {
+			// The authorization filter never throws: it answers 401/403. Reaching the controller and
+			// failing inside it (e.g. mapping an empty test body) still proves the request was authorized.
+		}
+	}
+
+	// ----- unauthenticated requests are rejected with 401 -----
+
+	@Test
+	@DisplayName("Anonymous access to /bills is unauthorized")
+	void billsRejectAnonymous() throws Exception {
+		mvc.perform(get("/bills")).andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Anonymous access to /stockmovements is unauthorized")
+	void stockMovementsRejectAnonymous() throws Exception {
+		mvc.perform(get("/stockmovements")).andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Anonymous access to /wardsNoMaternity is unauthorized")
+	void wardsNoMaternityRejectAnonymous() throws Exception {
+		mvc.perform(get("/wardsNoMaternity")).andExpect(status().isUnauthorized());
+	}
+
+	// ----- bills: reading -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.read" })
+	@DisplayName("Reading bills is allowed with bills.read")
+	void readBillsAllowed() throws Exception {
+		assertReachedController(get("/bills"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.create" })
+	@DisplayName("Reading bills is forbidden without bills.read")
+	void readBillsForbidden() throws Exception {
+		mvc.perform(get("/bills")).andExpect(status().isForbidden());
+	}
+
+	// ----- bills: the search endpoints use POST but are read operations -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.read" })
+	@DisplayName("Searching bills is allowed with bills.read")
+	void searchBillsAllowed() throws Exception {
+		assertReachedController(post("/bills/search/by/item")
+			.contentType(MediaType.APPLICATION_JSON).content("{}"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.create" })
+	@DisplayName("Searching bills is forbidden without bills.read")
+	void searchBillsForbidden() throws Exception {
+		mvc.perform(post("/bills/search/by/item").contentType(MediaType.APPLICATION_JSON).content("{}"))
+			.andExpect(status().isForbidden());
+	}
+
+	// ----- bills: mutating -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.create" })
+	@DisplayName("Creating a bill is allowed with bills.create")
+	void createBillAllowed() throws Exception {
+		assertReachedController(post("/bills")
+			.contentType(MediaType.APPLICATION_JSON).content("{}"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.read" })
+	@DisplayName("Creating a bill is forbidden without bills.create")
+	void createBillForbidden() throws Exception {
+		mvc.perform(post("/bills").contentType(MediaType.APPLICATION_JSON).content("{}"))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "bills.read" })
+	@DisplayName("Deleting a bill is forbidden without bills.delete")
+	void deleteBillForbidden() throws Exception {
+		mvc.perform(delete("/bills/1")).andExpect(status().isForbidden());
+	}
+
+	// ----- stock movements: reading -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "stockmovements.read" })
+	@DisplayName("Reading stock movements is allowed with stockmovements.read")
+	void readStockMovementsAllowed() throws Exception {
+		when(movManager.getMovements()).thenReturn(List.of());
+		assertReachedController(get("/stockmovements"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "stockmovements.create" })
+	@DisplayName("Reading stock movements is forbidden without stockmovements.read")
+	void readStockMovementsForbidden() throws Exception {
+		mvc.perform(get("/stockmovements")).andExpect(status().isForbidden());
+	}
+
+	// ----- stock movements: mutating -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "stockmovements.create" })
+	@DisplayName("Charging stock is allowed with stockmovements.create")
+	void chargeStockMovementsAllowed() throws Exception {
+		assertReachedController(post("/stockmovements/charge")
+			.contentType(MediaType.APPLICATION_JSON).content("[]"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "stockmovements.read" })
+	@DisplayName("Charging stock is forbidden without stockmovements.create")
+	void chargeStockMovementsForbidden() throws Exception {
+		mvc.perform(post("/stockmovements/charge").contentType(MediaType.APPLICATION_JSON).content("[]"))
+			.andExpect(status().isForbidden());
+	}
+
+	// ----- wardsNoMaternity (fall-through audit fix) -----
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "wards.read" })
+	@DisplayName("Reading wardsNoMaternity is allowed with wards.read")
+	void wardsNoMaternityAllowed() throws Exception {
+		when(wardManager.getWardsNoMaternity()).thenReturn(List.of());
+		assertReachedController(get("/wardsNoMaternity"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", authorities = { "wards.update" })
+	@DisplayName("Reading wardsNoMaternity is forbidden without wards.read")
+	void wardsNoMaternityForbidden() throws Exception {
+		mvc.perform(get("/wardsNoMaternity")).andExpect(status().isForbidden());
+	}
+}


### PR DESCRIPTION
## What

The `/bills/**` (`BillController`) and `/stockmovements/**` (`StockMovementController`) endpoints had no operation-specific authorization rule and fell through to `anyRequest().authenticated()`, so any authenticated user could reach them regardless of their permissions (CWE-862 Missing Authorization / OWASP Broken Access Control).

## Changes

- `SecurityConfig`: require operation-specific authorities on `/bills/**` and `/stockmovements/**`. The `POST /bills/search/**` endpoints are searches (reads over POST), so they require `bills.read`, ordered before the generic `POST /bills/**` create rule.
- Fall-through audit: the only other controller namespace that unintentionally fell through was `GET /wardsNoMaternity` (it does not match `/wards/**`); it now requires `wards.read`. `/healthcheck` is intentionally `permitAll`.
- `BillAndStockMovementAuthorizationTest`: covers allowed, denied (`403`) and unauthenticated (`401`) requests for GET and mutating operations across both namespaces and `wardsNoMaternity` (16 tests).
- README: new "Authorization model" section documenting the experimental API and its per-namespace `<namespace>.<action>` authority model.

## Acceptance criteria

- [x] `/bills/**` and `/stockmovements/**` require operation-specific authorities
- [x] authenticated user without the authority → `403`; unauthenticated → `401`; user with the authority can access
- [x] security tests cover allowed and denied GET + mutating operations
- [x] existing workflows keep working for appropriately configured users (admin granted the new permissions)
- [x] experimental API documentation mentions the authorization model and support status
- [x] broader fall-through audit performed (`GET /wardsNoMaternity` fixed)

## Dependency

The new authorities are seeded by informatici/openhospital-core#1650 — **merge the core PR first**, otherwise no user is granted `bills.*` / `stockmovements.*` and those endpoints return `403`.

Related to OP-1434.
