### PR TITLE
Require operation-specific authorities for user settings

### DIFF
--- a/src/main/java/org/isf/config/SecurityConfig.java
+++ b/src/main/java/org/isf/config/SecurityConfig.java
@@ -277,7 +277,10 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.PUT, "/users/{username}").hasAuthority("users.update")
 				.requestMatchers(HttpMethod.DELETE, "/users/**").hasAuthority("users.delete")
 				// user setting
-				.requestMatchers("/usersettings/**").authenticated()
+				.requestMatchers(HttpMethod.POST, "/usersettings/**").hasAuthority("usersettings.create")
+				.requestMatchers(HttpMethod.GET, "/usersettings/**").hasAuthority("usersettings.read")
+				.requestMatchers(HttpMethod.PUT, "/usersettings/**").hasAuthority("usersettings.update")
+				.requestMatchers(HttpMethod.DELETE, "/usersettings/**").hasAuthority("usersettings.delete")
 				// pregnanttreatmenttypes
 				.requestMatchers(HttpMethod.POST, "/pregnanttreatmenttypes/**").hasAuthority("pregnanttreatmenttypes.create")
 				.requestMatchers(HttpMethod.GET, "/pregnanttreatmenttypes/**").hasAnyAuthority("pregnanttreatmenttypes.read")

--- a/src/test/java/org/isf/usersettings/rest/UserSettingControllerTest.java
+++ b/src/test/java/org/isf/usersettings/rest/UserSettingControllerTest.java
@@ -83,7 +83,7 @@ class UserSettingControllerTest {
 	private UserSettingManager userSettingManager;
 
 	@Test
-	@WithMockUser(username = "contrib")
+	@WithMockUser(username = "contrib", authorities = "usersettings.read")
 	@DisplayName("Get logged-in user's setting")
 	void getCurrentUserSettings() throws Exception {
 		List<UserSetting> userSettings = UserSettingHelper.generateMany(5);
@@ -101,7 +101,7 @@ class UserSettingControllerTest {
 		LOGGER.debug("result: {}", result);
 	}
 	@Test
-	@WithMockUser(username = "admin")
+	@WithMockUser(username = "admin", authorities = "usersettings.read")
 	@DisplayName("Should get user setting by setting name")
 	void shouldGetUserSettingBySettingName() throws Exception {
 		UserSetting userSetting = UserSettingHelper.generate();
@@ -129,7 +129,7 @@ class UserSettingControllerTest {
 	class SaveUserSettings {
 
 		@Test
-		@WithMockUser(username = "oh user")
+		@WithMockUser(username = "oh user", authorities = "usersettings.create")
 		@DisplayName("Should create own user setting")
 		void shouldCreateOwnUserSetting() throws Exception {
 			User user = UserHelper.generateUser();
@@ -155,7 +155,7 @@ class UserSettingControllerTest {
 		}
 
 		@Test
-		@WithMockUser(username = "oh user")
+		@WithMockUser(username = "oh user", authorities = "usersettings.create")
 		@DisplayName("Should fail to create user setting for another user")
 		void shouldFailToCreateUserSettingForOtherUser() throws Exception {
 			User user = UserHelper.generateUser();
@@ -181,7 +181,7 @@ class UserSettingControllerTest {
 		}
 
 		@Test
-		@WithMockUser(username = "oh user")
+		@WithMockUser(username = "oh user", authorities = "usersettings.update")
 		@DisplayName("Should update own user setting")
 		void shouldUpdateOwnUserSetting() throws Exception {
 			User user = UserHelper.generateUser();
@@ -208,7 +208,7 @@ class UserSettingControllerTest {
 		}
 
 		@Test
-		@WithMockUser(username = "oh user")
+		@WithMockUser(username = "oh user", authorities = "usersettings.update")
 		@DisplayName("Should fail to update user setting for another user")
 		void shouldFailToUpdateUserSettingForOtherUser() throws Exception {
 			User user = UserHelper.generateUser();
@@ -240,7 +240,7 @@ class UserSettingControllerTest {
 	class DeleteUserSettings {
 
 		@Test
-		@WithMockUser(username = "contrib")
+		@WithMockUser(username = "contrib", authorities = "usersettings.delete")
 		@DisplayName("Should delete own user setting by id")
 		void shouldDeleteOwnUserSettingById() throws Exception {
 			UserSetting userSetting = UserSettingHelper.generate();
@@ -262,7 +262,22 @@ class UserSettingControllerTest {
 		}
 
 		@Test
-		@WithMockUser(username = "oh user")
+		@WithMockUser(
+			username = "contrib",
+			authorities = { "usersettings.create", "usersettings.read", "usersettings.update" }
+		)
+		@DisplayName("Should require delete authority")
+		void shouldRequireDeleteAuthority() throws Exception {
+			mvc.perform(
+					delete("/usersettings/{id}", 1)
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(log())
+				.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@WithMockUser(username = "oh user", authorities = "usersettings.delete")
 		@DisplayName("Should fail to delete user setting for another user")
 		void shouldFailToDeleteUserSettingForOtherUser() throws Exception {
 			UserSetting userSetting = UserSettingHelper.generate();


### PR DESCRIPTION
## What

- replace the blanket `authenticated()` rule for `/usersettings/**` with create/read/update/delete authorities by HTTP method
- keep the controller's existing ownership checks as a second authorization layer
- update controller tests with their required authorities
- add a regression proving delete is forbidden without `usersettings.delete`

## Why

Any authenticated account could previously reach every user-settings operation. In particular, an account with `usersettings.create` but without `usersettings.delete` could delete its settings because the DELETE route only checked authentication.

## Security impact

The API now enforces the existing user-settings permission model at the request boundary, while still preventing cross-user operations in the controller.

## Checks

- `./mvnw -q -Dtest=UserSettingControllerTest test`
- `git diff --check`