### PR TITLE
OP-1462 Restore the jdbc scheme in the log appender connection string

### DIFF
--- a/rsc/log4j2-spring.properties.dist
+++ b/rsc/log4j2-spring.properties.dist
@@ -29,7 +29,7 @@ appender.jdbc.type = JDBC
 appender.jdbc.name = jdbc
 appender.jdbc.connectionSource.driverClassName = org.mariadb.jdbc.Driver
 appender.jdbc.connectionSource.type = DriverManager
-appender.jdbc.connectionSource.connectionString = dbc:mariadb://DBSERVER:DBPORT/DBNAME?autoReconnect=true
+appender.jdbc.connectionSource.connectionString = jdbc:mariadb://DBSERVER:DBPORT/DBNAME?autoReconnect=true
 appender.jdbc.connectionSource.userName = DBUSER
 appender.jdbc.connectionSource.password = DBPASS
 appender.jdbc.tableName = logs


### PR DESCRIPTION
## [OP-1462](https://openhospital.atlassian.net/browse/OP-1462)

Found while testing the v1.15.1 pre-release, so this targets `release_1_15_1`.

Line 32 declares the JDBC appender with

```
appender.jdbc.connectionSource.connectionString = dbc:mariadb://DBSERVER:DBPORT/DBNAME?autoReconnect=true
```

The scheme reads `dbc:`, so `DriverManager` has no driver to match and the appender cannot open a connection.

The same line is in the other two repositories; each has its own pull request and the three are independent.

## Impact

None today: the appender is declared but never referenced — `rootLogger.appenderRef` and `logger.isf.appenderRefs` list only `STDOUT` and `RollingFile`. It bites whoever enables database logging, which the file itself invites.

[OP-1462]: https://openhospital.atlassian.net/browse/OP-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ