### PR TITLE
Rate limit failed login attempts

### DIFF
--- a/rsc/application.properties.dist
+++ b/rsc/application.properties.dist
@@ -33,6 +33,11 @@ jwt.token.validityInSeconds=1800
 ### JWT token validity for remember me, 3 days (259,200 seconds)
 jwt.token.validityInSecondsForRememberMe=259200
 
+### Login rate limiting (per client address and username/client-address pair)
+security.login-rate-limit.max-attempts=5
+security.login-rate-limit.window-seconds=60
+security.login-rate-limit.max-entries=10000
+
 # Hibernate properties
 # needed to start application even without DB connection
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect

--- a/src/main/java/org/isf/login/rest/LoginController.java
+++ b/src/main/java/org/isf/login/rest/LoginController.java
@@ -23,12 +23,15 @@ package org.isf.login.rest;
 
 import java.time.LocalDateTime;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 
 import org.isf.login.dto.LoginRequest;
 import org.isf.login.dto.LoginResponse;
 import org.isf.login.dto.TokenRefreshRequest;
+import org.isf.login.security.LoginAttemptService;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.security.CustomAuthenticationManager;
@@ -42,9 +45,12 @@ import org.isf.utils.exception.OHServiceException;
 import org.isf.utils.exception.model.OHExceptionMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,6 +77,8 @@ public class LoginController {
 
 	private final UserBrowsingManager userManager;
 
+	private final LoginAttemptService loginAttemptService;
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(LoginController.class);
 
 	public LoginController(
@@ -78,21 +86,42 @@ public class LoginController {
 		SessionAuditManager sessionAuditManager,
 		TokenProvider tokenProvider,
 		CustomAuthenticationManager authenticationManager,
-		UserBrowsingManager userManager
+		UserBrowsingManager userManager,
+		LoginAttemptService loginAttemptService
 	) {
 		this.httpSession = httpSession;
 		this.sessionAuditManager = sessionAuditManager;
 		this.tokenProvider = tokenProvider;
 		this.authenticationManager = authenticationManager;
 		this.userManager = userManager;
+		this.loginAttemptService = loginAttemptService;
 	}
 
 	@PostMapping(value = "/auth/login")
 	public LoginResponse authenticateUser(
-		@Valid @RequestBody LoginRequest loginRequest
-	) {
-		Authentication authentication = authenticationManager.authenticate(
-			new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+		@Valid @RequestBody LoginRequest loginRequest,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) throws OHAPIException {
+		String clientAddress = request.getRemoteAddr();
+		long retryAfterSeconds = loginAttemptService.retryAfterSeconds(loginRequest.getUsername(), clientAddress);
+		if (retryAfterSeconds > 0) {
+			response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(retryAfterSeconds));
+			throw new OHAPIException(
+				new OHExceptionMessage("Too many login attempts. Try again later."),
+				HttpStatus.TOO_MANY_REQUESTS
+			);
+		}
+
+		Authentication authentication;
+		try {
+			authentication = authenticationManager.authenticate(
+				new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+		} catch (AuthenticationException exception) {
+			loginAttemptService.loginFailed(loginRequest.getUsername(), clientAddress);
+			throw exception;
+		}
+		loginAttemptService.loginSucceeded(loginRequest.getUsername(), clientAddress);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		String userDetails = (String) authentication.getPrincipal();

--- a/src/main/java/org/isf/login/security/LoginAttemptService.java
+++ b/src/main/java/org/isf/login/security/LoginAttemptService.java
@@ -1,0 +1,132 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * This program is free and open source software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ */
+package org.isf.login.security;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tracks failed logins in a bounded, in-memory store. Limits are applied both to a client address and to a username/address pair.
+ */
+@Service
+public class LoginAttemptService {
+
+	private static final String ADDRESS_PREFIX = "address:";
+	private static final String USER_ADDRESS_PREFIX = "user-address:";
+
+	private final Map<String, AttemptWindow> attempts = new ConcurrentHashMap<>();
+	private final int maxAttempts;
+	private final Duration window;
+	private final int maxEntries;
+	private final Clock clock;
+
+	@Autowired
+	public LoginAttemptService(
+		@Value("${security.login-rate-limit.max-attempts:5}") int maxAttempts,
+		@Value("${security.login-rate-limit.window-seconds:60}") long windowSeconds,
+		@Value("${security.login-rate-limit.max-entries:10000}") int maxEntries
+	) {
+		this(maxAttempts, Duration.ofSeconds(windowSeconds), maxEntries, Clock.systemUTC());
+	}
+
+	LoginAttemptService(int maxAttempts, Duration window, int maxEntries, Clock clock) {
+		if (maxAttempts <= 0 || window.isZero() || window.isNegative() || maxEntries < 2) {
+			throw new IllegalArgumentException("Login rate-limit settings must be positive.");
+		}
+		this.maxAttempts = maxAttempts;
+		this.window = window;
+		this.maxEntries = maxEntries;
+		this.clock = clock;
+	}
+
+	/**
+	 * Returns the number of seconds before login can be retried, or zero when the request is allowed.
+	 */
+	public long retryAfterSeconds(String username, String clientAddress) {
+		Instant now = clock.instant();
+		long userAddressRetry = retryAfterSeconds(userAddressKey(username, clientAddress), now);
+		long addressRetry = retryAfterSeconds(addressKey(clientAddress), now);
+		return Math.max(userAddressRetry, addressRetry);
+	}
+
+	public void loginFailed(String username, String clientAddress) {
+		Instant now = clock.instant();
+		recordFailure(userAddressKey(username, clientAddress), now);
+		recordFailure(addressKey(clientAddress), now);
+	}
+
+	public void loginSucceeded(String username, String clientAddress) {
+		attempts.remove(userAddressKey(username, clientAddress));
+	}
+
+	private long retryAfterSeconds(String key, Instant now) {
+		AttemptWindow attemptWindow = attempts.get(key);
+		if (attemptWindow == null) {
+			return 0;
+		}
+		if (!now.isBefore(attemptWindow.expiresAt())) {
+			attempts.remove(key, attemptWindow);
+			return 0;
+		}
+		if (attemptWindow.failures() < maxAttempts) {
+			return 0;
+		}
+		long remainingMillis = Duration.between(now, attemptWindow.expiresAt()).toMillis();
+		return Math.max(1, (remainingMillis + 999) / 1000);
+	}
+
+	private void recordFailure(String key, Instant now) {
+		if (!attempts.containsKey(key) && attempts.size() >= maxEntries) {
+			evictOneEntry(now);
+		}
+		attempts.compute(key, (ignored, current) -> {
+			if (current == null || !now.isBefore(current.expiresAt())) {
+				return new AttemptWindow(1, now.plus(window));
+			}
+			return new AttemptWindow(current.failures() + 1, current.expiresAt());
+		});
+	}
+
+	private void evictOneEntry(Instant now) {
+		attempts.entrySet().removeIf(entry -> !now.isBefore(entry.getValue().expiresAt()));
+		if (attempts.size() < maxEntries) {
+			return;
+		}
+		attempts.entrySet().stream()
+			.min(Comparator.comparing(entry -> entry.getValue().expiresAt()))
+			.ifPresent(entry -> attempts.remove(entry.getKey(), entry.getValue()));
+	}
+
+	private String userAddressKey(String username, String clientAddress) {
+		String normalizedUsername = username == null ? "" : username.trim().toLowerCase(Locale.ROOT);
+		return USER_ADDRESS_PREFIX + normalizedUsername + ':' + normalizeAddress(clientAddress);
+	}
+
+	private String addressKey(String clientAddress) {
+		return ADDRESS_PREFIX + normalizeAddress(clientAddress);
+	}
+
+	private String normalizeAddress(String clientAddress) {
+		return clientAddress == null || clientAddress.isBlank() ? "unknown" : clientAddress;
+	}
+
+	private record AttemptWindow(int failures, Instant expiresAt) {
+	}
+}

--- a/src/test/java/org/isf/login/rest/LoginControllerTest.java
+++ b/src/test/java/org/isf/login/rest/LoginControllerTest.java
@@ -22,12 +22,16 @@
 package org.isf.login.rest;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -39,6 +43,7 @@ import org.isf.OpenHospitalApiApplication;
 import org.isf.login.dto.LoginRequest;
 import org.isf.login.dto.LoginResponse;
 import org.isf.login.dto.TokenRefreshRequest;
+import org.isf.login.security.LoginAttemptService;
 import org.isf.menu.manager.UserBrowsingManager;
 import org.isf.menu.model.User;
 import org.isf.security.CustomAuthenticationManager;
@@ -54,8 +59,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -85,14 +93,19 @@ class LoginControllerTest {
 	@Mock
 	private UserBrowsingManager userManager;
 
+	@Mock
+	private LoginAttemptService loginAttemptService;
+
+	private LoginController loginController;
+
 	private AutoCloseable closeable;
 
 	@BeforeEach
 	void setUp() {
 		closeable = MockitoAnnotations.openMocks(this);
 
-		LoginController loginController = new LoginController(
-			httpSession, sessionAuditManager, tokenProvider, authenticationManager, userManager
+		loginController = new LoginController(
+			httpSession, sessionAuditManager, tokenProvider, authenticationManager, userManager, loginAttemptService
 		);
 
 		this.mvc = MockMvcBuilders
@@ -135,11 +148,52 @@ class LoginControllerTest {
 
 		// Perform the login request
 		mvc.perform(post("/auth/login")
+				.with(request -> {
+					request.setRemoteAddr("192.0.2.1");
+					return request;
+				})
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(Objects.requireNonNull(UserHelper.asJsonString(loginRequest))))
 			.andExpect(status().isOk())
 			.andExpect(content().string(Objects.requireNonNull(expectedJson)))
 			.andReturn();
+
+		verify(loginAttemptService).loginSucceeded(username, "192.0.2.1");
+	}
+
+	@Test
+	void testAuthenticateUser_RateLimited() throws Exception {
+		LoginRequest loginRequest = new LoginRequest("testUser", "testPassword");
+		when(loginAttemptService.retryAfterSeconds("testUser", "192.0.2.1")).thenReturn(30L);
+
+		mvc.perform(post("/auth/login")
+				.with(request -> {
+					request.setRemoteAddr("192.0.2.1");
+					return request;
+				})
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(Objects.requireNonNull(UserHelper.asJsonString(loginRequest))))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(header().string("Retry-After", "30"))
+			.andExpect(content().string(containsString("Too many login attempts")));
+
+		verifyNoInteractions(authenticationManager);
+	}
+
+	@Test
+	void testAuthenticateUser_FailureIsRecorded() {
+		LoginRequest loginRequest = new LoginRequest("testUser", "wrongPassword");
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("192.0.2.1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Wrong password"));
+
+		assertThrows(
+			BadCredentialsException.class,
+			() -> loginController.authenticateUser(loginRequest, request, response)
+		);
+
+		verify(loginAttemptService).loginFailed("testUser", "192.0.2.1");
 	}
 
 	@Test

--- a/src/test/java/org/isf/login/security/LoginAttemptServiceTest.java
+++ b/src/test/java/org/isf/login/security/LoginAttemptServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Open Hospital (www.open-hospital.org)
+ * Copyright © 2006-2026 Informatici Senza Frontiere (info@informaticisenzafrontiere.org)
+ *
+ * This program is free and open source software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ */
+package org.isf.login.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoginAttemptServiceTest {
+
+	private MutableClock clock;
+	private LoginAttemptService loginAttemptService;
+
+	@BeforeEach
+	void setUp() {
+		clock = new MutableClock(Instant.parse("2026-01-01T00:00:00Z"));
+		loginAttemptService = new LoginAttemptService(3, Duration.ofSeconds(60), 100, clock);
+	}
+
+	@Test
+	void blocksUsernameAndAddressPairAfterConfiguredFailures() {
+		loginAttemptService.loginFailed("Admin", "192.0.2.1");
+		loginAttemptService.loginFailed("admin", "192.0.2.1");
+		loginAttemptService.loginFailed(" admin ", "192.0.2.1");
+
+		assertThat(loginAttemptService.retryAfterSeconds("ADMIN", "192.0.2.1")).isEqualTo(60);
+		assertThat(loginAttemptService.retryAfterSeconds("admin", "192.0.2.2")).isZero();
+	}
+
+	@Test
+	void blocksAnAddressThatTriesMultipleUsernames() {
+		loginAttemptService.loginFailed("user-one", "192.0.2.1");
+		loginAttemptService.loginFailed("user-two", "192.0.2.1");
+		loginAttemptService.loginFailed("user-three", "192.0.2.1");
+
+		assertThat(loginAttemptService.retryAfterSeconds("another-user", "192.0.2.1")).isEqualTo(60);
+	}
+
+	@Test
+	void allowsLoginAfterWindowExpires() {
+		loginAttemptService.loginFailed("admin", "192.0.2.1");
+		loginAttemptService.loginFailed("admin", "192.0.2.1");
+		loginAttemptService.loginFailed("admin", "192.0.2.1");
+		clock.advance(Duration.ofSeconds(61));
+
+		assertThat(loginAttemptService.retryAfterSeconds("admin", "192.0.2.1")).isZero();
+	}
+
+	private static class MutableClock extends Clock {
+
+		private Instant instant;
+
+		MutableClock(Instant instant) {
+			this.instant = instant;
+		}
+
+		void advance(Duration duration) {
+			instant = instant.plus(duration);
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return ZoneId.of("UTC");
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return this;
+		}
+
+		@Override
+		public Instant instant() {
+			return instant;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- throttle failed login attempts by username/client-address pair and by client address
- return HTTP 429 with Retry-After before password verification once the configured limit is reached
- keep limiter state bounded and expire fixed-window counters automatically
- expose max attempts, window duration, and entry cap as application properties

## Why

POST /auth/login currently accepts unlimited authentication attempts. This permits unrestricted password guessing and credential stuffing against application accounts.

The default policy permits five failed attempts in a 60-second window. Successful authentication clears the username/address pair but deliberately does not clear the address-wide counter, so a known valid account cannot be used to bypass IP throttling.

## Deployment notes

The implementation is an in-memory per-instance baseline. Multi-instance deployments should additionally enforce a shared limit at the reverse proxy or use a shared backing store. The limiter uses HttpServletRequest.getRemoteAddr(); deployments behind a proxy must configure trusted forwarded-header handling so this resolves to the client address.

## Verification

- ./mvnw -q -Dtest=LoginAttemptServiceTest,LoginControllerTest test
- 14 tests passed
- git diff --check