### PR TITLE
Sanitize API error responses

### DIFF
--- a/src/main/java/org/isf/shared/exceptions/OHAPIError.java
+++ b/src/main/java/org/isf/shared/exceptions/OHAPIError.java
@@ -21,10 +21,7 @@
  */
 package org.isf.shared.exceptions;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
 
 import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.ErrorDescription;
@@ -36,25 +33,22 @@ import org.springframework.http.HttpStatus;
  * @author antonio
  */
 public class OHAPIError {
+    private static final String INTERNAL_ERROR_MESSAGE = "The request could not be completed.";
+
     private HttpStatus status;
     private String message;
-    private String debugMessage;
-    private String stackTrace;
     private LocalDateTime timestamp;
     private ErrorDescription description;
 
     public OHAPIError(HttpStatus status, OHServiceException ex) {
         this.timestamp = LocalDateTime.now();
         this.status = status;
-        this.message = ex.getMessages().get(0).getMessage();
-        this.debugMessage = ex.getMessages()
-                .stream()
-                .map(em -> em.getMessage())
-                .collect(Collectors.joining(","));
-        StringWriter sw = new StringWriter();
-        ex.printStackTrace(new PrintWriter(sw));
-        this.stackTrace = sw.toString();
-        this.description = ex.getMessages().get(0).getDescription();
+        if (status.is5xxServerError()) {
+            this.message = INTERNAL_ERROR_MESSAGE;
+        } else {
+            this.message = ex.getMessages().get(0).getMessage();
+            this.description = ex.getMessages().get(0).getDescription();
+        }
     }
 
 	public HttpStatus getStatus() {
@@ -63,14 +57,6 @@ public class OHAPIError {
 
 	public String getMessage() {
 		return this.message;
-	}
-
-	public String getDebugMessage() {
-		return this.debugMessage;
-	}
-
-	public String getStackTrace() {
-		return this.stackTrace;
 	}
 
 	public LocalDateTime getTimestamp() {
@@ -83,14 +69,6 @@ public class OHAPIError {
 
 	public void setMessage(String message) {
 		this.message = message;
-	}
-
-	public void setDebugMessage(String debugMessage) {
-		this.debugMessage = debugMessage;
-	}
-
-	public void setStackTrace(String stackTrace) {
-		this.stackTrace = stackTrace;
 	}
 
 	public void setTimestamp(LocalDateTime timestamp) {

--- a/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
+++ b/src/main/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandler.java
@@ -32,6 +32,8 @@ import org.isf.utils.exception.OHInvalidSQLException;
 import org.isf.utils.exception.OHOperationNotAllowedException;
 import org.isf.utils.exception.OHReportException;
 import org.isf.utils.exception.OHServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -43,58 +45,62 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice
 public class OHResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+	private static final Logger LOGGER = LoggerFactory.getLogger(OHResponseEntityExceptionHandler.class);
 
     @ExceptionHandler(value = {OHDataValidationException.class})
     protected ResponseEntity<Object> handleOHServiceValidationException(OHServiceException ex) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.BAD_REQUEST, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.BAD_REQUEST, ex), ex);
     }
 
     @ExceptionHandler(value = {OHServiceException.class})
     protected ResponseEntity<Object> handleOHServiceException(OHServiceException ex) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHReportException.class})
     protected ResponseEntity<Object> handleReportException(OHReportException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHInvalidSQLException.class})
     protected ResponseEntity<Object> handleInvalidSqlException(OHInvalidSQLException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHOperationNotAllowedException.class})
     protected ResponseEntity<Object> handleOHServiceOperationNotAllowedException(OHOperationNotAllowedException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHDicomException.class})
     protected ResponseEntity<Object> handleDicomException(OHDicomException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHDBConnectionException.class})
     protected ResponseEntity<Object> handleDbConnectionException(OHDBConnectionException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.SERVICE_UNAVAILABLE, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.SERVICE_UNAVAILABLE, ex), ex);
     }
 
     @ExceptionHandler(value = {OHDataIntegrityViolationException.class})
     protected ResponseEntity<Object> handleDataIntegrityViolationException(OHDataIntegrityViolationException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHDataLockFailureException.class})
     protected ResponseEntity<Object> handleDbLockFailureException(OHDataLockFailureException ex, Locale locale) {
-        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex));
+        return buildResponseEntity(new OHAPIError(HttpStatus.INTERNAL_SERVER_ERROR, ex), ex);
     }
 
     @ExceptionHandler(value = {OHAPIException.class})
     protected ResponseEntity<Object> handleOHAPIException(OHAPIException ex) {
-        return buildResponseEntity(new OHAPIError(ex.getStatus(), ex));
+        return buildResponseEntity(new OHAPIError(ex.getStatus(), ex), ex);
     }
 
-    private ResponseEntity<Object> buildResponseEntity(OHAPIError apiError) {
+    private ResponseEntity<Object> buildResponseEntity(OHAPIError apiError, Exception ex) {
+		if (apiError.getStatus().is5xxServerError()) {
+			LOGGER.error("Request failed with status {}", apiError.getStatus(), ex);
+		}
         return new ResponseEntity<>(apiError, apiError.getStatus());
     }
 }

--- a/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/org/isf/shared/exceptions/OHResponseEntityExceptionHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * This program is free and open source software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ */
+package org.isf.shared.exceptions;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.isf.utils.exception.OHServiceException;
+import org.isf.utils.exception.model.OHExceptionMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class OHResponseEntityExceptionHandlerTest {
+
+	private MockMvc mvc;
+
+	@BeforeEach
+	void setUp() {
+		this.mvc = MockMvcBuilders
+			.standaloneSetup(new ExceptionController())
+			.setControllerAdvice(new OHResponseEntityExceptionHandler())
+			.build();
+	}
+
+	@Test
+	void clientErrorDoesNotExposeDebugInformation() throws Exception {
+		mvc.perform(get("/client-error").accept("application/json"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("Bill not found"))
+			.andExpect(jsonPath("$.debugMessage").doesNotExist())
+			.andExpect(jsonPath("$.stackTrace").doesNotExist());
+	}
+
+	@Test
+	void serverErrorUsesGenericMessage() throws Exception {
+		mvc.perform(get("/server-error").accept("application/json"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.message").value("The request could not be completed."))
+			.andExpect(jsonPath("$.description").doesNotExist())
+			.andExpect(jsonPath("$.debugMessage").doesNotExist())
+			.andExpect(jsonPath("$.stackTrace").doesNotExist())
+			.andExpect(content().string(not(containsString("database.internal"))));
+	}
+
+	@RestController
+	private static class ExceptionController {
+
+		@GetMapping("/client-error")
+		void clientError() throws OHAPIException {
+			throw new OHAPIException(new OHExceptionMessage("Bill not found"), HttpStatus.NOT_FOUND);
+		}
+
+		@GetMapping("/server-error")
+		void serverError() throws OHServiceException {
+			throw new OHServiceException(new OHExceptionMessage("database.internal"));
+		}
+	}
+}


### PR DESCRIPTION
## What

- remove `debugMessage` and serialized stack traces from API error responses
- replace internal 5xx exception messages with a generic response
- preserve useful 4xx business messages
- log 5xx exceptions server-side
- add regression tests for both client and server errors

## Why

The custom `OHAPIError` response bypassed Spring Boot's `server.error.include-stacktrace=never` setting and returned Java stack traces and internal exception messages to clients.

## Security impact

Prevents disclosure of controller class names, source line numbers, database details, and other internal diagnostics through error responses.

## Checks

- `./mvnw -q -Dtest=OHResponseEntityExceptionHandlerTest test`
- `git diff --check`