### PR TITLE
Resolve JWT authorities from the database

### DIFF
--- a/src/main/java/org/isf/security/jwt/TokenProvider.java
+++ b/src/main/java/org/isf/security/jwt/TokenProvider.java
@@ -24,8 +24,6 @@ package org.isf.security.jwt;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -40,8 +38,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -185,24 +181,9 @@ public class TokenProvider implements Serializable {
 	}
 
 	public Authentication getAuthentication(String token) {
-		final Claims claims = getAllClaimsFromToken(token);
-
-		/*
-		 * claims.get(AUTHORITIES_KEY) cannot be null, at least an empty string Left for security but not testable
-		 */
-		String authoritiesClaim = claims.get(AUTHORITIES_KEY) != null ? claims.get(AUTHORITIES_KEY).toString() : "";
-		if (authoritiesClaim.isEmpty()) {
-			LOGGER.error("JWT token does not contain any authorities");
-			throw new IllegalArgumentException("JWT token does not contain authorities.");
-		}
-
-		final Collection< ? extends GrantedAuthority> authorities = Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-			.map(SimpleGrantedAuthority::new)
-			.collect(Collectors.toList());
-
-		User principal = new User(claims.getSubject(), "", authorities);
-
-		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+		String username = getUsernameFromToken(token);
+		UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+		return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
 	}
 
 	public Authentication getAuthenticationByUsername(String username) {

--- a/src/test/java/org/isf/security/TokenProviderTest.java
+++ b/src/test/java/org/isf/security/TokenProviderTest.java
@@ -22,7 +22,6 @@
 package org.isf.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -35,6 +34,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -238,8 +238,11 @@ class TokenProviderTest {
 	}
 
 	@Test
-	void testGetAuthentication() {
-		Authentication authentication = createAuthentication();
+	void testGetAuthenticationIgnoresTokenAuthorities() throws Exception {
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			"testuser", "password", List.of(new SimpleGrantedAuthority("users.delete"))
+		);
+		mockDatabaseAuthorities("testuser", "patients.read");
 
 		// Generate token
 		String token = tokenProvider.generateJwtToken(authentication, false);
@@ -257,25 +260,27 @@ class TokenProviderTest {
 
 		// Check authorities
 		Collection< ? extends GrantedAuthority> resultAuthorities = authToken.getAuthorities();
-		assertThat(resultAuthorities).extracting(GrantedAuthority::getAuthority).contains("ROLE_USER");
+		assertThat(resultAuthorities).extracting(GrantedAuthority::getAuthority)
+			.containsExactly("patients.read")
+			.doesNotContain("users.delete");
 
 		// Check credentials
 		assertThat(authToken.getCredentials()).isEqualTo(token);
 	}
 
 	@Test
-	void testGetAuthentication_EmptyAuthorities() {
-		// Create an Authentication with empty authorities
-		List<GrantedAuthority> authorities = List.of();
-		Authentication authentication = new UsernamePasswordAuthenticationToken("testuser", "password", authorities);
+	void testGetAuthenticationDoesNotRequireAuthoritiesClaim() throws Exception {
+		Key key = extractKeyFromTokenProvider();
+		String token = Jwts.builder()
+			.setSubject("testuser")
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+		mockDatabaseAuthorities("testuser", "patients.read");
 
-		// Generate token
-		String token = tokenProvider.generateJwtToken(authentication, false);
+		Authentication result = tokenProvider.getAuthentication(token);
 
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			tokenProvider.getAuthentication(token);
-		});
-		assertThat(exception.getMessage()).contains("JWT token does not contain authorities.");
+		assertThat(result.getAuthorities()).extracting(GrantedAuthority::getAuthority)
+			.containsExactly("patients.read");
 	}
 
 	@Test
@@ -428,6 +433,20 @@ class TokenProviderTest {
 		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 		Authentication authentication = new UsernamePasswordAuthenticationToken("testuser", "password", authorities);
 		return authentication;
+	}
+
+	private void mockDatabaseAuthorities(String username, String... authorityNames) throws Exception {
+		org.isf.menu.model.User user = new org.isf.menu.model.User();
+		user.setUserName(username);
+		user.setPasswd("password");
+		when(userManager.getUserByName(username)).thenReturn(user);
+
+		List<Permission> permissions = Arrays.stream(authorityNames).map(authorityName -> {
+			Permission permission = new Permission();
+			permission.setName(authorityName);
+			return permission;
+		}).toList();
+		when(permissionManager.retrievePermissionsByUsername(username)).thenReturn(permissions);
 	}
 
 	// Helper method to extract key by reflection, needed to avoid getters


### PR DESCRIPTION
## What

- load the authenticated user and current permissions from the database when accepting an access token
- stop constructing Spring Security authorities from the JWT `auth` claim
- retain the claim in newly issued tokens for client compatibility, but treat it as untrusted server-side metadata
- add regressions proving injected authorities are ignored and the claim is not required

## Why

The API currently treats the comma-separated `auth` claim as the server-side source of authority. Anyone able to sign a token can therefore inject arbitrary permissions without those permissions being present on the account. It also leaves revoked permissions active until token expiry.

## Security impact

A token can no longer elevate an account by changing its `auth` claim. Permission changes take effect on the next authenticated request.

This is defense in depth and does not replace rotation of a compromised signing key: a party that knows the HMAC key can still forge another account's `sub` claim.

## Checks

- `./mvnw -q -Dtest=TokenProviderTest,JWTFilterTest test`
- `git diff --check`