### PR TITLE
OP-1464 Substitute API_URL when generating the specification

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -98,7 +98,9 @@ jobs:
           cp rsc/database.properties.dist rsc/database.properties
           cp rsc/log4j2-spring.properties.dist rsc/log4j2-spring.properties
           cp rsc/settings.properties.dist rsc/settings.properties
-          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" -e "s/API_HOST/localhost/g" -e "s/API_PORT/8080/g" rsc/application.properties.dist > rsc/application.properties
+          # api.host carries /API_URL on this branch, which the launcher fills in at install time:
+          # left in place it would end up in the generated spec and never match the committed one
+          sed -e "s/JWT_TOKEN_SECRET/${{ steps.jwt.outputs.token }}/g" -e "s/API_HOST/localhost/g" -e "s/API_PORT/8080/g" -e "s&/API_URL&&g" rsc/application.properties.dist > rsc/application.properties
           mvn install -DskipTests=true
           
       - name: Run API


### PR DESCRIPTION
## [OP-1464](https://openhospital.atlassian.net/browse/OP-1464)

On `release_1_15_1` the *OpenAPI breaking changes check* fails on every pull request, whatever it changes:

```
< "url": "http://localhost:8080/API_URL"
---
> "url": "http://localhost:8080"
The OpenAPI spec has changed. Please update the committed version.
```

`rsc/application.properties.dist` line 22 reads `api.host=API_HOST:API_PORT/API_URL` on this branch, which is correct: the launchers fill the placeholder in at install time, both applying `s&API_URL&$OH_API_PROD&g` (`ohmac.sh:344`, `oh.sh:1015`). The workflow that generates the specification substitutes only `JWT_TOKEN_SECRET`, `API_HOST` and `API_PORT`, so `api.host` keeps the literal `/API_URL` and the generated document can never match the committed one.

This teaches the workflow the placeholder rather than touching the template the launchers rely on. The slash belongs inside the pattern: without it the value would end as `localhost:8080/` and still not match.

## Verified

Simulated on this branch's own template:

| | api.host |
|---|---|
| workflow as it stands | `localhost:8080/API_URL` |
| with the substitution | `localhost:8080` |

which is exactly what `openapi/oh.yaml` declares. `develop` is unaffected: there `api.host` is `API_HOST:API_PORT`, with no placeholder left over.

[OP-1464]: https://openhospital.atlassian.net/browse/OP-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ